### PR TITLE
Change Branch in Edit button on pages

### DIFF
--- a/themes/digital.gov/static/js/all-images.js
+++ b/themes/digital.gov/static/js/all-images.js
@@ -60,7 +60,7 @@ jQuery(document).ready(function($) {
             "<p><strong>alt:</strong> "+alt+"</p>",
             "<p><strong>shortcode:</strong></p>",
             "<pre>{{< img src=\""+uid+"\" capton=\"\" alt=\"\" >}}</pre>", // shortcode
-            "<p><a target='_new' href='https://github.com/GSA/digitalgov.gov/tree/master/data/images/"+uid+".yml' title='view on GitHub'>Edit on GitHub »</a></p>",
+            "<p><a target='_new' href='https://github.com/GSA/digitalgov.gov/edit/master/data/images/"+uid+".yml' title='view on GitHub'>Edit on GitHub »</a></p>",
           "</div>",
         "</div>"
       ].join("\n");

--- a/themes/digital.gov/static/js/all-images.js
+++ b/themes/digital.gov/static/js/all-images.js
@@ -60,7 +60,7 @@ jQuery(document).ready(function($) {
             "<p><strong>alt:</strong> "+alt+"</p>",
             "<p><strong>shortcode:</strong></p>",
             "<pre>{{< img src=\""+uid+"\" capton=\"\" alt=\"\" >}}</pre>", // shortcode
-            "<p><a target='_new' href='https://github.com/GSA/digitalgov.gov/tree/demo/data/images/"+uid+".yml' title='view on GitHub'>Edit on GitHub »</a></p>",
+            "<p><a target='_new' href='https://github.com/GSA/digitalgov.gov/tree/master/data/images/"+uid+".yml' title='view on GitHub'>Edit on GitHub »</a></p>",
           "</div>",
         "</div>"
       ].join("\n");

--- a/themes/digital.gov/static/js/external.js
+++ b/themes/digital.gov/static/js/external.js
@@ -7,7 +7,7 @@ function transform_edit_file_link(){
 	if ( $('.entry .edit_file').length ) {
 		var data = $('.edit_file'); // get the edit link data
 		var filepath = $(data).attr('data-filepath'); // the filename in GitHub
-		var github_file_path = 'https://github.com/GSA/digitalgov.gov/blob/demo/content/'+filepath;
+		var github_file_path = 'https://github.com/GSA/digitalgov.gov/blob/master/content/'+filepath;
 		$(data).attr('href', github_file_path);
 	}
 }

--- a/themes/digital.gov/static/js/external.js
+++ b/themes/digital.gov/static/js/external.js
@@ -7,7 +7,7 @@ function transform_edit_file_link(){
 	if ( $('.entry .edit_file').length ) {
 		var data = $('.edit_file'); // get the edit link data
 		var filepath = $(data).attr('data-filepath'); // the filename in GitHub
-		var github_file_path = 'https://github.com/GSA/digitalgov.gov/blob/master/content/'+filepath;
+		var github_file_path = 'https://github.com/GSA/digitalgov.gov/edit/master/content/'+filepath;
 		$(data).attr('href', github_file_path);
 	}
 }


### PR DESCRIPTION
This fixes https://github.com/GSA/digitalgov.gov/issues/170

The "Edit" button on posts/pages/events is currently pointing to `Demo`
This should point to `Master`