### PR TITLE
US Digital Registry - added 2 aliases

### DIFF
--- a/content/services/u-s-digital-registry.md
+++ b/content/services/u-s-digital-registry.md
@@ -3,7 +3,8 @@ url: /services/u-s-digital-registry/
 date: 2016-01-08 11:06:56 -0400
 title: 'U.S. Digital Registry'
 summary: 'The U.S. Digital Registry serves as a resource for agencies, citizens, and developers to confirm the official status of social media and public-facing collaboration accounts, mobile apps, and mobile websites.'
-
+aliases:
+  - /services/social-media-registry/
 ---
 
 Whether for access to emergency, financial or education public services, users need to trust they are engaging with official U.S. government digital accounts.

--- a/content/services/u-s-digital-registry.md
+++ b/content/services/u-s-digital-registry.md
@@ -5,6 +5,7 @@ title: 'U.S. Digital Registry'
 summary: 'The U.S. Digital Registry serves as a resource for agencies, citizens, and developers to confirm the official status of social media and public-facing collaboration accounts, mobile apps, and mobile websites.'
 aliases:
   - /services/social-media-registry/
+  - /services/the-federal-mobile-apps-registry/
 ---
 
 Whether for access to emergency, financial or education public services, users need to trust they are engaging with official U.S. government digital accounts.


### PR DESCRIPTION
1) /services/social-media-registry/ 
and
2) /services/the-federal-mobile-apps-registry/

Should redirect to: https://www.digitalgov.gov/services/u-s-digital-registry/ 