### PR TITLE
Fixed Open Graph meta tags

### DIFF
--- a/themes/digital.gov/layouts/partials/head.html
+++ b/themes/digital.gov/layouts/partials/head.html
@@ -53,6 +53,7 @@
   <meta property="og:type" content="{{ $.Scratch.Get "pagetype" }}">
   <meta property="og:url" content="{{ .Permalink }}" />
   <meta property="og:site_name" content="DigitalGov">
+  {{ if $featImgURL }}<meta property="og:image" content="{{ $featImgURL }}" />{{ end }}
   <meta property="fb:admins" content="100000569454928" />
   <meta property="article:publisher" content="https://www.facebook.com/digitalgov" />
   {{ if $.Params.date }}<meta property="article:published_time" content="{{ $.Params.date }}" />{{ end }}
@@ -62,6 +63,7 @@
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:site" content="@Digital_Gov" />
   <meta name="twitter:creator" content="@Digital_Gov" />
+  {{ if $featImgTwitterURL }}<meta name="twitter:image:src" content="{{ $featImgTwitterURL }}">{{ end }}
   <meta property="twitter:description" content="{{ $.Params.summary | default $.Site.Params.description | markdownify }}">
   <meta property="twitter:title" content="{{ $.Params.title | default $.Site.Title | markdownify }}">
   {{ "<!-- End of Twitter -->" | safeHTML }}

--- a/themes/digital.gov/layouts/partials/head.html
+++ b/themes/digital.gov/layouts/partials/head.html
@@ -52,14 +52,10 @@
   <meta property="og:description" content="{{ $.Params.summary | default $.Site.Params.description | markdownify }}">
   <meta property="og:type" content="{{ $.Scratch.Get "pagetype" }}">
   <meta property="og:url" content="{{ .Permalink }}" />
-  <meta property="og:image" content="{{ $featImgURL }}" />
-  <meta property="og:image" content="https://s3.amazonaws.com/digitalgov/tile-1.png" />
-  <meta property="og:image" content="https://s3.amazonaws.com/digitalgov/tile-2.png" />
-  <meta property="og:image:width" content="{{ $featImgWidth }}" />
   <meta property="og:site_name" content="DigitalGov">
   <meta property="fb:admins" content="100000569454928" />
   <meta property="article:publisher" content="https://www.facebook.com/digitalgov" />
-  <meta property="article:author" content="willsullivan" />
+  <meta property="article:author" content="digitalgov" />
   <meta property="article:published_time" content="2017-09-25T09:00:15Z" />
   <meta property="article:modified_time" content="2017-09-25T09:00:15Z" />
   {{ "<!-- End of Facebook Open Graph -->" | safeHTML }}
@@ -70,8 +66,6 @@
   <meta name="twitter:creator" content="@Digital_Gov" />
   <meta property="twitter:description" content="{{ $.Params.summary | default $.Site.Params.description | markdownify }}">
   <meta property="twitter:title" content="{{ $.Params.title | default $.Site.Title | markdownify }}">
-  <meta property="twitter:image" content="{{ $featImgTwitterURL }}">
-  <meta itemprop="image" content="{{ $featImgURL }}" />
   {{ "<!-- End of Twitter -->" | safeHTML }}
 
   {{ "<!-- RSS Feed-->" | safeHTML }}

--- a/themes/digital.gov/layouts/partials/head.html
+++ b/themes/digital.gov/layouts/partials/head.html
@@ -55,9 +55,7 @@
   <meta property="og:site_name" content="DigitalGov">
   <meta property="fb:admins" content="100000569454928" />
   <meta property="article:publisher" content="https://www.facebook.com/digitalgov" />
-  <meta property="article:author" content="digitalgov" />
-  <meta property="article:published_time" content="2017-09-25T09:00:15Z" />
-  <meta property="article:modified_time" content="2017-09-25T09:00:15Z" />
+  {{ if $.Params.date }}<meta property="article:published_time" content="{{ $.Params.date }}" />{{ end }}
   {{ "<!-- End of Facebook Open Graph -->" | safeHTML }}
 
   {{ "<!-- Start of Twitter Card -->" | safeHTML }}


### PR DESCRIPTION
A fix to the data in the OG meta tags in the head of the page to correct this **issue:** https://github.com/GSA/digitalgov.gov/issues/345



## What was made better
- removed the `article:author` property all together, since that property only accepts single authors and we often publish with multiple authors.
- removed the `last-modified` property because that is hard to access as the moment, and non-essential
- made the featured image conditional

**Preview:** https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/og-image-card/