### PR TITLE
Added alias on 9/6/17 post

### DIFF
--- a/content/posts/2017/09/2017-09-06-how-federal-leaders-can-build-the-will-skill-and-velocity-needed-for-digital-transformation.md
+++ b/content/posts/2017/09/2017-09-06-how-federal-leaders-can-build-the-will-skill-and-velocity-needed-for-digital-transformation.md
@@ -15,6 +15,8 @@ tag:
   - human resources
   - skills
   - The Data Briefing
+aliases:
+  - /2017/09/06/five-ways-federal-leaders-can-build-the-will-skill-and-velocity-needed-for-digital-transformation/
 ---
 
 _Learning—and practicing—five imperatives of network leadership can help agencies improve their odds for successful digital transformation._


### PR DESCRIPTION
/2017/09/06/five-ways-federal-leaders-can-build-the-will-skill-and-velocity-needed-for-digital-transformation/ (title had changed back then)

should redirect to: https://www.digitalgov.gov/2017/09/06/how-federal-leaders-can-build-the-will-skill-and-velocity-needed-for-digital-transformation/