### PR TITLE
Fix typo in 11/6 FedRAMP event description

### DIFF
--- a/content/events/2018/11/2018-11-06-fedramps-resources-for-agencies.md
+++ b/content/events/2018/11/2018-11-06-fedramps-resources-for-agencies.md
@@ -19,7 +19,7 @@ youtube_id: JMSKBVKjE9g
 
 {{< img-right src="featued-301-x-212-fedramp-2017-5th-anniversary-logo" >}}
 
-A video walkthrough + Q & A for Agency partners interested in learning more about [the recent updates](https://www.fedramp.gov/find-resources-easier-with-new-updates-to-fedrampgov/) to [fedramp.gov](https://fedramp.gov) and the resources available to help CSPs through the FedRAMP authorization process.
+A video walkthrough + Q & A for Agency partners interested in learning more about [the recent updates](https://www.fedramp.gov/find-resources-easier-with-new-updates-to-fedrampgov/) to [fedramp.gov](https://fedramp.gov) and the resources available to help Agency partners through the FedRAMP authorization process.
 
 ## What we’ll cover
 


### PR DESCRIPTION
Replaced "CSPs" with "Agency partners" in the following sentence: "the resources available to help CSPs through the FedRAMP authorization process."