### PR TITLE
Post launch Fixes

### DIFF
--- a/content/posts/2015/07/2015-07-17-digitalgov-podcast-leaders-come-and-go-but-your-customers-will-remain.md
+++ b/content/posts/2015/07/2015-07-17-digitalgov-podcast-leaders-come-and-go-but-your-customers-will-remain.md
@@ -1,5 +1,5 @@
 ---
-slug: digitalgov-podcast-leaders-come-and-go-but-your-customers-will-remain.md
+slug: digitalgov-podcast-leaders-come-and-go-but-your-customers-will-remain
 date: 2015-07-17 13:00:20 -0400
 title: 'DigitalGov Podcast: Leaders Come and Go, But Your Customers Will Remain'
 summary: 'To provide great customer service, bring your agency’s customers to the table. This is one of many insights recently offered by Stephanie Thum, Vice President of Customer Experience at the Export-Import Bank of the United States. Thum has previously written about customer experience for DigitalGov, including Three Ways to Evolve Your Agency’s Customer Mindset and'
@@ -22,8 +22,8 @@ This is one of many insights recently offered by Stephanie Thum, Vice President 
 
 In May, Thum sat down with DigitalGov to dig deeper into the federal customer experience (CX) landscape. Thum discussed how the CX mindset is gaining momentum and attention around government, how CX is a management discipline that deserves a seat at the C-suite, and why providing great customer service makes fundamental business sense.<audio class="wp-audio-shortcode" id="audio-288702-3" preload="none" style="width: 100%;" controls="controls"><source type="audio/mpeg" src="https://s3.amazonaws.com/digitalgov/legacy-img/2015/07/Stephanie-Thum-Leaders-Customer-Podcast.mp3?_=3" />
 
-<https://s3.amazonaws.com/digitalgov/legacy-img/2015/07/Stephanie-Thum-Leaders-Customer-Podcast.mp3></audio> 
+<https://s3.amazonaws.com/digitalgov/legacy-img/2015/07/Stephanie-Thum-Leaders-Customer-Podcast.mp3></audio>
 
- 
+
 
 To listen to the podcast offline, [download the .mp3 file](https://s3.amazonaws.com/digitalgov/legacy-img/2015/07/Stephanie-Thum-Leaders-Customer-Podcast.mp3 "Listen to An Inside look at the Digital Analytics Program") (11 MB). You can also [download and read the transcript](https://s3.amazonaws.com/digitalgov/legacy-img/2015/07/DigitalGov-Customer-Service-Podcast-Transcript-May-2015-Ashley-Wichman-and-Stephanie-Thum.docx) (5 pages, 21 kb MS Word).

--- a/data/featured_programs.yml
+++ b/data/featured_programs.yml
@@ -6,28 +6,16 @@ featured:
       uid   : new-dap-image-no-url-for-dg-homepage
       alt   :
 # ==============================================
-  - uid     : mobile-application-testing-program
-    summary :
-    img:
-      uid   : mobile-devices-testing-app-tilted
-      alt   :
-# ==============================================
-  - uid     : sites-usa-gov
-    summary :
-    img:
-      uid   : usa-gov-digital-strategy
-      alt   :
-# ==============================================
   - uid     : challenges-prizes
     summary :
     img:
       uid   : challengegov-logo
       alt   :
 # ==============================================
-  - uid     : social-media
+  - uid     : mobile-application-testing-program
     summary :
     img:
-      uid   : social-media-icons-ailverv-istock-thinkstock-476494475
+      uid   : mobile-devices-testing-app-tilted
       alt   :
 # ==============================================
   - uid     : negotiated-terms-of-service-agreements


### PR DESCRIPTION
This change fixes two things
1. The it removes two programs on the homepage, Sites and Social
2. It fixes a URL that included a `.md` extension, and was breaking the page