### PR TITLE
Removed featured image code from tag pages

### DIFF
--- a/themes/digital.gov/layouts/partials/summary-withImage.html
+++ b/themes/digital.gov/layouts/partials/summary-withImage.html
@@ -1,11 +1,5 @@
 <div class="post notthird notsecond post-386618 type-post status-publish format-standard has-post-thumbnail hentry">
 
-  <div class="post-feature-image">
-    <a href="{{ .Permalink }}" rel="bookmark" title="Permanent link to {{ .Title }}">
-      <img class="thumbnail large" src="{{/* .Params.featured-image.link */}}" alt="{{/* .Params.featured-image.title */}}" title="{{/* .Params.featured-image.title */}}" />
-    </a>
-  </div>
-
   <div class="entry">
     <div class="my-excerpt">
       <h2 class="post-title"><a href="{{ .Permalink }}" rel="bookmark" title="{{ .Title | markdownify }}">{{ .Title | markdownify }}</a></h2>


### PR DESCRIPTION
This fixes https://github.com/GSA/digitalgov.gov/issues/290

## What we fixed:

The featured image code was not working and causing the the headlines on tag, category and author pages to be compressed. Since tag and category pages are meant for quick scanning and browsing, I removed the featured image all together.

Before: https://www.digitalgov.gov/categories/mobile/
After (preview): https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/tag-page-line-break-bug/categories/mobile/