### PR TITLE
fix to .File.Path for GitHub edit button

### DIFF
--- a/themes/digital.gov/layouts/partials/post-meta--feedback.html
+++ b/themes/digital.gov/layouts/partials/post-meta--feedback.html
@@ -2,9 +2,9 @@
   <p class="feedback">Have feedback or questsions about this {{ .page_type | markdownify }}? <a target="new" href="mailto:digitalgov@gsa.gov?subject=Feedback%3A%20{{ htmlUnescape .page.Title | safeHTML }}&amp;body=%0D%0A---enter%20your%20feedback%2Fquestions%20here---%0D%0A%0D%0A%0D%0A-%20-%20-%20-%20-%20%0D%0APage%3A%20{{ htmlUnescape .page.Title | safeHTML }}%0D%0AURL%3A%20https%3A%2F%2Fwww.digitalgov.gov{{ .page.Permalink | markdownify }}%0D%0A-%20-%20-%20-%20-%0D%0A%0D%0A%0D%0AWe%20value%20your%20feedback%20and%20open%20questions.%20Thank%20you%20for%20helping%20to%20make%20our%20pages%20better.%0D%0A%0D%0Ahttps%3A%2F%2Fwww.digitalgov.gov%0D%0A%40digital_gov%20on%20Twitter{{ if .cc }}&amp;cc={{ .cc }}{{ end }}">Send us an email »</a></p>
 
   <!-- Edit file on GitHub -->
-  <div class="last_commit" data-filepath="{{.File.Path}}">
+  <div class="last_commit" data-filepath="{{.page.File.Path}}">
 
-    <a target="_blank" class="edit_file" href="https://github.com/GSA/digitalgov.gov" data-filepath="{{.File.Path}}" title="Edit in GitHub"><img src="{{ "img/GitHub-Mark-Light-32px.png" | absURL }}" alt="GitHub Logo"><span>Edit</span></a>
+    <a target="_blank" class="edit_file" href="https://github.com/GSA/digitalgov.gov" data-filepath="{{ .page.File.Path }}" title="Edit in GitHub"><img src="{{ "img/GitHub-Mark-Light-32px.png" | absURL }}" alt="GitHub Logo"><span>Edit</span></a>
     <p>Last updated by <span class="commit-author"></span> on <span class="commit-date"></span></p>
   </div>
 


### PR DESCRIPTION
## what was fixed

The `edit` button on pages was not pointing to the correct file in GitHub.
The `.File.Path`was not getting the context for the `.page`.
This has been fixed for all pages.

**Preview:** https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/fix-post-meta/about/

- [ ] the edit button should take you to the file in the `master` branch on github