### PR TITLE
registration button wasn't showing, fixed error in date.

### DIFF
--- a/content/events/2018/2018-09-20-dap-learning-series-writing-custom-javascript-for-tag-managers.md
+++ b/content/events/2018/2018-09-20-dap-learning-series-writing-custom-javascript-for-tag-managers.md
@@ -8,7 +8,7 @@ featured_image:
 event_type:
   - youtube-live
 date: 2018-09-20 14:00:00 -0400
-end_date: 2018-02-05 15:00:00 -0400
+end_date: 2018-09-20 15:00:00 -0400
 event_organizer: DigitalGov University
 host: Digital Analytics Program
 registration_url: https://www.eventbrite.com/e/dap-learning-series-writing-custom-javascript-for-tag-managers-registration-42564562753


### PR DESCRIPTION
Here is a preview: https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/jthalls-patch-6/event/dap-learning-series-writing-custom-javascript-for-tag-managers/