### PR TITLE
Added YouTube conditional to DAP script

### DIFF
--- a/themes/digital.gov/layouts/partials/head.html
+++ b/themes/digital.gov/layouts/partials/head.html
@@ -133,7 +133,7 @@
   <script type='text/javascript' src='{{ "js/flex-script-main.js" | absURL }}'></script>
 
   {{ "<!-- DAP — Digital Analytics Program | Learn more: https://digitalgov.gov/dap/ -->" | safeHTML }}
-  <script language="javascript" id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?ver=true&agency=GSA"></script>
+  <script language="javascript" id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?ver=true&agency=GSA{{ if (isset .Params "youtube_id") }}&yt=true{{ end }}"></script>
 
   {{ "<!-- Google Analytics — Global Site Tag (gtag.js) | because our site has been around a lot longer than DAP -->" | safeHTML }}
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-47271808-1"></script>


### PR DESCRIPTION
## Re: https://github.com/GSA/digitalgov.gov/issues/561

- [ ] If the page has `youtube_id` in the page data, then add this parameter `&yt=true` to the end of the DAP script.

### Previews:
- Event page with video: https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/dap-video-script/event/2018/04/11/a-deep-dive-into-top-tasks-with-gerry-mcgovern/
- Event page without video: https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/dap-video-script/event/2018/02/14/us-digital-registry-open-office-hours-feb2018/
- Home https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/dap-video-script/
- Blog post: https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/dap-video-script/2018/04/03/thinking-about-going-agile-5-benefits-your-office-will-reap-with-agile-methods/

