### PR TITLE
Update Challenge event date

### DIFF
--- a/content/events/2018/2018-01-23-federal-challenge-prize-community-practice-quarterly-meeting.md
+++ b/content/events/2018/2018-01-23-federal-challenge-prize-community-practice-quarterly-meeting.md
@@ -1,5 +1,5 @@
 ---
-slug: federal-challenge-prize-community-practice-quarterly-meeting
+slug: federal-challenge-prize-community-practice-quarterly-meeting-february-2018
 title: 'Federal Challenge & Prize Community of Practice Quarterly Meeting'
 summary: 'This quarterly meeting brings together federal employees from a range of agencies to discuss trends, success stories and lessons learned in the use of crowdsourcing competitions&#46;'
 featured_image:
@@ -13,7 +13,7 @@ host: Challenges & Prizes Community of Practice
 registration_url: https://www.eventbrite.com/e/federal-challenge-prize-community-of-practice-quarterly-meeting-registration-41463270759
 venue:
   venue_name: U.S. General Services Administration
-  room: 4150
+  room: 1459/1460
   address: 1800 F Street NW
   city: Washington
   state: D.C.
@@ -40,7 +40,7 @@ This quarterly meeting brings together federal employees from a range of agencie
   </tr>
   <tr>
     <td>9:10 a.m.</td>
-    <td><strong>Introductions and Program Updates</strong><ul><li>Kelly Oslon, GSA</li></ul></td>
+    <td><strong>Introductions and Program Updates</strong><ul><li>Kelly Olson, GSA</li></ul></td>
   </tr>
   <tr>
     <td>9:10 a.m.</td>
@@ -56,15 +56,15 @@ This quarterly meeting brings together federal employees from a range of agencie
   </tr>
   <tr>
     <td>10:10 a.m.</td>
-    <td><strong>Accelerating for Action: How Agencies Use this Industry Model</strong><ul><li>Moderator: Jack Bienko, Eisenhower Fellowship</li><li> Panelist: Sandeep Patel, Department of Health and Human Services</li><li>Panelist: Jennifer Garson, Department of Energy</li><li>Panelist: Nancy Merritt, National Institute of Standards & Technology </li> <li>Panelist: Jim Thompson, Department of State</li></ul></td>
+    <td><strong>Accelerating for Action: How Agencies Use this Industry Model</strong><ul><li>Moderator: Jack Bienko, Eisenhower Fellowship</li><li> Panelist: Sandeep Patel, Department of Health and Human Services</li><li>Panelist: Jennifer Garson, Department of Energy</li><li>Panelist: Nancy Merritt, National Institute of Standards & Technology </li> </ul></td>
   </tr>
   <tr>
     <td>11:00 a.m.</td>
-    <td><strong>Executive Update from the White House</strong><ul><li>Matt Lira, White House Office of American Innovation</li></ul></td>
+    <td><strong>Executive Update from the White House</strong><ul><li>Matt Lira, White House Office of American Innovation <i>(invited)</i></li></ul></td>
   </tr>
   <tr>
     <td>11:15 a.m.</td>
-    <td><strong>Helping Hands: Spotlight on Humanitarian Efforts</strong><ul><li>Doug Stropes, U.S. Agency for International Development</li><li> Edward Elliott,  U.S. Patent & Trademark Office</li></ul></td>
+    <td><strong>Helping Hands: Spotlight on Humanitarian Efforts</strong><ul><li>Doug Stropes, U.S. Agency for International Development <i>(invited)</i> </li><li> Edward Elliott,  U.S. Patent & Trademark Office</li></ul></td>
   </tr>
   <tr>
     <td>12:00p.m.</td>

--- a/content/events/2018/2018-01-23-federal-challenge-prize-community-practice-quarterly-meeting.md
+++ b/content/events/2018/2018-01-23-federal-challenge-prize-community-practice-quarterly-meeting.md
@@ -23,9 +23,7 @@ venue:
 
 ---
 
-
 This quarterly meeting brings together federal employees from a range of agencies to discuss trends, success stories and lessons learned in the use of crowdsourcing competitions.
-
 
 ## Agenda
 
@@ -70,9 +68,7 @@ This quarterly meeting brings together federal employees from a range of agencie
     <td>12:00p.m.</td>
     <td>Event concludes</td>
   </tr>
-
 </table>
-
 
 **At this meeting, attendees will:**
 

--- a/content/events/2018/2018-01-23-federal-challenge-prize-community-practice-quarterly-meeting.md
+++ b/content/events/2018/2018-01-23-federal-challenge-prize-community-practice-quarterly-meeting.md
@@ -23,8 +23,6 @@ venue:
 
 ---
 
-**This event has been postponed due to the government shutdown. We are exploring a new date in February, stay tuned.**
-
 
 This quarterly meeting brings together federal employees from a range of agencies to discuss trends, success stories and lessons learned in the use of crowdsourcing competitions.
 

--- a/content/events/2018/2018-01-23-federal-challenge-prize-community-practice-quarterly-meeting.md
+++ b/content/events/2018/2018-01-23-federal-challenge-prize-community-practice-quarterly-meeting.md
@@ -26,8 +26,8 @@ venue:
 
 This quarterly meeting brings together federal employees from a range of agencies to discuss trends, success stories and lessons learned in the use of crowdsourcing competitions.
 
-## Agenda
 
+## Agenda
 
 <table>
   <tr>
@@ -74,7 +74,7 @@ This quarterly meeting brings together federal employees from a range of agencie
 </table>
 
 
-At this meeting, attendees will:
+**At this meeting, attendees will:**
 
 - Meet and greet the Special Assistant to the President for Innovation Policy and Initiatives and hear his vantage point from within the White House Office of American Innovation.
 - Hear how a DARPA challenge to forecast the spread of infectious disease is pinpointing where to perform clinical trials on a new vaccine for the chikungunya virus.

--- a/content/events/2018/2018-01-23-federal-challenge-prize-community-practice-quarterly-meeting.md
+++ b/content/events/2018/2018-01-23-federal-challenge-prize-community-practice-quarterly-meeting.md
@@ -9,7 +9,7 @@ event_type: mixed
 date: 2018-02-27 9:00:00 -0400
 end_date: 2018-02-27 12:00:00 -0400
 event_organizer: DigitalGov University
-host: Challenges & Prizes Community of Practice
+host: Challenge & Prize Community of Practice
 registration_url: https://www.eventbrite.com/e/federal-challenge-prize-community-of-practice-quarterly-meeting-registration-41463270759
 venue:
   venue_name: U.S. General Services Administration

--- a/content/events/2018/2018-01-23-federal-challenge-prize-community-practice-quarterly-meeting.md
+++ b/content/events/2018/2018-01-23-federal-challenge-prize-community-practice-quarterly-meeting.md
@@ -6,8 +6,8 @@ featured_image:
   uid:
   alt: ''
 event_type: mixed
-date: 2018-01-23 9:00:00 -0400
-end_date: 2018-01-23 12:00:00 -0400
+date: 2018-02-27 9:00:00 -0400
+end_date: 2018-02-27 12:00:00 -0400
 event_organizer: DigitalGov University
 host: Challenges & Prizes Community of Practice
 registration_url: https://www.eventbrite.com/e/federal-challenge-prize-community-of-practice-quarterly-meeting-registration-41463270759
@@ -20,7 +20,6 @@ venue:
   zip: 20405
   country: USA
   map: https://goo.gl/maps/bFWBD6QfDLA2
-draft: true
 
 ---
 


### PR DESCRIPTION
We are re-publishing the Challenge.gov Event with a new date, same registration URL.

Preview: https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/SoncerrayBolling-patch-3/event/federal-challenge-prize-community-practice-quarterly-meeting/