### PR TITLE
Remove Google Plus from social sources

### DIFF
--- a/data/social.yml
+++ b/data/social.yml
@@ -22,9 +22,3 @@ sources:
     link          : "http://www.youtube.com/user/howtogov"
     shortcode     : "youtube"
     action        : "Connect on YouTube"
-
-  - name          : "Google Plus"
-    username      : nil
-    link          : "https://plus.google.com/109077476228639396954?rel=author"
-    shortcode     : "gplus"
-    action        : "Connect on Google+"


### PR DESCRIPTION
Fixes #106 
Preview: https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/dw-google-plus/

### to review
- [x] Remove google plus link/icon from header
- [x] Remove google plus link/icon from footer