### PR TITLE
Updating URL

### DIFF
--- a/content/events/2018/2018-02-14-us-digital-registry-open-office-hours-feb2017.md
+++ b/content/events/2018/2018-02-14-us-digital-registry-open-office-hours-feb2017.md
@@ -1,5 +1,5 @@
 ---
-slug: us-digital-registry-open-office-hours-feb2017
+slug: us-digital-registry-open-office-hours-feb2018
 title: 'U.S. Digital Registry Open Office Hours'
 summary: 'Virtual open office hours to answer your questions about the U.S. Digital Registry.'
 featured_image: 
@@ -11,7 +11,9 @@ end_date: 2018-02-14 10:30:00 -0400
 event_organizer: DigitalGov University
 host: 
 registration_url: https://www.eventbrite.com/e/us-digital-registry-open-office-hours-registration-41577054088
-
+aliases:
+  - /event/us-digital-registry-open-office-hours-feb2017/
+  
 ---
 
 On the second Wednesday of every month, from 10:00 - 10:30 am, ET, the U.S Digital Registry team hosts monthly, open-office time to answer questions, discuss ideas, and take feedback about the U.S. Digital Registry. 


### PR DESCRIPTION
The URL of this page has `2017` in the URL
https://www.digitalgov.gov/event/us-digital-registry-open-office-hours-feb2017/
This changes it to 2018

**Preview:** https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/url-fix/event/us-digital-registry-open-office-hours-feb2018/

**Old URL:** https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/url-fix/event/us-digital-registry-open-office-hours-feb2017/