### PR TITLE
Updating address in event and fixing bug in address display for all events

### DIFF
--- a/content/events/2017/2017-12-12-workshop-making-government-websites-with-github-federalist-us-web-design-standards.md
+++ b/content/events/2017/2017-12-12-workshop-making-government-websites-with-github-federalist-us-web-design-standards.md
@@ -10,29 +10,29 @@ host: Will Slack
 registration_url: https://www.eventbrite.com/e/workshop-making-government-websites-with-federalist-github-basics-registration-39457265744
 youtube_id:
 venue:
-  venue_name: The General Services Administration
+  venue_name: U.S. General Services Administration
   room: 4150
-  address: 1800 F St.
+  address: 1800 F Street NW
   city: Washington
   state: D.C.
-  zip: 20006
+  zip: 20405
   country: USA
   map: https://goo.gl/maps/bFWBD6QfDLA2
 
 ---
 
-Come learn how to create a simple, compliant government website, using Federalist, GitHub and the U.S. Web Design Standards.
+Come learn how to create a simple, compliant government website using [GitHub](https://www.github.com/), [Federalist](https://federalist.18f.gov/), and the [U.S. Web Design Standards](https://standards.usa.gov/).
 
-This workshop will provide you and your team with an overview of using TTS’s new government-specific tools in combination with GitHub. Then we’ll show you how, together, they make it easier than ever to create and launch compliant, government websites.
+This workshop will provide you and your team with an overview of using two new government-specific tools from the Technology Transformation Service (TTS) with GitHub. Then we’ll show you how, together, they make it easier than ever to create and launch compliant government websites.
 
-The second part of the workshop is your chance to get hands-on experience with these tools. We are designing three breakout sessions aimed at helping those on your team publish on Federalist by the end of the day.
+The second part of the workshop will be your chance to get hands-on experience with these tools. We are designing three breakout sessions aimed at helping those on your team publish on Federalist by the end of the day.
 
 ### Schedule
 * 9 - 9:15am — Arrivals
 * 9:15 - 10am — Federalist overview
 * 10 - 10:45am — Breakout working groups
 * 10:45am — Take temperature of the room
-* 10:45 — 11am - Break
+* 10:45 - 11am — Break
 * 11 - 12:00pm — Further learning and discussion
 
 

--- a/content/events/2017/2017-12-12-workshop-making-government-websites-with-github-federalist-us-web-design-standards.md
+++ b/content/events/2017/2017-12-12-workshop-making-government-websites-with-github-federalist-us-web-design-standards.md
@@ -42,5 +42,5 @@ When you register for the event, we’d like to know:
 * Do you have a website you think Federalist might be a good candidate for hosting?
 * If so, tell us about the website
 * Are you interested in learning how to design, code, and build Federalist websites?
-* Are you interested in more details on managing a Federalist site in your agency? (non technical discussion)
+* Are you interested in more details on managing a Federalist site in your agency? (non-technical discussion)
 * Any other areas/questions you’d like us to cover at this event?

--- a/content/pages/new-event.html
+++ b/content/pages/new-event.html
@@ -83,7 +83,7 @@ css: [front-matter.css]
         <div class="checkbox">
           <label class="m_1800f">
             <input name="m_1800f" type="checkbox" value="1800f">
-            1800 F St. Washington D.C. 20006
+            1800 F Street NW, Washington D.C. 20405
           </label>
         </div>
         <label class="m_room">

--- a/themes/digital.gov/layouts/events/single.html
+++ b/themes/digital.gov/layouts/events/single.html
@@ -272,10 +272,10 @@
                       		<span class="tribe-locality">{{ $venue.city }}</span><span class="tribe-delimiter">,</span>
                           {{/* TODO: String lookup for full state name */}}
                         	<abbr class="tribe-region tribe-events-abbr" title="{{/* full-state-name */}}">{{ $venue.state }}</abbr>
-                        	<span class="tribe-postal-code">{{ $venue.zip }}</span>
-                        	<span class="tribe-country-name">{{ $venue.country }}</span>
+                        	<span class="tribe-postal-code">{{ $venue.zip }}</span><br>
+                          <a href="{{ $venue.map }}">View map</a>
                         </span>
-                        <a href="{{ $venue.map }}">{{ $venue.map}}</a>
+
                       </address>
     								</dd><!-- .tribe-venue-location -->
     							</dl>

--- a/themes/digital.gov/layouts/events/single.html
+++ b/themes/digital.gov/layouts/events/single.html
@@ -127,7 +127,7 @@
                   </p><hr/>
                 {{ end }}
                 <p><strong>Location</strong><br />
-                  {{ with .Params.venue.venue_name }}{{ . }}000000<br />{{ end }}
+                  {{ with .Params.venue.venue_name }}{{ . }}<br />{{ end }}
                   {{ .Params.venue.address }}<br />
                   {{ .Params.venue.city }}, {{ .Params.venue.state }}<br />
                   {{ with .Params.venue.zip }}{{ . }} {{ end }}{{ .Params.venue.country }}<br />
@@ -139,7 +139,7 @@
               <!-- else if "in-person" -->
               {{ else }}
     						<p><strong>Location</strong><br />
-                  {{ .Params.venue.venue_name }}121212121<br />
+                  {{ .Params.venue.venue_name }}<br />
                   {{ .Params.venue.address }}<br />
                   {{ .Params.venue.city }}, {{ .Params.venue.state }} {{ .Params.venue.zip }}<br />
                   Room: {{ .Params.venue.room }}<br />

--- a/themes/digital.gov/static/js/front-matter.js
+++ b/themes/digital.gov/static/js/front-matter.js
@@ -227,11 +227,11 @@ jQuery(document).ready(function($) {
 
   function set_1800f(set){
     if (set == true) {
-      $('.m_venue_name input').val('The General Services Administration').prop("readonly", true).addClass('quiet');
-      $('.m_address input').val('1800 F St.').prop("readonly", true).addClass('quiet');
+      $('.m_venue_name input').val('U.S. General Services Administration').prop("readonly", true).addClass('quiet');
+      $('.m_address input').val('1800 F Street NW').prop("readonly", true).addClass('quiet');
       $('.m_city input').val('Washington').prop("readonly", true).addClass('quiet');
       $('.m_state input').val('D.C.').prop("readonly", true).addClass('quiet');
-      $('.m_zip input').val('20006').prop("readonly", true).addClass('quiet');
+      $('.m_zip input').val('20405').prop("readonly", true).addClass('quiet');
       $('.m_country input').val('USA').prop("readonly", true).addClass('quiet');
       $('.m_map input').val('https://goo.gl/maps/bFWBD6QfDLA2').prop("readonly", true).addClass('quiet');
       get_matter_data();


### PR DESCRIPTION
### Fixes

- Typo in address on the [Workshop: Making Government Websites with GitHub, Federalist & U.S. Web Design Standards](https://www.digitalgov.gov/event/workshop-making-government-websites-with-github-federalist-us-web-design-standards/) event page
- Light copy edit/grammar fixes
- Updated location/venue name & address in [the event generator](https://www.digitalgov.gov/new-event/)

Issue: https://github.com/GSA/digitalgov.gov/issues/203
