### PR TITLE
Fixed Caption typo

### DIFF
--- a/themes/digital.gov/static/js/all-images.js
+++ b/themes/digital.gov/static/js/all-images.js
@@ -58,8 +58,8 @@ jQuery(document).ready(function($) {
             "<p><strong>attribution:</strong> "+attribution+"</p>",
             "<p><strong>caption:</strong> "+caption+"</p>",
             "<p><strong>alt:</strong> "+alt+"</p>",
-            "<p><strong>shortcode:</strong></p>",
             "<pre>{{< img src=\""+uid+"\" caption=\"\" alt=\"\" >}}</pre>", // shortcode
+            "<pre>{{< img-right src=\""+uid+"\" caption=\"\" alt=\"\" >}}</pre>", // shortcode
             "<p><a target='_new' href='https://github.com/GSA/digitalgov.gov/edit/master/data/images/"+uid+".yml' title='view on GitHub'>Edit on GitHub »</a></p>",
           "</div>",
         "</div>"

--- a/themes/digital.gov/static/js/all-images.js
+++ b/themes/digital.gov/static/js/all-images.js
@@ -59,7 +59,7 @@ jQuery(document).ready(function($) {
             "<p><strong>caption:</strong> "+caption+"</p>",
             "<p><strong>alt:</strong> "+alt+"</p>",
             "<p><strong>shortcode:</strong></p>",
-            "<pre>{{< img src=\""+uid+"\" capton=\"\" alt=\"\" >}}</pre>", // shortcode
+            "<pre>{{< img src=\""+uid+"\" caption=\"\" alt=\"\" >}}</pre>", // shortcode
             "<p><a target='_new' href='https://github.com/GSA/digitalgov.gov/edit/master/data/images/"+uid+".yml' title='view on GitHub'>Edit on GitHub »</a></p>",
           "</div>",
         "</div>"


### PR DESCRIPTION
From Issue: https://github.com/GSA/digitalgov.gov/issues/395

## What was changed
- Fixed typo in the shortcode from `capton` to `caption`.
- Added the `img-right` shortcode as an option

Preview: https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/caption-typo/images/
