### PR TITLE
adding caching to partials

### DIFF
--- a/themes/digital.gov/layouts/_default/baseof.html
+++ b/themes/digital.gov/layouts/_default/baseof.html
@@ -1,8 +1,8 @@
-{{- partial "set-env.html" . -}}
+{{- partialCached "set-env.html" . -}}
 {{ block "pagevars" . }}{{ end }}
 
 <!DOCTYPE html>
-{{ partial "head-comment.html" . }}
+{{ partialCached "head-comment.html" . }}
 {{ partial "head.html" . }}
 {{ partial "body-top.html" . }}
 

--- a/themes/digital.gov/layouts/_default/list.json.json
+++ b/themes/digital.gov/layouts/_default/list.json.json
@@ -1,4 +1,4 @@
-{{- partial "set-env.html" . -}}
+{{- partialCached "set-env.html" . -}}
 {{- $list := .Data.Pages -}}
 {{- $length := (len $list) -}}
 {

--- a/themes/digital.gov/layouts/_default/single.json.json
+++ b/themes/digital.gov/layouts/_default/single.json.json
@@ -1,4 +1,4 @@
-{{- partial "set-env.html" . -}}
+{{- partialCached "set-env.html" . -}}
 {{- $list := .Data.Pages -}}
 {{- $length := (len $list) -}}
 {

--- a/themes/digital.gov/layouts/_default/taxonomy.html
+++ b/themes/digital.gov/layouts/_default/taxonomy.html
@@ -51,8 +51,8 @@
 
           {{ partial "sidebar--relatedCommunities.html" . (dict "list" . "communities" ($.Scratch.Get "relatedCommunities")) }}
           {{ partial "sidebar--topics.html" . }}
-          {{ partial "sidebar--recentPosts.html" . }}
-          {{ partial "sidebar--events.html" . }}
+          {{ partialCached "sidebar--recentPosts.html" . }}
+          {{ partialCached "sidebar--events.html" . }}
         </div>
       </div>
 

--- a/themes/digital.gov/layouts/docs/baseof.html
+++ b/themes/digital.gov/layouts/docs/baseof.html
@@ -1,4 +1,4 @@
-{{- partial "set-env.html" . -}}
+{{- partialCached "set-env.html" . -}}
 {{- if eq .Params.feed "xml" -}}
   {{- partial "all-posts-feed.html" . -}}
 {{- else if eq .Params.feed "json" -}}

--- a/themes/digital.gov/layouts/events/baseof.html
+++ b/themes/digital.gov/layouts/events/baseof.html
@@ -1,4 +1,4 @@
-{{- partial "set-env.html" . -}}
+{{- partialCached "set-env.html" . -}}
 {{- if eq .Layout "json" -}}
   {{- block "json" . -}} The JSON CONTENT didn't load. :( {{- end -}}
 {{- else -}}

--- a/themes/digital.gov/layouts/events/li.html
+++ b/themes/digital.gov/layouts/events/li.html
@@ -1,4 +1,4 @@
-{{ partial "event-venue--inPerson.html" . }}
+{{ partialCached "event-venue--inPerson.html" . }}
 
 <!-- Event  -->
 <div class="event entry">

--- a/themes/digital.gov/layouts/events/past.html
+++ b/themes/digital.gov/layouts/events/past.html
@@ -1,4 +1,4 @@
-{{ partial "event-venue--inPerson.html" . }}
+{{ partialCached "event-venue--inPerson.html" . }}
 
 <!-- Event  -->
 <div class="event event-past entry">

--- a/themes/digital.gov/layouts/events/single.html
+++ b/themes/digital.gov/layouts/events/single.html
@@ -5,7 +5,7 @@
 
 {{ define "content" }}
 
-{{ partial "event-venue--inPerson.html" . }}
+{{ partialCached "event-venue--inPerson.html" . }}
 
 <div class="entry event">
   <div class="event-head">

--- a/themes/digital.gov/layouts/index.html
+++ b/themes/digital.gov/layouts/index.html
@@ -7,10 +7,9 @@
 <div id="widgetized-page" class="clearfix">
   <div class="page-widget-wide top clearfix">
 
-    {{ partial "body-top6.html" . }}
-    <!-- {{ partial "body-latest-events.html" . }} -->
-    {{ partial "body-featured-events.html" . }}
-    <!-- {{ partial "body-featured.html" . }} -->
+    {{ partialCached "body-top6.html" . }}
+    {{ partialCached "body-featured-events.html" . }}
+
 
   </div><!-- /div.page-widget-wide -->
   <div class="page-widget-wide bottom clearfix">

--- a/themes/digital.gov/layouts/partials/body-top.html
+++ b/themes/digital.gov/layouts/partials/body-top.html
@@ -24,12 +24,12 @@
     {{ partial "notice-bar.html" . }}
   {{ end }}
 
-  {{ partial "usa-banner.html" . }}
+  {{ partialCached "usa-banner.html" . }}
 
   <div id="outer-wrap" role="main">
 
     {{ partial "nav-top-nav.html" . }}
-    {{ partial "header.html" . }}
+    {{ partialCached "header.html" . }}
 
     <div id="wrap">
       {{ if ($.Scratch.Get "has_sidebar") }}

--- a/themes/digital.gov/layouts/partials/event--item.html
+++ b/themes/digital.gov/layouts/partials/event--item.html
@@ -1,4 +1,4 @@
-{{ partial "event-venue--inPerson.html" . }}
+{{ partialCached "event-venue--inPerson.html" . }}
 {{ $displaytitle := $.Scratch.Get "displaytitle" }}
 
 <li class="tribe-events-list-widget-events type-tribe_events tribe-clearfix">

--- a/themes/digital.gov/layouts/partials/footer-widgets.html
+++ b/themes/digital.gov/layouts/partials/footer-widgets.html
@@ -2,8 +2,8 @@
   <div class="limit clearfix">
     <div class="footer-widget1">
 
-      {{ partial "footer--social.html" . }}
-      {{ partial "footer--info.html" . }}
+      {{ partialCached "footer--social.html" . }}
+      {{ partialCached "footer--info.html" . }}
 
     </div>
     <div class="footer-widget2">
@@ -13,12 +13,12 @@
     </div>
     <div class="footer-widget3">
 
-      {{ partial "footer--recent-posts.html" . }}
+      {{ partialCached "footer--recent-posts.html" . }}
 
     </div>
     <div class="footer-widget4" id="tribe-events-list-widget-7">
 
-      {{ partial "sidebar--events.html" . }}
+      {{ partialCached "sidebar--events.html" . }}
 
     </div>
   </div>

--- a/themes/digital.gov/layouts/partials/footer.html
+++ b/themes/digital.gov/layouts/partials/footer.html
@@ -1,8 +1,8 @@
-{{ partial "footer-widgets.html" . }}
-{{ partial "footer-wtf.html" . }}
+{{ partialCached "footer-widgets.html" . }}
+{{ partialCached "footer-wtf.html" . }}
 <a id="backtotop" href="#top">Top</a>
 </div><!-- /div#outerwrap -->
 {{ partial "footer-end-scripts.html" . }}
-{{ partial "footer--custom-js.html" . }}
+{{ partialCached "footer--custom-js.html" . }}
 </body>
 </html>

--- a/themes/digital.gov/layouts/partials/head.html
+++ b/themes/digital.gov/layouts/partials/head.html
@@ -162,5 +162,5 @@
   </script>
 
 
-  {{ partial "head--custom-css.html" . }}
+  {{ partialCached "head--custom-css.html" . }}
 </head>

--- a/themes/digital.gov/layouts/partials/header.html
+++ b/themes/digital.gov/layouts/partials/header.html
@@ -6,7 +6,7 @@
       <a href="{{ "index.html" | absURL }}" title="DigitalGov"><img src="https://s3.amazonaws.com/sitesusa/wp-content/uploads/sites/212/2014/01/logo2.png" alt="DigitalGov" /></a>
     </div>
 
-    {{ partial "nav-catnav.html" . }}
+    {{ partialCached "nav-catnav.html" . }}
 
   </div>
 </div>

--- a/themes/digital.gov/layouts/partials/sidebar-common.html
+++ b/themes/digital.gov/layouts/partials/sidebar-common.html
@@ -2,8 +2,8 @@
   <div id="sidebar" class="clearfix">
 
     {{ partial "sidebar--relatedCommunities.html" . }}
-    {{ partial "sidebar--recentPosts.html" . }}
-    {{ partial "sidebar--events.html" . }}
+    {{ partialCached "sidebar--recentPosts.html" . }}
+    {{ partialCached "sidebar--events.html" . }}
 
   </div><!-- #sidebar -->
 </div><!-- #contentright -->

--- a/themes/digital.gov/layouts/robots.txt
+++ b/themes/digital.gov/layouts/robots.txt
@@ -1,4 +1,4 @@
-{{- partial "set-env.html" . -}}
+{{- partialCached "set-env.html" . -}}
 User-agent: *
 {{ if eq ($.Scratch.Get "env") "site" }}
 {{- else -}}


### PR DESCRIPTION
## What we made better

After running a few scripts to assess the performance of HUGO, 
https://gohugo.io/troubleshooting/build-performance/

I was able to determine that a number of the partials and sub-files we have can be cached.

See: https://gohugo.io/functions/partialcached/

This should speed up the build of the site.

Preview: https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/partial-caching/
