### PR TITLE
Page details overlay

### DIFF
--- a/themes/digital.gov/layouts/_default/single.html
+++ b/themes/digital.gov/layouts/_default/single.html
@@ -15,9 +15,10 @@
     <div class="entry-content">
       {{ .Content }}
     </div>
-    
-    {{ partial "post-meta--feedback" (dict "page" . "page_type" "page" "branch" ($.Scratch.Get "branch") ) }}
 
+    {{ partial "post-meta--feedback" (dict "page" . "page_type" "page" "branch" ($.Scratch.Get "branch") ) }}
+    {{ partial "page-details" . }}
+    
   </div>
 
 </div>

--- a/themes/digital.gov/layouts/docs/single.html
+++ b/themes/digital.gov/layouts/docs/single.html
@@ -17,7 +17,8 @@
         {{ .Content }}
 
         {{ partial "post-meta--feedback" (dict "page" . "page_type" "resource" "branch" ($.Scratch.Get "branch")) }}
-
+        {{ partial "page-details" . }}
+        
       </div><!-- .entry -->
     </div><!--.post -->
   </div><!-- #content -->

--- a/themes/digital.gov/layouts/events/single.html
+++ b/themes/digital.gov/layouts/events/single.html
@@ -50,6 +50,7 @@
   {{ end }}
 
   {{ partial "post-meta--feedback" (dict "page" . "page_type" "event" "cc" "digitalgovu@gsa.gov" "branch" ($.Scratch.Get "branch")) }}
-
+  {{ partial "page-details" . }}
+  
 </div>
 {{ end }}

--- a/themes/digital.gov/layouts/guide/single.html
+++ b/themes/digital.gov/layouts/guide/single.html
@@ -37,6 +37,7 @@
     </div>
 
     {{ partial "post-meta--feedback" (dict "page" . "page_type" "guide" "branch" ($.Scratch.Get "branch")) }}
+    {{ partial "page-details" . }}
 
   </div>
 

--- a/themes/digital.gov/layouts/partials/head.html
+++ b/themes/digital.gov/layouts/partials/head.html
@@ -111,7 +111,7 @@
   <link rel='stylesheet' href='{{ "css/notice-bar.css" | absURL }}' type='text/css' media='all' />
   <link rel='stylesheet' href='{{ "css/tribe-events-full.min.css?ver=4.4.1.1" | absURL }}' type='text/css' media='all' />
   <link rel='stylesheet' href='{{ "css/tribe-events-theme.min.css?ver=4.4.1.1" | absURL }}' type='text/css' media='all' />
-  <link rel='stylesheet' href='{{ "css/entry.css" | absURL }}' type='text/css' media='all' />
+  <link rel='stylesheet' href='{{ "css/entry.css?=20180626" | absURL }}' type='text/css' media='all' />
   <link rel='stylesheet' href='{{ "css/toc.css" | absURL }}' type='text/css' media='all' />
   <link rel='stylesheet' href='{{ "lib/uswds/css/dg-uswds.min.css" | absURL }}' type='text/css' media='all' />
   <link rel="stylesheet" media="all" href="{{ "css/override.css" | absURL }}" type="text/css" />

--- a/themes/digital.gov/layouts/partials/page-details.html
+++ b/themes/digital.gov/layouts/partials/page-details.html
@@ -1,0 +1,11 @@
+<div class="page-details">
+  <div class="contents">
+    <h6>File name</h6>
+    <p>{{ .File.LogicalName }}<p>
+    <h6>File path</h6>
+    <p>{{ .File.Path }}<p>
+    <h6>Link Shortcode</h6>
+    <p>&#x0007B;&#x0007B;&#x0003C; link "{{ .File.Path }}" &#x0003E;&#x0007D;&#x0007D;<p>
+    <button class="close" type="button" name="button">close</button>
+  </div>
+</div>

--- a/themes/digital.gov/layouts/posts/single.html
+++ b/themes/digital.gov/layouts/posts/single.html
@@ -26,7 +26,7 @@
         {{ partial "post-meta--related-posts" . }}
         {{ partial "post-meta--tag-list" . }}
         {{ partial "post-meta--feedback" (dict "page" . "page_type" "article" "branch" ($.Scratch.Get "branch")) }}
-
+        {{ partial "page-details" . }}
 
       </div><!-- .entry -->
 

--- a/themes/digital.gov/static/css/entry.css
+++ b/themes/digital.gov/static/css/entry.css
@@ -1,4 +1,5 @@
 @import "top6.css";
+@import "page-details.css";
 .page .entry{
 }
 

--- a/themes/digital.gov/static/css/page-details.css
+++ b/themes/digital.gov/static/css/page-details.css
@@ -1,0 +1,44 @@
+.page-details{
+	background: rgba(0, 0, 0, 0.9);
+	display: none;
+	width: 100%;
+	height: 100%;
+	position: fixed;
+	top:0;
+	left: 0;
+	z-index: 999;
+}
+.page-details .contents *{
+	color: #fff;
+}
+.page-details .contents{
+	width: 960px;
+	height: 60%;
+	margin: 100px auto;
+	font-size: 1.5rem;
+	line-height: 2rem;
+	color: #fff;
+	/* background: rgba(255, 255, 255, 0.5); */
+}
+
+.page-details .contents h6{
+	margin-bottom: 15px;
+	text-transform: uppercase;
+	font-size: .9rem;
+}
+.page-details .contents p{
+	margin-bottom: 2rem;
+
+}
+.page-details .close{
+	margin-top: 10px;
+	padding: 7px 12px 9px 12px;
+	background: none;
+	border: 3px #fff solid;
+	font-size: 1.2rem;
+	border-radius: 2px;
+	cursor: pointer;
+}
+.page-details .close:hover{
+	background: rgba(255, 255, 255, .3);
+}

--- a/themes/digital.gov/static/js/external.js
+++ b/themes/digital.gov/static/js/external.js
@@ -1,5 +1,13 @@
 jQuery(document).ready(function($) {
 
+$(".page-details .close").click(function() {
+	$(".page-details").toggle();
+});
+$(document).bind('keyup', function (evt) {
+  if (evt.keyCode == 191){
+		$(".page-details").toggle();
+	}
+});
 var featured_height = $('.featured-video').height();
 var featured_hed = $('.featured-news .hed').height();
 var featured_foot = $('.featured-news .foot').height();


### PR DESCRIPTION
## the problem
Getting the filename/file-path and the shortcode that is needed to link to a filename is quite difficult.
`{{< link "events/2018/07/2018-07-06-a-first-look-at-uswds-20.md" >}}`

## what we made better
Now you can press `shift + ?` to get an overlay that contains the filename + link to the shortcode that is needed for linking to an internal page/file.

Examples:
- https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/helper-box/communities/
- https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/helper-box/resources/customer-experience-toolkit/




