### PR TITLE
Fixing the mobile breakpoint css

### DIFF
--- a/content/resources/index.md
+++ b/content/resources/index.md
@@ -73,12 +73,12 @@ Looking for overall digital policy guidance? See the <a href="{{< link "checklis
 *   [U.S. Web Design Standards](https://standards.usa.gov/)
 *   [Style Guides by Government Agencies]({{< link "style-guides-by-government-agencies.md" >}})
 
+
 ## Digital Strategy
 
-*   [Digital Government Strategy](https://obamawhitehouse.archives.gov/sites/default/files/omb/egov/digital-government/digital-government.html) (May 2012)
-    *   [Agency Digital Strategy Pages]({{< link "2012-08-22-agency-digital-strategy-pages.md" >}})
-    *   [Guidelines for Improving Digital Services]({{< link "guidelines-for-improving-digital-services.md" >}})
-
+* [Digital Government Strategy](https://obamawhitehouse.archives.gov/sites/default/files/omb/egov/digital-government/digital-government.html) (May 2012)
+  * [Agency Digital Strategy Pages]({{< link "2012-08-22-agency-digital-strategy-pages.md" >}})
+  *   [Guidelines for Improving Digital Services]({{< link "guidelines-for-improving-digital-services.md" >}})
 *   [Putting Citizens First: Transforming Online Government]({{< link "https://s3.amazonaws.com/digitalgov/_legacy-img/2013/11/Federal-Web-Managers-White-Paper.pdf" >}}) (PDF, 47 kb, 4 pages, November 2008)
 
 ## Measurement

--- a/themes/digital.gov/static/css/entry.css
+++ b/themes/digital.gov/static/css/entry.css
@@ -49,7 +49,7 @@
 		margin: 0;
 		padding: 15px;
 	}
-	.entry{
+	.page .entry{
 		width:auto;
 	}
 }
@@ -60,7 +60,7 @@
 		padding: 15px;
 		width:auto;
 	}
-	.entry{
+	.page .entry{
 		width:auto;
 	}
 }


### PR DESCRIPTION
There is a bug that is making the mobile view of resource pages wider than it should be on mobile viewports. This CSS fix corrects for that.

Here is a preview: https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/hotfix-mobile-breakpoint/resources/
_(Make sure you view it on your phone 📱 )_