### PR TITLE
fixed text transform on mobile select menu

### DIFF
--- a/themes/digital.gov/static/css/style-responsive.css
+++ b/themes/digital.gov/static/css/style-responsive.css
@@ -151,7 +151,7 @@
 		max-width:100% !important;
 		margin: 0 auto 20px;
 		font-size:14px;
-		text-transform:none;
+		text-transform:capitalize;
 		color:#333;
 		-webkit-appearance:none;
 		background:#fff url(images/downarrow-dark.png) 98% 50% no-repeat;


### PR DESCRIPTION
## fixed https://github.com/GSA/digitalgov.gov/issues/283

The text-transform property on the mobile select menu was set to none. This has been changed in the CSS.

Preview: https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/bug-mobile-menu/

