### PR TITLE
Modify banner text and link creation process

### DIFF
--- a/themes/digital.gov/layouts/partials/notice-bar.html
+++ b/themes/digital.gov/layouts/partials/notice-bar.html
@@ -6,9 +6,10 @@
 {{ $cleanurl := replaceRE "^(.)" "/$1" $cleanurl }}
 {{ $cleanurl := replaceRE "//" "/" $cleanurl }}
 {{ $siteslink := printf "https://%s" (printf "www.digitalgov.gov%s" $cleanurl) }}
+{{ $cleanurl := printf "digitalgov.gov%s" $cleanurl }}
 
 <div div class="notice">
   <div class="notice-content">
-    <p class="notice-text"><span class="notice-text--primary">This is the Federalist version of DigitalGov.</span> Visit the Sites page <a href="{{ $siteslink }}" target="_blank">{{ $cleanurl }}</a></p>
+    <p class="notice-text"><span class="notice-text--primary">This is the prerelease preview of DigitalGov.</span> Visit the live page <a href="{{ $siteslink }}" target="_blank">{{ $cleanurl }}</a></p>
   </div>
 </div>


### PR DESCRIPTION
Fixes #123 
Preview: https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/dw-update-banner/

## fixes
- [ ] Update text to read `This is the prerelease preview of DigitalGov. Visit the live site [link]?`
- [ ] homepage link should appear as `digitalgov.gov`