### PR TITLE
Fixing email link in Plain event page

### DIFF
--- a/content/events/2018/2018-03-14-infographics-plain-language-considerations.md
+++ b/content/events/2018/2018-03-14-infographics-plain-language-considerations.md
@@ -35,6 +35,6 @@ Join the [the Plain Language Community of Practice](https://www.digitalgov.gov/c
 - How do you deal with data? 
 - How do you communicate with people who want you to create an infographic?
 
-[Send us a sample](digitalgovu@gsa.gov "Email a sample infographic to DGU") before the meeting, or add the URL of your infographic when you register.
+[Send us a sample](mailto:digitalgovu@gsa.gov "Email a sample infographic to DGU") before the meeting, or add the URL of your infographic when you register.
 
 _The Plain Language Action and Information Network (PLAIN) is a group of federal employees from different agencies and specialties who support the use of clear communication in government writing. Visit [plainlanguage.gov](https://www.plainlanguage.gov/) or [join the community](https://www.digitalgov.gov/communities/plain-language/)._


### PR DESCRIPTION

https://www.digitalgov.gov/event/infographics-plain-language-considerations/

Changing 
`[Send us a sample](digitalgovu@gsa.gov "Email a sample infographic to DGU")`
to
`[Send us a sample](mailto:digitalgovu@gsa.gov "Email a sample infographic to DGU")`