### PR TITLE
Balance spacing in unordered lists

### DIFF
--- a/themes/digital.gov/static/css/override.css
+++ b/themes/digital.gov/static/css/override.css
@@ -783,3 +783,11 @@ p.tribe-events-widget-link {
 .auth-bio a.subicon {
   background-color: #0c555d;
 }
+
+#tribe-events-pg-template .tribe-events-content ol li, #tribe-events-pg-template .tribe-events-content ul li, .tribe-events-after-html ol li, .tribe-events-after-html ul li, .tribe-events-before-html ol li, .tribe-events-before-html ul li {
+  margin: 0 0 .5em;
+}
+
+.entry ul, .entry ol {
+  margin-top: .5em;
+}


### PR DESCRIPTION
There's now less space between list items (`20px` --> `0.5em`) and more space about unordered lists (`0.5em`).

<img width="892" alt="screen shot 2018-02-07 at 10 43 56 am" src="https://user-images.githubusercontent.com/11464021/35934836-80e266d4-0bf3-11e8-9522-cfc4239af7e9.png">

<img width="1000" alt="screen shot 2018-02-07 at 10 43 48 am" src="https://user-images.githubusercontent.com/11464021/35934837-81113900-0bf3-11e8-8677-2ad219bfc323.png">
