### PR TITLE
Alphabetizing and sorting tags

### DIFF
--- a/themes/digital.gov/layouts/partials/post-meta--categories-list.html
+++ b/themes/digital.gov/layouts/partials/post-meta--categories-list.html
@@ -7,7 +7,7 @@
 {{ if (not (isset .Params "categories")) | or (eq .Params.categories "") }}
 {{ else }}
   <li class="meta-cats"> {{/* meta-cats! */}}
-    {{ $_cats := .Params.categories }}
+    {{ $_cats := sort .Params.categories }}
     {{ $.Scratch.Set "relatedCommunities" (slice) }}
     {{ $length := $_cats | len }}
     {{ range $i, $e := $_cats }}

--- a/themes/digital.gov/layouts/partials/post-meta--categories-list.html
+++ b/themes/digital.gov/layouts/partials/post-meta--categories-list.html
@@ -20,9 +20,9 @@
       {{ end }}
       {{ $link := printf "categories/%s/" $slug }}
       {{ if lt (add $i 1) $length }}
-        <a href="{{ $link | absURL }}" rel="category tag">{{ $category.display_name }}</a>,
+        <a href="{{ $link | absURL }}" rel="category tag">{{- if $category -}}{{- $category.display_name -}}{{- else -}}{{- $slug -}}{{- end -}}</a>,
       {{ else }}
-        <a href="{{ $link | absURL }}" rel="category tag">{{ $category.display_name }}</a>
+        <a href="{{ $link | absURL }}" rel="category tag">{{- if $category -}}{{- $category.display_name -}}{{- else -}}{{- $slug -}}{{- end -}}</a>
       {{ end }}
     {{ end }}
   </li>

--- a/themes/digital.gov/layouts/partials/post-meta--tag-list.html
+++ b/themes/digital.gov/layouts/partials/post-meta--tag-list.html
@@ -2,7 +2,7 @@
 {{ if (not (isset .Params "tag")) | or (eq .Params.tag "") }}
 {{ else }}
   <p class="tags">Tags:
-    {{ $_taxonomy := .Params.tag }}
+    {{ $_taxonomy := sort .Params.tag }}
     {{ $length := $_taxonomy | len }}
     {{ range $i, $e := $_taxonomy }}
       {{ $slug := $e | urlize }}

--- a/themes/digital.gov/layouts/partials/post-meta--tag-list.html
+++ b/themes/digital.gov/layouts/partials/post-meta--tag-list.html
@@ -4,15 +4,20 @@
   <p class="tags">Tags:
     {{ $_taxonomy := sort .Params.tag }}
     {{ $length := $_taxonomy | len }}
+
     {{ range $i, $e := $_taxonomy }}
+
       {{ $slug := $e | urlize }}
       {{ $tag := index $sitetags $slug }}
       {{ $link := printf "tag/%s/" $slug }}
+
       {{ if lt (add $i 1) $length }}
-        <a href="{{ $link | absURL }}" rel="tag">{{ $tag.display_name }}</a>,
+        <a href="{{ $link | absURL }}" rel="tag">{{- if $tag -}}{{- $tag.display_name -}}{{- else -}}{{- $slug -}}{{- end -}}</a>,
       {{ else }}
-        <a href="{{ $link | absURL }}" rel="tag">{{ $tag.display_name }}</a>
+        <a href="{{ $link | absURL }}" rel="tag">{{- if $tag -}}{{- $tag.display_name -}}{{- else -}}{{- $slug -}}{{- end -}}</a>
       {{ end }}
+
     {{ end }}
+
   </p>
 {{ end }}


### PR DESCRIPTION
## what we made better

For tags and categories lists on the post pages, we are making sure we are not excluding tags without data files and we are alphabetizing the whole list.

Preview: https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/exploring-tags/2018/08/30/collaborating-for-better-design-technology-user-experience/