### PR TITLE
Multiple code, formatting corrections on Open Opps page

### DIFF
--- a/content/resources/10-tips-for-creating-the-perfect-open-opportunity-task.md
+++ b/content/resources/10-tips-for-creating-the-perfect-open-opportunity-task.md
@@ -7,67 +7,22 @@ authors:
   - tburwell
 ---
 
-<li style="margin-bottom: 15px">
-  <b>Divide and conquer: </b>Keep projects simple: if you have a big project, consider dividing it into smaller tasks. You can also offer several tasks at the same time (rather than sequentially). <ul>
-    <li>
-      In order to create the Federal Crowdsource Mobile Testing Program, the Mobile team posted a 20 percent task to help plan and create the program. Once the program was up and running, the team created two additional opportunities: one to manage the program and a second to run individual test cycles. Multiple test cycles can be advertised on Open Opps at the same time.
-    </li>
-  </ul>
-</li>
+1. **Divide and conquer**: Keep projects simple: if you have a big project, consider dividing it into smaller tasks. You can also offer several tasks at the same time (rather than sequentially). <br /><br />In order to create the Federal Crowdsource Mobile Testing Program, the Mobile team posted a 20 percent task to help plan and create the program. Once the program was up and running, the team created two additional opportunities: one to manage the program and a second to run individual test cycles. Multiple test cycles can be advertised on Open Opps at the same time. 
 
-<li style="margin-bottom: 15px">
-  <b>Be specific: </b>Define exactly what needs to be done and what deliverables you expect. Include links or documents that the participant will need. <ul>
-    <li>
-      The DigitalGov team <a href="https://openopps.digitalgov.gov/tasks/25">needed a writer</a> who could contribute to a weekly blog series. The task included <a href="{{< link "tag/trends-on-tuesday" >}}">a link to the blog series</a> so that potential participants could get familiar with existing articles.
-    </li>
-  </ul>
-</li>
+2. **Be specific**: Define exactly what needs to be done and what deliverables you expect. Include links or documents that the participant will need. <br /><br />The DigitalGov team [needed a writer](https://openopps.digitalgov.gov/tasks/25) who could contribute to a weekly blog series. The task included [a link to the blog series](https://www.digitalgov.gov/tag/trends-on-tuesday/) so that potential participants could get familiar with existing articles. 
 
-<li style="margin-bottom: 15px">
-  <b>Give the big picture: </b>Include information on how participants’ work will/may be used. This helps participants understand their work is part of a greater effort. <ul>
-    <li>
-      The National Institute of Standards and Technology (NIST) <a href="https://openopps.digitalgov.gov/tasks/24">needed facts sheets updated</a>. For their task, they explained that the fact sheets would be posted on their website and would  “help the world understand the importance of the National Network for Manufacturing Innovation at NIST.”
-    </li>
-  </ul>
-</li>
+3. **Give the big picture**: Include information on how participants' work will/may be used. This helps participants understand their work is part of a greater effort. <br /><br />The National Institute of Standards and Technology (NIST) [needed facts sheets updated](https://openopps.digitalgov.gov/tasks/24). For their task, they explained that the fact sheets would be posted on their website and would "help the world understand the importance of the National Network for Manufacturing Innovation at NIST." 
 
-<li style="margin-bottom: 15px">
-  <b>Know your own availability: </b>Remember that you are an active part of Open Opps: the more clarity you provide, the less ‘back and forth’ you will need to do in the future with participants. If you are submitting a 20%er task, ensure that you are able to invest time supporting participants for the duration of your project.
-</li>
-<li style="margin-bottom: 15px">
-  <b>A title is more than words: </b>Write a catchy title (BUT also make sure it’s clear and descriptive!). <ul>
-    <li>
-      Every task can have a catchy title. “<a href="http://gsablogs.gsa.gov/dsic/2013/05/07/help-us-tell-the-story-about-a-nih-rockstar-who-is-creating-modular-on-the-go-content/">Help Us Tell the Story of an NIH Rockstar</a>” catches more attention than “Interview an Employee of NIH.”
-    </li>
-  </ul>
-</li>
+4. **Know your own availability**: Remember that you are an active part of Open Opps: the more clarity you provide, the less 'back and forth' you will need to do in the future with participants. If you are submitting a 20%er task, ensure that you are able to invest time supporting participants for the duration of your project. 
 
-<li style="margin-bottom: 15px">
-  <b>Focus on skills, not job titles:</b> Participants may skip over opportunities if they do not identify with a particular job title. A skill list will self-populate as you create your task. Use that skill list to guide your task description. <ul>
-    <li>
-      For example: “I need someone with strong data analysis skills in Excel” rather than “I need someone with experience as a Research Assistant.”
-    </li>
-  </ul>
-</li>
+5. **A title is more than words**: Write a catchy title (BUT also make sure it's clear and descriptive!). <br /><br />Every task can have a catchy title. "[Help Us Tell the Story of an NIH Rockstar](http://gsablogs.gsa.gov/dsic/2013/05/07/help-us-tell-the-story-about-a-nih-rockstar-who-is-creating-modular-on-the-go-content/)" catches more attention than "Interview an Employee of NIH." 
 
-<li style="margin-bottom: 15px">
-  <b>Drop jargon: </b>Write your tasks in plain language. Use full office names rather than acronyms. Avoid using office-specific slang. Define complicated terms or include links to relevant resources that will help participants understand the task.
-</li>
-<li style="margin-bottom: 15px">
-  <b>Set realistic timelines: </b>Participants may not be familiar with your office or agency. Does your task require background knowledge that may take a variable amount of time for the participant to research, depending on learning styles?
-</li>
-<li style="margin-bottom: 15px">
-  <b>Every Open Opp is a learning opportunity. </b>Many tasks do not require participants to be experts in a given field. If you are looking for somebody who is willing to learn a new skill, clearly state that. <ul>
-    <li>
-      The DigitalGov usability team requested help with <a href="https://openopps.digitalgov.gov/tasks/18">writing usability case studies</a>. They clearly stated that using WordPress was part of the task, but they would accept a participant who was willing to learn WordPress basics.
-    </li>
-  </ul>
-</li>
+6. **Focus on skills, not job titles**: Participants may skip over opportunities if they do not identify with a particular job title. A skill list will self-populate as you create your task. Use that skill list to guide your task description. <br /><br />For example: "I need someone with strong data analysis skills in Excel" rather than "I need someone with experience as a Research Assistant." 
 
-<li style="margin-bottom: 15px">
-  <b>Market your Open Opp</b>. Are there communities of practice (CoP’s) that might be interested in your task? Use our <a href="https://s3.amazonaws.com/digitalgov/_legacy-img/2015/04/Open-Opps-Marketing-Email-Template-for-CoPs.docx">Open Opps Marketing Email Template for CoPs</a> (14 kb MS Word .docx) to craft a message. <ul>
-    <li>
-      Want to target an individual (or six?) Each task has a “share” button that produces a pre-populated email template.
-    </li>
-  </ul>
-</li>
+7. **Drop jargon**: Write your tasks in plain language. Use full office names rather than acronyms. Avoid using office-specific slang. Define complicated terms or include links to relevant resources that will help participants understand the task. 
+
+8. **Set realistic timelines**: Participants may not be familiar with your office or agency. Does your task require background knowledge that may take a variable amount of time for the participant to research, depending on learning styles? 
+
+9. **Every Open Opp is a learning opportunity**. Many tasks do not require participants to be experts in a given field. If you are looking for somebody who is willing to learn a new skill, clearly state that. <br /><br />The DigitalGov usability team requested help with [writing usability case studies](https://openopps.digitalgov.gov/tasks/18). They clearly stated that using WordPress was part of the task, but they would accept a participant who was willing to learn WordPress basics. 
+
+10. **Market your Open Opp**. Are there Communities of Practice (CoPs) that might be interested in your task? Use our [Open Opps Marketing Email Template for CoPs](https://s3.amazonaws.com/digitalgov/_legacy-img/2015/04/Open-Opps-Marketing-Email-Template-for-CoPs.docx) (14 kb, MS Word, .docx) to craft a message. <br /><br />Want to target an individual (or six?) Each task has a "share" button that produces a pre-populated email template.


### PR DESCRIPTION
Switched from HTML to [primarily] Markdown for numbered list, bold formatting, and hyperlinks; had to use line break HTML tags to keep any secondary paragraphs indented with the margin for list line items (1st paragraph)
https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/ToniBonittoGSA-patch-2/resources/open-opportunities-task-creator-toolkit/10-tips-for-creating-the-perfect-open-opportunity-task/ 

* this is in wrong section (/resources/); should be in **_/join/open-opportunities-in-digitalgov/_**
not sure how to move..