### PR TITLE
Updated copy on DGU page

### DIFF
--- a/content/about/digitalgov-university.md
+++ b/content/about/digitalgov-university.md
@@ -2,25 +2,29 @@
 url: /digitalgov-university/
 date: 2013-11-17 11:11:43 -0400
 title: DigitalGov University
-summary: 'DigitalGov University (DGU) is helping agencies meet the public&rsquo;s 21st century digital expectations by providing a platform for federal agencies to share innovations, offer case-studies, host summits and workshops and connect with each other.'
+summary: 'DigitalGov helps agencies meet the public&rsquo;s 21st century digital expectations by providing a platform for federal agencies to share innovations, offer case-studies, host summits and workshops and connect with each other.'
 aliases:
   - /digitalgov-university/digitalgov-university-event-and-training-request-form/
 ---
 
 We provide a range of free online and in-person trainings and events for people and teams across the federal government. Many of our events highlight innovations, case studies, tools, and resources. All of our events are recorded and [archived on YouTube](https://youtube.com/digitalgov). Trainings are open to anyone working in the government or for a government agency.
 
-[Fill out our form](https://docs.google.com/a/gsa.gov/forms/d/e/1FAIpQLSdiVKVO9g9PVKdifYwJ76O8zUxg7YTycNodDxN4FnbHiG9Drw/viewform) to request an online or in-person training or event. If you have any questions, please [send us an email](mailto:digitalgovu@gsa.gov).
+- [View our upcoming events »]({{< link "/events/" >}})
+- [View our video archive »](https://youtube.com/digitalgov)
 
-<hr style="border: none" />
+## Work with us
 
-<p style="text-align: center">
-  {{< button href="events" text="Upcoming Events" >}}
-  {{< button href="https://youtube.com/digitalgov" text="Video Archive" >}}
-</p>
+**Interested in hosting an online or in-person training or event?**<br/>
+Send us an email with describing your idea, the type of training or event you think would best convey that idea, and who the intended audience would be. [**digitalgovu@gsa.gov**](mailto:digitalgovu@gsa.gov)
 
-## Use of DigitalGov University Materials
+{{< button href="mailto:digitalgovu@gsa.gov?subject=Training%20Idea" text="Send us an email" >}}
 
-{{< legacy-img src="/2013/11/SocialGov-1024x762-250x186.jpg" alt="Gathering of people at an inperson training event" >}}Unless a copyright is indicated, material presented by DigitalGov University is free of copyright and may be copied and distributed without permission. Citation of DigitalGov University as source is appreciated. However, some material used in DGU training is the property of private individuals, companies, or independent contractors and therefore may be protected by copyright.
+
+
+
+## Use of DigitalGov Materials
+
+Unless a copyright is indicated, material presented by DigitalGov is free of copyright and may be copied and distributed without permission. Citation of DigitalGov as source is appreciated. However, some material used in DGU training is the property of private individuals, companies, or independent contractors and therefore may be protected by copyright.
 
 If a copyright is indicated on a photo, graphic, or other material, you must get permission from the original source to use or to copy this material.
 


### PR DESCRIPTION
A reader emailed us saying that Google Forms were not accessible at her agency (dod).

- It is not clear who owns the google form on the existing DGU page.
- I changed out the text in the page to simply request that this information be sent via email.

