### PR TITLE
Video CoP: added a 2nd alias

### DIFF
--- a/content/communities/video.md
+++ b/content/communities/video.md
@@ -6,6 +6,7 @@ title: 'Video Production Pros Community of Practice'
 summary: 'Video Production Pros brings together passionate storytellers, artists, social gurus, strategists, and video production experts from across the U.S. government.'
 aliases:
   - /communities/video-production-pros-community-of-practice/
+  - /communities/digital-audio-video-community-of-practice/
 ---
 
 


### PR DESCRIPTION
/communities/digital-audio-video-community-of-practice/ 

should redirect to: https://www.digitalgov.gov/communities/video-production/