### PR TITLE
Date/Calendar–related bugs

### DIFF
--- a/content/events/2018/2018-02-13-customer-relationship-management-government-sector-best-practices-pitfalls-tips.md
+++ b/content/events/2018/2018-02-13-customer-relationship-management-government-sector-best-practices-pitfalls-tips.md
@@ -6,8 +6,8 @@ featured_image:
   uid:
   alt: ''
 event_type: mixed
-date: 2018-02-13 10:00:00 -0400
-end_date: 2018-02-13 12:00:00 -0400
+date: 2018-02-13 10:00:00 -0500
+end_date: 2018-02-13 12:00:00 -0500
 event_organizer: DigitalGov University
 host: Customer Experience Community of Practice
 registration_url: https://www.eventbrite.com/e/customer-relationship-management-government-sector-best-practices-pitfalls-and-tips-registration-42687953819

--- a/content/events/2018/2018-02-14-february-plain-meeting.md
+++ b/content/events/2018/2018-02-14-february-plain-meeting.md
@@ -3,12 +3,12 @@ slug: february-plain-meeting
 title: 'Plain Language Community Meeting'
 summary: 'This in-person meeting of the Plain Language Community of Practice will focus on volunteers.'
 event_type: in-person
-date: 2018-02-14 14:00:00 -0400
-end_date: 2018-02-14 15:30:00 -0400
+date: 2018-02-14 14:00:00 -0500
+end_date: 2018-02-14 15:30:00 -0500
 event_organizer: DigitalGov University
 host: PLAIN Language
 registration_url: https://www.eventbrite.com/e/february-plain-monthly-meeting-registration-42365715997
-venue: 
+venue:
   venue_name: U.S. General Services Administration
   room: 6026
   address: 1800 F Street NW

--- a/content/events/2018/2018-02-14-how-fedramp-supports-agencies-a-resource-overview.md
+++ b/content/events/2018/2018-02-14-how-fedramp-supports-agencies-a-resource-overview.md
@@ -6,8 +6,8 @@ featured_image:
   uid: featued-301-x-212-fedramp-2017-5th-anniversary-logo
   alt: 'FedRAMP Logo'
 event_type: online
-date: 2018-02-14 12:00:00 -0400
-end_date: 2018-02-14 13:00:00 -0400
+date: 2018-02-14 12:00:00 -0500
+end_date: 2018-02-14 13:00:00 -0500
 event_organizer: DigitalGov University
 host: FedRAMP
 registration_url: https://www.eventbrite.com/e/how-fedramp-supports-agencies-a-resource-overview-registration-41287416775

--- a/content/events/2018/2018-02-14-us-digital-registry-open-office-hours-feb2017.md
+++ b/content/events/2018/2018-02-14-us-digital-registry-open-office-hours-feb2017.md
@@ -2,22 +2,22 @@
 slug: us-digital-registry-open-office-hours-feb2018
 title: 'U.S. Digital Registry Open Office Hours'
 summary: 'Virtual open office hours to answer your questions about the U.S. Digital Registry.'
-featured_image: 
-  uid: 
-  alt: 
+featured_image:
+  uid:
+  alt:
 event_type: online
-date: 2018-02-14 10:00:00 -0400
-end_date: 2018-02-14 10:30:00 -0400
+date: 2018-02-14 10:00:00 -0500
+end_date: 2018-02-14 10:30:00 -0500
 event_organizer: DigitalGov University
-host: 
+host:
 registration_url: https://www.eventbrite.com/e/us-digital-registry-open-office-hours-registration-41577054088
 aliases:
   - /event/us-digital-registry-open-office-hours-feb2017/
-  
+
 ---
 
-On the second Wednesday of every month, from 10:00 - 10:30 am, ET, the U.S Digital Registry team hosts monthly, open-office time to answer questions, discuss ideas, and take feedback about the U.S. Digital Registry. 
- 
+On the second Wednesday of every month, from 10:00 - 10:30 am, ET, the U.S Digital Registry team hosts monthly, open-office time to answer questions, discuss ideas, and take feedback about the U.S. Digital Registry.
+
 **About the U.S. Digital Registry**
- 
+
 The [U.S. Digital Registry](https://usdigitalregistry.digitalgov.gov/) serves as a resource for agencies, citizens, and developers to confirm the official status of social media and public-facing collaboration accounts, mobile apps, and mobile websites. The accounts in the registry are independently updated by federal managers across the government who maintain individual agency accounts.

--- a/content/events/2018/2018-02-15-dap-learning-series-digital-analytics-program-101.md
+++ b/content/events/2018/2018-02-15-dap-learning-series-digital-analytics-program-101.md
@@ -2,12 +2,12 @@
 slug: dap-learning-series-digital-analytics-program-101
 title: 'DAP Learning Series: An Introduction to the Basics'
 summary: 'This online class will provide an introductory training on how to use Digital Analytics Program (DAP) google analytics data.'
-featured_image: 
-  uid: 
+featured_image:
+  uid:
   alt: ''
 event_type: online
-date: 2018-02-15 13:00:00 -0400
-end_date: 2018-02-15 16:00:00 -0400
+date: 2018-02-15 13:00:00 -0500
+end_date: 2018-02-15 16:00:00 -0500
 event_organizer: DigitalGov University
 host: Digital Analytics Program
 registration_url: https://www.eventbrite.com/e/dap-learning-series-digital-analytics-program-101-registration-42540102592
@@ -19,9 +19,9 @@ _The [Digital Analytics Program](https://www.digitalgov.gov/services/dap/) (DAP)
 
 This half-day, online class will provide an introductory training on how to use DAP's Google Analytics data.
 
-**Concepts we'll cover**: 
+**Concepts we'll cover**:
 
-- basic terms and concepts 
+- basic terms and concepts
 - common web metrics: what they mean and when to use them
 - how to create and deliver reports
 - analytics and sampling

--- a/themes/digital.gov/layouts/events/single.html
+++ b/themes/digital.gov/layouts/events/single.html
@@ -31,13 +31,13 @@
   				<div class="tribe-events-schedule tribe-clearfix">
             <h2>
               <span class="tribe-event-date-start">
-                {{ with .Date }}
+                {{ with .Params.date }}
                   {{ . | dateFormat "Monday, Jan 2, 2006" }}
                 {{ end }}
               </span><br/>
               <span class="tribe-event-time">
-                {{ with .Date }}
-                  {{ . | dateFormat "3:04 PM" }}
+                {{ with .Params.date }}
+                  {{ . | dateFormat "3:04 PM ET" }}
                 {{ end }} —
                 {{ with .Params.end_date }}
                   {{ . | dateFormat "3:04 PM ET" }}
@@ -144,8 +144,8 @@
 
   					</div><!-- .tribe-events-content -->
   					<div class="tribe-events-cal-links">
-              {{ $event_startDate := dateFormat "2006-01-02 03:04:05" (time .Params.date).UTC }}
-              {{ $event_endDate := dateFormat "2006-01-02 03:04:05" (time .Params.end_date).UTC }}
+              {{ $event_startDate := dateFormat "2006-01-02 15:04:05" (time .Params.date).UTC }}
+              {{ $event_endDate := dateFormat "2006-01-02 15:04:05" (time .Params.end_date).UTC }}
               {{ $event_title := .Title | markdownify }}
               {{ $event_description := .Summary | markdownify }}
               {{ $event_location := .Params.venue.venue_name }}

--- a/themes/digital.gov/static/js/front-matter.js
+++ b/themes/digital.gov/static/js/front-matter.js
@@ -78,7 +78,7 @@ jQuery(document).ready(function($) {
 
   // Combines date + time into a string that's ready for the front matter
   function matter_datetime(date, time){
-    var dt = date + ' ' + time + ':00 -0400';
+    var dt = date + ' ' + time + ':00 -0500';
     return dt;
   }
 


### PR DESCRIPTION
@ToniBonittoGSA 
@jthalls 
@jeremyzilar 

- I fixed the add-to-calendar button. It was outputting the converted date/time in 12-hr format (`2006-01-02 03:04:05`)  instead of 24-hr format (`2006-01-02 15:04:05`). **Fixed.**
- All springtime events (pre 3/11/2018) should be EST, which is `-0500` UTC instead of `-0400`. **Fixed.**
- Frontmatter generator was outputting dates as -0400, which is Daylight Savings Time (which doesn't start until 3/11/18). **I just changed to `-0500`, but there should be a more elegant fix in the future.**