### PR TITLE
Added alias on 9/7/17 post

### DIFF
--- a/content/posts/2017/09/2017-09-07-usda-foodkeeper-app-update-expands-content-offerings.md
+++ b/content/posts/2017/09/2017-09-07-usda-foodkeeper-app-update-expands-content-offerings.md
@@ -20,6 +20,8 @@ tag:
   - mobile apps
   - multilingual
   - USDA
+aliases:
+  - /2017/09/07/usdas-foodkeeper-app-update-features-food-safety-recall-information/
 ---
 
 > _The USDA&#8217;s multilingual FoodKeeper app has been updated to include three options for receiving food recall updates and expands storage timelines to over 500 products._


### PR DESCRIPTION
/2017/09/07/usdas-foodkeeper-app-update-features-food-safety-recall-information/ (title had changed back then)

Should redirect to: https://www.digitalgov.gov/2017/09/07/usda-foodkeeper-app-update-expands-content-offerings/