### PR TITLE
Fixed Bullets on Community Managers List

### DIFF
--- a/content/communities/government-contact-center-council.md
+++ b/content/communities/government-contact-center-council.md
@@ -18,6 +18,7 @@ To join, send an [email to Tim Cossairt](mailto:tim.cossairt@tsa.dhs.gov) with â
 **Community Managers**
 
 The G3C leadership is a volunteer board of the following individuals:
+
 - Tim Cossairt (Transportation Security Administration) - Co-Chair
 - Rosetta Lue (Veterans Administration) â€“ Co-Chair
 - Dora G. Best (U.S. Patent and Trade Office) - Secretary


### PR DESCRIPTION
The names and titles were in a rolling line instead of bulleted.