### PR TITLE
Fixing the plural titles in the breadcrumbs

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -63,6 +63,8 @@ taxonomies:
   category              : "categories"
   author                : "authors"
 
+pluralizelisttitles     : false
+
 menu:
   primary:
     - Name            : "home"

--- a/config_dev.yml
+++ b/config_dev.yml
@@ -67,6 +67,8 @@ taxonomies:
   category              : "categories"
   author                : "authors"
 
+pluralizelisttitles     : false
+
 menu:
   primary:
     - Name            : "home"


### PR DESCRIPTION
## Fixing https://github.com/GSA/digitalgov.gov/issues/785
by setting pluralizelisttitles to FALSE

Preview: https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/breadcrumb-fix/about/