### PR TITLE
New post button fix

### DIFF
--- a/themes/digital.gov/layouts/docs/baseof.html
+++ b/themes/digital.gov/layouts/docs/baseof.html
@@ -10,7 +10,7 @@
   {{ partial "body-top.html" . }}
 
   {{ block "content" . }} The DOCS CONTENT didn't load. :( {{ end }}
-  {{ if or (eq .Layout "1col") (eq .Layout "all-images") }}{{ else }}
+  {{ if or (eq .Layout "1col") (eq .Layout "all-images") (eq .Layout "new-file") }}{{ else }}
   {{ block "sidebar" . }} The DOCS SIDEBAR didn't load. :( {{ end }}
   {{ end }}
 

--- a/themes/digital.gov/layouts/docs/new-file.html
+++ b/themes/digital.gov/layouts/docs/new-file.html
@@ -15,4 +15,4 @@
   {{ .Content }}
 </div>
 
-{{ end }} {{/* end 'content' block */}}
+{{ end }}

--- a/themes/digital.gov/static/css/custom.css
+++ b/themes/digital.gov/static/css/custom.css
@@ -103,7 +103,7 @@ Add styles inside the media query below that you only want to be applied to the 
 	display: block;
 }
 
-.btn{
+.event_actions .btn{
 	display: inline-block;
 	color: #fff !important;
 	padding:10px 16px;
@@ -118,7 +118,7 @@ Add styles inside the media query below that you only want to be applied to the 
 	border:3px solid #2673DF;
 	color:#2673DF !important;
 }
-.event_register{
+.event_actions .event_register{
 	background: #000;
 }
 

--- a/themes/digital.gov/static/css/front-matter.css
+++ b/themes/digital.gov/static/css/front-matter.css
@@ -1,6 +1,6 @@
 
 .matter-container{
-  margin: 10px 0;
+  margin: 10px 0 50px 0;
 }
 
 .btn-group{
@@ -27,16 +27,16 @@
   border-right:1px #555 solid;
 }
 .btn-group .btn:hover{
-  background: #efefef;
+  background: #ccc;
   cursor: pointer;
 }
 .btn-group .selected{
-  background: #3F4FFF;
+  background: #2673DF;
   color:#fff;
   outline:none;
 }
 .btn-group .selected:hover{
-  background: #3F4FFF;
+  background: #2673DF;
   color:#fff;
 }
 
@@ -146,7 +146,7 @@
 .gcol2 #newfile {
   padding:10px 20px;
   font-weight: bold;
-  background: #3F4FFF;
+  background: #2673DF;
   color:#fff;
   display: block;
 }


### PR DESCRIPTION
## What was fixed

The "create" post type buttons on the post generator pages are not the right color and it is making it hard to read the names of the buttons.

https://www.digitalgov.gov/new-post/

This change fixes that.

**Preview:** https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/post-generator-fix/new-post/