### PR TITLE
added alias for Social Media Analytics hackpad

### DIFF
--- a/content/posts/2013/04/2013-04-19-social-media-metrics-for-federal-agencies.md
+++ b/content/posts/2013/04/2013-04-19-social-media-metrics-for-federal-agencies.md
@@ -10,6 +10,8 @@ categories:
   - Social Media
 tag:
   - SocialGov
+aliases:
+  - /resources/federal-social-media-analytics-toolkit-hackpad/
 ---
 
 [{{< legacy-img src="2013/12/key-metrics-250x118.jpg" alt="Image of visualized performance metrics. " >}}](https://s3.amazonaws.com/digitalgov/_legacy-img/2013/12/key-metrics.jpg)Social media is transforming how government engages with citizens and how it delivers service. Agencies are using social media to share information and deliver service more quickly and effectively than ever before. Increasingly, these tools are also being used for predictive and sentiment analysis—using the vast amount of real-time data from these social platforms to predict emerging trends and respond to them quickly (referred to as “social data”).


### PR DESCRIPTION
/resources/federal-social-media-analytics-toolkit-hackpad/ 

should redirect to: https://www.digitalgov.gov/2013/04/19/social-media-metrics-for-federal-agencies/