### PR TITLE
Added in Multilingual resources to the community page

### DIFF
--- a/content/communities/multilingual.md
+++ b/content/communities/multilingual.md
@@ -10,21 +10,23 @@ aliases:
 
 We are a group of federal, state and local government content managers, formerly known as the Federal Multilingual Websites Committee, who are working to expand and improve digital content in languages other than English.
 
-### Join
+## Join
 
 [Fill out this form](https://docs.google.com/spreadsheet/viewform?formkey=dHI0aTEwWXh2NURMR0gzR3ozVlJ2T2c6MQ) to subscribe to our listserv or send an email to group Chair, [Laura Godfrey](mailto:laura.godfrey@gsa.gov).
 
 Join us if you are a government employee working for a federal, state or local U.S. government agency or a contractor with a government email address working on government digital content.
 
-### Who we are
+## Who we are
 
 We work to support Executive Order 13166, “[Improving Access to Services for People with Limited English Proficiency](http://www.justice.gov/crt/about/cor/Pubs/eolep.pdf)” (PDF, 255 KB, 6 pages, August 2000). Our primary purpose is to meet the growing demand for government information and services in other languages and to share ideas, challenges and best practices for managing multilingual content and websites.
 
 We [collect research]({{< link "2014-07-01-multilingual-digital-content.md" >}}), and develop and curate tools and best practices. We also meet several times a year and maintain an active listserv.
 
-We work on three main areas:
 
-##### Multilingual Websites and Digital Channels–Standards, Guidelines, Research and Mandates
+
+## We work on three main areas:
+
+### Multilingual Websites and Digital Channels–Standards, Guidelines, Research and Mandates
 
 The goal is to develop templates and compile research data, mandates and other materials to help digital content managers have a successful cross-platform presence. The group also develops guidelines to answer questions such as how to:
 
@@ -36,7 +38,7 @@ The goal is to develop templates and compile research data, mandates and other m
   * Have a successful presence in social media channels
   * Offer content in other languages via APIs
 
-##### Translation/Adaptation/Localization of Content
+### Translation/Adaptation/Localization of Content
 
 The group comes together to work on:
 
@@ -46,7 +48,7 @@ The group comes together to work on:
   * Developing plain language guidelines
   * Creating general guidelines for the acquisition and management of translation work and contracts
 
-##### Marketing, Outreach, Education, Training
+### Marketing, Outreach, Education, Training
 
 The group compiles and documents best practice examples across government to answer questions such as:
 
@@ -56,3 +58,20 @@ The group compiles and documents best practice examples across government to ans
   * Communication: How do we communicate success?
 
 The group also researches outreach opportunities such as participating in training sessions, workshops and community events.
+
+---
+
+### Getting Started
+- [Top 10 Best Practices for Multilingual Websites](https://www.digitalgov.gov/resources/top-10-best-practices-for-multilingual-websites/)
+- [Agencias y Departamentos del Gobierno Federal](https://gobierno.usa.gov/agencias-federales/a)
+- [Spanish Language Style Guide and Glossaries](https://www.digitalgov.gov/resources/spanish-language-style-guide-and-glossaries/)
+- [Accessibility Editorial Guidelines for Videos](https://www.digitalgov.gov/2012/08/01/accessibility-editorial-guidelines-for-youtube/)
+- [Lost in Translation](https://www.digitalgov.gov/2012/10/01/automated-translation-good-solution-or-not/)
+
+### Featured Articles
+- [A Guide to Publishing Multilingual Digital Content](https://www.digitalgov.gov/2014/07/01/multilingual-digital-content/)
+- [Multiple Languages, Single Platforms: the World Digital Library](https://www.digitalgov.gov/2015/04/09/multiple-languages-single-platforms-the-world-digital-library/)
+- [Trends on Tuesday: Hispanic Millennials Provide Insight on Mobile Future](https://www.digitalgov.gov/2014/05/27/trends-on-tuesday-hispanic-millennials-provide-insight-on-mobile-future/)
+- [Persona Development Case Study: NCI and Spanish Language Outreach](https://www.digitalgov.gov/2015/03/02/persona-development-case-study-nci-and-spanish-language-outreach/)
+- [More on Multilingual »](https://www.digitalgov.gov/tag/multilingual/)
+  

--- a/content/communities/multilingual.md
+++ b/content/communities/multilingual.md
@@ -26,7 +26,7 @@ We [collect research]({{< link "2014-07-01-multilingual-digital-content.md" >}})
 
 ## We work on three main areas:
 
-### Multilingual Websites and Digital Channels–Standards, Guidelines, Research and Mandates
+### Standards, Guidelines, Research, and Mandates for Multilingual Websites and Digital Channels
 
 The goal is to develop templates and compile research data, mandates and other materials to help digital content managers have a successful cross-platform presence. The group also develops guidelines to answer questions such as how to:
 
@@ -38,7 +38,7 @@ The goal is to develop templates and compile research data, mandates and other m
   * Have a successful presence in social media channels
   * Offer content in other languages via APIs
 
-### Translation/Adaptation/Localization of Content
+### Translation, Adaptation, and Localization of Content
 
 The group comes together to work on:
 
@@ -48,7 +48,7 @@ The group comes together to work on:
   * Developing plain language guidelines
   * Creating general guidelines for the acquisition and management of translation work and contracts
 
-### Marketing, Outreach, Education, Training
+### Marketing, Outreach, Education, and Training
 
 The group compiles and documents best practice examples across government to answer questions such as:
 


### PR DESCRIPTION
A number of the related resources got dropped from the Multilingual Page migration. This fix brings those back. Here is the issue: https://github.com/GSA/digitalgov.gov/issues/260