### PR TITLE
Post launch Fixes

### DIFF
--- a/content/communities/crowdsourcing-and-citizen-science.md
+++ b/content/communities/crowdsourcing-and-citizen-science.md
@@ -6,6 +6,7 @@ title: 'Crowdsourcing and Citizen Science Community of Practice'
 summary: 'The Federal Community of Practice on Crowdsourcing and Citizen Science (CCS) works across the government to share lessons learned and develop best practices for designing, implementing, and evaluating crowdsourcing and citizen science initiatives.'
 aliases:
   - /federal-crowdsourcing-and-citizen-science/
+  - /communities/federal-crowdsourcing-and-citizen-science/
 ---
 
 If you had 100,000 people to help you with your work, what would you do?

--- a/content/communities/manage.md
+++ b/content/communities/manage.md
@@ -6,6 +6,7 @@ title: 'Manage Your Listserv Subscription'
 summary: 'GSA supports many communities of practice by hosting listservs which provide our DigitalGov community with an easy way to collaborate, ask questions, and share information.'
 aliases:
   - /manage-your-listserv-subscription/
+  - /communities/manage-your-listserv-subscription/
 ---
 
 GSA supports many communities of practice by hosting listservs which provide our DigitalGov community with an easy way to collaborate, ask questions, and share information.

--- a/themes/digital.gov/layouts/sitemap.xml
+++ b/themes/digital.gov/layouts/sitemap.xml
@@ -1,7 +1,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {{ range .Data.Pages }}
   <url>
-    <loc>{{ .Site.Params.defaulturl }}{{ .Permalink | absURL }}</loc>{{ if not .Lastmod.IsZero }}
+    <loc>https://www.digitalgov.gov{{ .Permalink | relURL }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
     <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
     <priority>{{ .Sitemap.Priority }}</priority>{{ end }}


### PR DESCRIPTION
We just launched the site on Federalist and there were a few issues that needed fixing.
1. Sitemaps had relative URLs. They needed to be full URLs.
2. The redirects on two of the community pages were wrong.