### PR TITLE
Update data-cabinet sign up info

### DIFF
--- a/content/communities/data-cabinet.md
+++ b/content/communities/data-cabinet.md
@@ -46,4 +46,4 @@ _Visit [https://www.ntis.gov/thedatacabinet/](https://www.ntis.gov/thedatacabine
 
 ## How to Join
 
-To join, send an email to [DATACABINET-subscribe-request@listserv.gsa.gov](mailto:DATACABINET-subscribe-request@listserv.gsa.gov?subject=subscribe%20to%20DATA%20CABINET) with “subscribe to DATA CABINET” in the subject. Anyone with a .gov or .mil email address is eligible.
+To join, send an email to [DATACABINET-subscribe-request@listserv.gsa.gov](mailto:DATACABINET-subscribe-request@listserv.gsa.gov?subject=subscribe%20to%20DATA%20CABINET) with `"subscribe to DATA CABINET”` in the subject. Anyone with a .gov or .mil email address is eligible.

--- a/content/communities/data-cabinet.md
+++ b/content/communities/data-cabinet.md
@@ -46,4 +46,4 @@ _Visit [https://www.ntis.gov/thedatacabinet/](https://www.ntis.gov/thedatacabine
 
 ## How to Join
 
-To join, send an email to [DATACABINET-subscribe-request@listserv.gsa.gov](mailto:DATACABINET-subscribe-request@listserv.gsa.gov?subject=subscribe%20to%20DATA%20CABINET) with `"subscribe to DATA CABINET”` in the subject. Anyone with a .gov or .mil email address is eligible.
+To join, send an email to [DATACABINET-subscribe-request@listserv.gsa.gov](mailto:DATACABINET-subscribe-request@listserv.gsa.gov?subject=subscribe%20to%20DATA%20CABINET) with `"subscribe to DATA CABINET”` in the subject. Anyone with a **.gov** or **.mil** email address is eligible.

--- a/content/communities/data-cabinet.md
+++ b/content/communities/data-cabinet.md
@@ -46,4 +46,4 @@ _Visit [https://www.ntis.gov/thedatacabinet/](https://www.ntis.gov/thedatacabine
 
 ## How to Join
 
-To join, send an email to [**listserv@listserv.gsa.gov**](mailto:listserv@listserv.gsa.gov?subject=&amp;body=subscribe%20DATA%20CABINET) with “Subscribe to DATA CABINET” in the subject. Anyone with a .gov or .mil email address is eligible.
+To join, send an email to [DATACABINET-subscribe-request@listserv.gsa.gov](mailto:DATACABINET-subscribe-request@listserv.gsa.gov?subject=subscribe%20to%20DATA%20CABINET) with “subscribe to DATA CABINET” in the subject. Anyone with a .gov or .mil email address is eligible.


### PR DESCRIPTION
From Amirah over ✉️ — 
> I do need to make one major change to the language on how folks can subscribe to the Cabinet's listserv. I made the change in the document and include a comment so you can see the change. 

Here are her comments: https://docs.google.com/document/d/1d3TbKwiTIcR_w0tR3MHfabuqi2Z7hc1QhVQvdKpRjww/edit

**Current Page:** https://www.digitalgov.gov/communities/data-cabinet/
**Preview:** https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/data-cabinet-edit/communities/data-cabinet/