### PR TITLE
added a redirect from old Video page to new Video Page

### DIFF
--- a/content/communities/video.md
+++ b/content/communities/video.md
@@ -4,6 +4,8 @@ uid: video-production
 date: 2016-07-08 1:19:06 -0400
 title: 'Video Production Pros Community of Practice'
 summary: 'Video Production Pros brings together passionate storytellers, artists, social gurus, strategists, and video production experts from across the U.S. government.'
+aliases:
+  - /communities/video-production-pros-community-of-practice/
 ---
 
 


### PR DESCRIPTION
Here is the new page URL: https://www.digitalgov.gov/communities/video-production/
This is the URL that we are redirecting: https://www.digitalgov.gov/communities/video-production-pros-community-of-practice/


### Preview URLs

This URL https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/jeremyzilar-patch-1/communities/video-production-pros-community-of-practice/
should redirect to https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/jeremyzilar-patch-1/communities/video-production/