### PR TITLE
Updating new YouTube ID

### DIFF
--- a/content/events/2018/2018-03-13-new-release-fedramp-continuous-monitoring-documents.md
+++ b/content/events/2018/2018-03-13-new-release-fedramp-continuous-monitoring-documents.md
@@ -12,7 +12,7 @@ end_date: 2018-03-13 14:00:00 -0500
 event_organizer: DigitalGov University
 host: FedRAMP
 registration_url: https://www.eventbrite.com/e/new-release-of-fedramp-continuous-monitoring-documents-registration-43037189392
-youtube_id: CPqxez8jUnM
+youtube_id: CNGKskdv1DY
 ---
 
 Over the past year, [FedRAMP](https://www.fedramp.gov/) gathered feedback from CSPs and JAB review teams on how we could streamline, clarify, and improve the Continuous Monitoring (ConMon) Process. As a result, we’ve made updates to existing documents and created new documents to:


### PR DESCRIPTION
The live video was pulled for editing right after the event.
The video was then re-uploaded to YouTube and is now is re-added back into the old event page.

**Preview:** https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/YouTube-ID-update/event/new-release-fedramp-continuous-monitoring-documents/
