### PR TITLE
update RSS link in Social Icons

### DIFF
--- a/data/social.yml
+++ b/data/social.yml
@@ -1,7 +1,7 @@
 sources:
   - name          : "RSS Feed"
     username      : nil
-    link          : "https://www.digitalgov.gov/feed/"
+    link          : "https://www.digital.gov/feed/index.xml"
     shortcode     : "rss"
     action        : "Subscribe via RSS Feed"
 


### PR DESCRIPTION

## What we made better
Switched out all instances of digitalgov.gov for digital.gov in the `/theme/` folder.
Related: https://github.com/GSA/digitalgov.gov/issues/565

