### PR TITLE
Fixing Images in IE

### DIFF
--- a/themes/digital.gov/layouts/docs/baseof.html
+++ b/themes/digital.gov/layouts/docs/baseof.html
@@ -4,16 +4,18 @@
 {{- else if eq .Params.feed "json" -}}
   {{- block "data" . -}} The DATA didn't load. :( {{- end -}}
 {{- else -}}
-  {{ block "pagevars" . }}{{ end }}
+  {{- block "pagevars" . -}}{{- end -}}
 
-  {{ partial "head.html" . }}
-  {{ partial "body-top.html" . }}
+<!DOCTYPE html>
+{{ partial "head-comment.html" . }}
+  {{- partial "head.html" . -}}
+  {{- partial "body-top.html" . -}}
 
-  {{ block "content" . }} The DOCS CONTENT didn't load. :( {{ end }}
-  {{ if or (eq .Layout "1col") (eq .Layout "all-images") (eq .Layout "new-file") }}{{ else }}
-  {{ block "sidebar" . }}  {{ end }}
-  {{ end }}
+  {{- block "content" . -}} The DOCS CONTENT didn't load. :( {{- end -}}
+  {{- if or (eq .Layout "1col") (eq .Layout "all-images") (eq .Layout "new-file") -}}{{- else -}}
+  {{- block "sidebar" . -}}  {{- end -}}
+  {{- end -}}
 
-  {{ partial "body-bottom.html" . }}
-  {{ partial "footer.html" . }}
+  {{- partial "body-bottom.html" . -}}
+  {{- partial "footer.html" . -}}
 {{- end -}}

--- a/themes/digital.gov/layouts/events/baseof.html
+++ b/themes/digital.gov/layouts/events/baseof.html
@@ -2,13 +2,13 @@
 {{- if eq .Layout "json" -}}
   {{- block "json" . -}} The JSON CONTENT didn't load. :( {{- end -}}
 {{- else -}}
-  {{ block "pagevars" . }}{{ end }}
+  {{- block "pagevars" . -}}{{- end -}}
 
-  {{ partial "head.html" . }}
-  {{ partial "body-top.html" . }}
-
-  {{ block "content" . }} The DOCS CONTENT didn't load. :( {{ end }}
-
-  {{ partial "body-bottom.html" . }}
-  {{ partial "footer.html" . }}
+<!DOCTYPE html>
+{{ partial "head-comment.html" . }}
+  {{- partial "head.html" . -}}
+  {{- partial "body-top.html" . -}}
+  {{- block "content" . -}} The DOCS CONTENT didn't load. :( {{- end -}}
+  {{- partial "body-bottom.html" . -}}
+  {{- partial "footer.html" . -}}
 {{- end -}}

--- a/themes/digital.gov/layouts/shortcodes/img-right.html
+++ b/themes/digital.gov/layouts/shortcodes/img-right.html
@@ -9,12 +9,12 @@
 
 <div class="align-right">
   <img
-    src='{{ $imgBaseCDN }}_bu.{{ $imgExt }}'
+    src='{{ $imgBaseCDN }}_w200.{{ $imgExt }}'
     {{ if or (.Get "alt") $thisimg.alt }}
     alt='{{ with .Get "alt" }}{{ . }}{{ else }}{{ $thisimg.alt }}{{ end }}'
     {{ end }}
     srcset='
-    {{ if gt $imgWidth 200 }}{{ $imgBaseCDN }}_bu.{{ $imgExt }} 48w,
+    {{ if gt $imgWidth 200 }}{{ $imgBaseCDN }}_bu.jpg 48w,
       {{ if gt $imgWidth 400 }}
         {{ if gt $imgWidth 600 }}
           {{/* high-res values for when we implement...

--- a/themes/digital.gov/layouts/shortcodes/img.html
+++ b/themes/digital.gov/layouts/shortcodes/img.html
@@ -13,12 +13,12 @@
 <div class="image{{ if (.Get "align") }} align-{{ .Get "align" }}{{ else}}{{ if lt $imgWidth 600 }} align-right{{ end }}{{ end }}">
   <img
     class="{{ if (.Get "align") }}{{ else }}aligncenter{{ end }}"
-    src='{{ if ne $prefix $thisuid }}{{ $thisuid }}{{ else }}{{ $imgBaseCDN }}_bu.{{ $imgExt }}{{ end }}'
+    src='{{ if ne $prefix $thisuid }}{{ $thisuid }}{{ else }}{{ $imgBaseCDN }}_w800.{{ $imgExt }}{{ end }}'
     {{ if or (.Get "alt" ) $thisimg.alt }}
     alt='{{ with .Get "alt" }}{{ . }}{{ else }}{{ $thisimg.alt }}{{ end }}'
     {{ end }}{{ if eq $prefix $thisuid }}
     srcset='
-    {{ if ge $imgWidth 200 }}{{ $imgBaseCDN }}_bu.{{ $imgExt }} 48w,
+    {{ if ge $imgWidth 200 }}{{ $imgBaseCDN }}_bu.jpg 48w,
       {{ if ge $imgWidth 400 }}
         {{ if ge $imgWidth 600 }}
           {{/* high-res values for when we implement...


### PR DESCRIPTION
## Fixing https://github.com/GSA/digitalgov.gov/issues/644
---

PNG images that we are inserting on pages with the image shortcode are not showing up in IE 9.
This aims to fix that.

**Previews**: 
- **PNG** — https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/ie-png-fix/event/2018/07/20/plain-language-summit-2018/
- **JPG** — https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/ie-png-fix/event/2018/06/14/usability-testing-with-steve-krug/
- **PNG** — https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/ie-png-fix/event/2018/05/31/this-how-we-work-together-with-brad-frost/



