### PR TITLE
Cleaning up markdown errors on Style Guide page

### DIFF
--- a/content/resources/style-guides-by-government-agencies.md
+++ b/content/resources/style-guides-by-government-agencies.md
@@ -9,6 +9,8 @@ Style guides are used to set the tone and guidelines for how an agency communica
 
 This page is a collection of style guides created by government agencies.  You can add your agency&#8217;s guide by [emailing DigitalGov]({{< link "/about/" >}}) or sharing in the [Plain Language Community of Practice]({{< link "plain-language-community-of-practice.md" >}}).
 
+---
+
 #### Plain Language
 
 - [plainlanguage.gov](https://plainlanguage.gov/)

--- a/content/resources/style-guides-by-government-agencies.md
+++ b/content/resources/style-guides-by-government-agencies.md
@@ -21,7 +21,7 @@ This page is a collection of style guides created by government agencies.  You c
 
 #### Centers for Disease Control and Prevention (CDC)
 
-- [CDC Guide to Writing for Social Media](https://www.cdc.gov/socialmedia/tools/guidelines/guideforwriting.html) (PDF,1.6 MB, 60 pgs)
+- [CDC Guide to Writing for Social Media](https://www.cdc.gov/socialmedia/tools/guidelines/guideforwriting.html) (PDF, 1.6 MB, 60 pgs)
 - [CDC Social Media Tools, Guidelines & Best Practices](https://www.cdc.gov/socialmedia/tools/guidelines/)
 - [Emerging Infectious Diseases Additional Style Guides and Print Resources](https://wwwnc.cdc.gov/eid/page/additional-style-guides-and-print-resources)
 - [Emerging Infectious Diseases Author Resource Center](https://wwwnc.cdc.gov/eid/page/author-resource-center)
@@ -53,10 +53,9 @@ This page is a collection of style guides created by government agencies.  You c
 
 #### U.S. Department of Health and Human Services (HHS)
 
-- [Administration for Children & Families Editorial Style Guide](https://www.acf.hhs.gov/digital-toolbox/content/editorial-style-guide)[
-- HealthCare.gov Styleguide](https://styleguide.healthcare.gov/)[
-- HHS.gov Style Guide
-  ](https://www.hhs.gov/web/policies-and-standards/style-guide/) [Underage Drinking Prevention National Media Campaign Style Guide](https://www.samhsa.gov/sites/default/files/uad_campaign_style_guide.pdf), Substance Abuse and Mental Health Services Administration (PDF, 285 KB, 4 pgs)
+- [Administration for Children & Families Editorial Style Guide](https://www.acf.hhs.gov/digital-toolbox/content/editorial-style-guide)
+- [HealthCare.gov Styleguide](https://styleguide.healthcare.gov/)
+- [HHS.gov Style Guide](https://www.hhs.gov/web/policies-and-standards/style-guide/) [Underage Drinking Prevention National Media Campaign Style Guide](https://www.samhsa.gov/sites/default/files/uad_campaign_style_guide.pdf), Substance Abuse and Mental Health Services Administration (PDF, 285 KB, 4 pgs)
 - [HHS Web Style Guide](https://www.hhs.gov/web/policies-and-standards/web-style-guide/)
 
 

--- a/content/resources/style-guides-by-government-agencies.md
+++ b/content/resources/style-guides-by-government-agencies.md
@@ -1,83 +1,78 @@
 ---
 url: /resources/style-guides-by-government-agencies/
 date: 2017-05-23 3:43:08 -0400
-title: Style Guides by Government Agencies
-summary: 'This page is a collection of style guides created by government agencies. Style guides are used to set the tone and guidelines for how an agency communicates with the public. You can add your agency&#8217;s guide by emailing DigitalGov or sharing in the Plain Language Community of Practice. 18F Content Guide Centers for Disease Control and Prevention (CDC)'
-authors:
-  - andreanocesigritz
+title: 'Style Guides by Government Agencies'
+summary: 'This page is a collection of style guides created by government agencies.'
 ---
 
-This page is a collection of style guides created by government agencies. Style guides are used to set the tone and guidelines for how an agency communicates with the public. You can add your agency&#8217;s guide by [emailing DigitalGov]({{< link "/about/" >}}) or sharing in the [Plain Language Community of Practice]({{< link "plain-language-community-of-practice.md" >}}).
+Style guides are used to set the tone and guidelines for how an agency communicates with the public.
+
+This page is a collection of style guides created by government agencies.  You can add your agency&#8217;s guide by [emailing DigitalGov]({{< link "/about/" >}}) or sharing in the [Plain Language Community of Practice]({{< link "plain-language-community-of-practice.md" >}}).
+
+#### Plain Language
+
+- [plainlanguage.gov](https://plainlanguage.gov/)
 
 #### 18F
 
-[Content Guide](https://content-guide.18f.gov/)
+- [Content Guide](https://content-guide.18f.gov/)
 
 #### Centers for Disease Control and Prevention (CDC)
 
-[CDC Guide to Writing for Social Media](https://www.cdc.gov/socialmedia/tools/guidelines/guideforwriting.html) (PDF,1.6 MB, 60 pgs)
-  
-[CDC Social Media Tools, Guidelines & Best Practices](https://www.cdc.gov/socialmedia/tools/guidelines/)
-  
-[Emerging Infectious Diseases Additional Style Guides and Print Resources](https://wwwnc.cdc.gov/eid/page/additional-style-guides-and-print-resources)
-  
-[Emerging Infectious Diseases Author Resource Center](https://wwwnc.cdc.gov/eid/page/author-resource-center)
-  
-[Emerging Infectious Diseases Journal Editorial Style Guide](https://wwwnc.cdc.gov/eid/pdfs/StyleGuide.pdf) (PDF, 794 KB, 88 pgs)[
-  ](https://www.cdc.gov/other/plainwriting.html) [Facebook Guidelines and Best Practices](https://www.cdc.gov/socialmedia/tools/guidelines/facebook-guidelines.html)[
-  
-Plain Writing at CDC](https://www.cdc.gov/other/plainwriting.html)
-  
-[The Health Communicator’s Social Media Toolkit](https://www.cdc.gov/socialmedia/tools/guidelines/socialmediatoolkit.html) (PDF, 2.5 MB, 59 pgs)
-  
-[Twitter Guidelines & Best Practices](https://www.cdc.gov/socialmedia/tools/guidelines/twitter.html)
+- [CDC Guide to Writing for Social Media](https://www.cdc.gov/socialmedia/tools/guidelines/guideforwriting.html) (PDF,1.6 MB, 60 pgs)
+- [CDC Social Media Tools, Guidelines & Best Practices](https://www.cdc.gov/socialmedia/tools/guidelines/)
+- [Emerging Infectious Diseases Additional Style Guides and Print Resources](https://wwwnc.cdc.gov/eid/page/additional-style-guides-and-print-resources)
+- [Emerging Infectious Diseases Author Resource Center](https://wwwnc.cdc.gov/eid/page/author-resource-center)
+- [Emerging Infectious Diseases Journal Editorial Style Guide](https://wwwnc.cdc.gov/eid/pdfs/StyleGuide.pdf) (PDF, 794 KB, 88 pgs)
+- [Plain Writing at CDC](https://www.cdc.gov/other/plainwriting.html)
+- [Facebook Guidelines and Best Practices](https://www.cdc.gov/socialmedia/tools/guidelines/facebook-guidelines.html)
+- [The Health Communicator’s Social Media Toolkit](https://www.cdc.gov/socialmedia/tools/guidelines/socialmediatoolkit.html) (PDF, 2.5 MB, 59 pgs)
+- [Twitter Guidelines & Best Practices](https://www.cdc.gov/socialmedia/tools/guidelines/twitter.html)
 
 #### Central Intelligence Agency (CIA)
 
-[Directorate of Intelligence’s Style Manual & Writers Guide for Intelligence Publications, 8th edition, 2011](https://www.scribd.com/doc/233259974/Directorate-of-Intelligence-Style-Manual-Writers-Guide-for-Intelligence-Publications-Eighth-Edition-2011)
+- [Directorate of Intelligence’s Style Manual & Writers Guide for Intelligence Publications, 8th edition, 2011](https://www.scribd.com/doc/233259974/Directorate-of-Intelligence-Style-Manual-Writers-Guide-for-Intelligence-Publications-Eighth-Edition-2011)
 
 #### Congressional Budget Office (CBO)
 
-[A Guide to Style and Usage](http://www.cbo.gov/sites/default/files/cbofiles/attachments/44975-StyleGuide.pdf) (PDF, 1.8 MB, 100 pgs)
+- [A Guide to Style and Usage](http://www.cbo.gov/sites/default/files/cbofiles/attachments/44975-StyleGuide.pdf) (PDF, 1.8 MB, 100 pgs)
 
 #### Consumer Financial Protection Bureau (CFPB)
 
-[CFPB&#8217;s Glossary of English-Spanish Financial Terms](https://s3.amazonaws.com/files.consumerfinance.gov/f/201510_cfpb_spanish-style-guide-glossary.pdf) (PDF, 132 KB, 20 pgs)
+- [CFPB&#8217;s Glossary of English-Spanish Financial Terms](https://s3.amazonaws.com/files.consumerfinance.gov/f/201510_cfpb_spanish-style-guide-glossary.pdf) (PDF, 132 KB, 20 pgs)
 
 #### National Archives and Records Administration (NARA)
 
-[NARA Style Guide](https://www.archives.gov/files/open/plain-writing/style-guide.pdf) (PDF, 428 KB, 63 pgs)
+- [NARA Style Guide](https://www.archives.gov/files/open/plain-writing/style-guide.pdf) (PDF, 428 KB, 63 pgs)
 
 #### Social Security Administration (SSA)
 
-[Program Operational Manual for Notice Standards](https://secure.ssa.gov/apps10/poms.nsf/lnx/0900610000)
+- [Program Operational Manual for Notice Standards](https://secure.ssa.gov/apps10/poms.nsf/lnx/0900610000)
 
 #### U.S. Department of Health and Human Services (HHS)
 
-[Administration for Children & Families Editorial Style Guide](https://www.acf.hhs.gov/digital-toolbox/content/editorial-style-guide)[
-  
-HealthCare.gov Styleguide](https://styleguide.healthcare.gov/)[
-  
-HHS.gov Style Guide
+- [Administration for Children & Families Editorial Style Guide](https://www.acf.hhs.gov/digital-toolbox/content/editorial-style-guide)[
+- HealthCare.gov Styleguide](https://styleguide.healthcare.gov/)[
+- HHS.gov Style Guide
   ](https://www.hhs.gov/web/policies-and-standards/style-guide/) [Underage Drinking Prevention National Media Campaign Style Guide](https://www.samhsa.gov/sites/default/files/uad_campaign_style_guide.pdf), Substance Abuse and Mental Health Services Administration (PDF, 285 KB, 4 pgs)
-  
-[HHS Web Style Guide](https://www.hhs.gov/web/policies-and-standards/web-style-guide/)
+- [HHS Web Style Guide](https://www.hhs.gov/web/policies-and-standards/web-style-guide/)
+
 
 #### U.S. Energy Information Administration (EIA)
 
-[EIA Writing Style Guide](https://www.eia.gov/about/eiawritingstyleguide.pdf) (PDF, 1.3 MB, 139 pgs)
+- [EIA Writing Style Guide](https://www.eia.gov/about/eiawritingstyleguide.pdf) (PDF, 1.3 MB, 139 pgs)
 
 #### U.S. Environmental Protection Agency (EPA)
 
-[EPA Communications Style Book](https://www.epa.gov/stylebook)
+- [EPA Communications Style Book](https://www.epa.gov/stylebook)
 
 #### U.S. General Services Administration (GSA)
 
-[USAGov Bilingual Style Guide: Table of Contents](https://www.usa.gov/style-guide/table-of-contents)
+- [USAGov Bilingual Style Guide: Table of Contents](https://www.usa.gov/style-guide/table-of-contents)
 
 #### U.S. Government Publishing Office (GPO)
 
-[U.S. Government Publishing Office Style Manual](https://www.gpo.gov/fdsys/search/pagedetails.action?collectionCode=GPO&granuleId=&packageId=GPO-STYLEMANUAL-2016)
+- [U.S. Government Publishing Office Style Manual](https://www.gpo.gov/fdsys/search/pagedetails.action?collectionCode=GPO&granuleId=&packageId=GPO-STYLEMANUAL-2016)
 
 * * *
 
@@ -85,12 +80,11 @@ HHS.gov Style Guide
 
 Here&#8217;s a collection of guides created by digital communities of practice and other groups.
 
-[Department of Defense&#8217;s Introduction to Plain Language](http://www.dtic.mil/whs/directives/plainlanguage/PlainLanguageCourse.pdf) (PDF, 407 KB, 44 pgs)[
-  
-PLAIN&#8217;s Federal Plain Language Guidelines
-  ](http://www.plainlanguage.gov/howto/guidelines/FederalPLGuidelines/index.cfm?CFID=838730&CFTOKEN=f64d36ad05e03d58-ED6E6827-0361-55F8-E6207170C554B1DF&jsessionid=A3A593B93EAEE361431FC8D8B4799DF0.chh) [Spanish Health Care Terms in the United States
-  ]({{< link "spanish-health-care-terms-in-the-united-states.md" >}}) [Spanish Language Style Guide and Glossaries
-  ]({{< link "spanish-language-style-guide-and-glossaries.md" >}}) [Spanish Language Style Guide & Glossaries: Frequently Mistranslated English Terms
-  ]({{< link "spanish-language-style-guide-glossaries-frequently-mistranslated-english-terms.md" >}}) [Spanish Language Style Guide and Glossaries: Grammar
-  ]({{< link "spanish-language-style-guide-and-glossaries-grammar.md" >}}) [Spanish Language Style Guide & Glossaries: Information Technology Terms
-  ]({{< link "spanish-language-style-guide-glossaries-information-technology-terms.md" >}}) [Spanish Language Style Guide & Glossaries: Internet Resources]({{< link "spanish-language-style-guide-glossaries-internet-resources.md" >}})
+- [Department of Defense&#8217;s Introduction to Plain Language](http://www.dtic.mil/whs/directives/plainlanguage/PlainLanguageCourse.pdf) (PDF, 407 KB, 44 pgs)
+- [PLAIN&#8217;s Federal Plain Language Guidelines](http://www.plainlanguage.gov/howto/guidelines/FederalPLGuidelines/index.cfm?CFID=838730&CFTOKEN=f64d36ad05e03d58-ED6E6827-0361-55F8-E6207170C554B1DF&jsessionid=A3A593B93EAEE361431FC8D8B4799DF0.chh)
+- [Spanish Health Care Terms in the United States]({{< link "spanish-health-care-terms-in-the-united-states.md" >}})
+- [Spanish Language Style Guide and Glossaries]({{< link "spanish-language-style-guide-and-glossaries.md" >}})
+- [Spanish Language Style Guide & Glossaries: Frequently Mistranslated English Terms]({{< link "spanish-language-style-guide-glossaries-frequently-mistranslated-english-terms.md" >}})
+- [Spanish Language Style Guide and Glossaries: Grammar]({{< link "spanish-language-style-guide-and-glossaries-grammar.md" >}})
+- [Spanish Language Style Guide & Glossaries: Information Technology Terms]({{< link "spanish-language-style-guide-glossaries-information-technology-terms.md" >}})
+- [Spanish Language Style Guide & Glossaries: Internet Resources]({{< link "spanish-language-style-guide-glossaries-internet-resources.md" >}})


### PR DESCRIPTION
This change aims to fix a number of the markdown errors on this page: https://www.digitalgov.gov/resources/style-guides-by-government-agencies/

Here is a preview: https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/hotfix-style-guide-page/resources/style-guides-by-government-agencies/