### PR TITLE
Adding addthis to all pages

### DIFF
--- a/themes/digital.gov/layouts/_default/single.html
+++ b/themes/digital.gov/layouts/_default/single.html
@@ -14,11 +14,16 @@
 
     <div class="entry-content">
       {{ .Content }}
+
+      <!-- Go to www.addthis.com/dashboard to customize your tools -->
+      <div class="addthis_inline_share_toolbox"></div>
     </div>
+
+
 
     {{ partial "post-meta--feedback" (dict "page" . "page_type" "page" "branch" ($.Scratch.Get "branch") ) }}
     {{ partial "page-details" . }}
-    
+
   </div>
 
 </div>

--- a/themes/digital.gov/layouts/communities/single.html
+++ b/themes/digital.gov/layouts/communities/single.html
@@ -13,10 +13,11 @@
     </div>
 
     <div class="entry-content">
-      {{ .Content }}
-
       <!-- Go to www.addthis.com/dashboard to customize your tools -->
       <div class="addthis_inline_share_toolbox"></div>
+
+      {{ .Content }}
+
     </div>
 
 

--- a/themes/digital.gov/layouts/communities/single.html
+++ b/themes/digital.gov/layouts/communities/single.html
@@ -14,7 +14,12 @@
 
     <div class="entry-content">
       {{ .Content }}
+
+      <!-- Go to www.addthis.com/dashboard to customize your tools -->
+      <div class="addthis_inline_share_toolbox"></div>
     </div>
+
+
 
     {{ partial "post-meta--feedback" (dict "page" . "page_type" "page" "branch" ($.Scratch.Get "branch") ) }}
     {{ partial "page-details" . }}

--- a/themes/digital.gov/layouts/events/single.html
+++ b/themes/digital.gov/layouts/events/single.html
@@ -40,8 +40,10 @@
     {{ partial "event-stage.html" . }}
   {{ end }}
 
-
   <div class="event-content">
+    <!-- Go to www.addthis.com/dashboard to customize your tools -->
+    <div class="addthis_inline_share_toolbox"></div>
+
     {{ .Content }}
   </div>
 
@@ -51,6 +53,6 @@
 
   {{ partial "post-meta--feedback" (dict "page" . "page_type" "event" "cc" "digitalgovu@gsa.gov" "branch" ($.Scratch.Get "branch")) }}
   {{ partial "page-details" . }}
-  
+
 </div>
 {{ end }}

--- a/themes/digital.gov/layouts/guide/single.html
+++ b/themes/digital.gov/layouts/guide/single.html
@@ -36,17 +36,19 @@
         <h6>In this page</h6>
         {{ partial "toc.html" . }}
       </div>
-      <!-- Go to www.addthis.com/dashboard to customize your tools -->
-      <div class="addthis_inline_share_toolbox"></div>
+
     </div>
 
 
     <div class="entry-content">
+      <!-- Go to www.addthis.com/dashboard to customize your tools -->
+      <div class="addthis_inline_share_toolbox"></div>
+      
       {{ .Content }}
 
       <!-- Go to www.addthis.com/dashboard to customize your tools -->
       <div class="addthis_inline_share_toolbox"></div>
-      
+
     </div>
 
     {{ partial "post-meta--feedback" (dict "page" . "page_type" "guide" "branch" ($.Scratch.Get "branch")) }}

--- a/themes/digital.gov/layouts/guide/single.html
+++ b/themes/digital.gov/layouts/guide/single.html
@@ -36,10 +36,17 @@
         <h6>In this page</h6>
         {{ partial "toc.html" . }}
       </div>
+      <!-- Go to www.addthis.com/dashboard to customize your tools -->
+      <div class="addthis_inline_share_toolbox"></div>
     </div>
+
 
     <div class="entry-content">
       {{ .Content }}
+
+      <!-- Go to www.addthis.com/dashboard to customize your tools -->
+      <div class="addthis_inline_share_toolbox"></div>
+      
     </div>
 
     {{ partial "post-meta--feedback" (dict "page" . "page_type" "guide" "branch" ($.Scratch.Get "branch")) }}

--- a/themes/digital.gov/layouts/partials/footer-end-scripts.html
+++ b/themes/digital.gov/layouts/partials/footer-end-scripts.html
@@ -216,7 +216,5 @@
 
 <script src='{{ "lib/uswds/js/uswds.min.js" | absURL }}'></script>
 
-{{ if eq .Section "posts" }}
 <!-- Go to www.addthis.com/dashboard to customize your tools -->
 <script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-533093ab734d6d4c"></script>
-{{ end }}

--- a/themes/digital.gov/layouts/posts/single.html
+++ b/themes/digital.gov/layouts/posts/single.html
@@ -16,6 +16,7 @@
         </h1>
 
         {{ partial "post-meta" . }}
+        
         <!-- Go to www.addthis.com/dashboard to customize your tools -->
         <div class="addthis_inline_share_toolbox"></div>
 

--- a/themes/digital.gov/layouts/resources/single.html
+++ b/themes/digital.gov/layouts/resources/single.html
@@ -13,8 +13,13 @@
     </div>
 
     <div class="entry-content">
+      <!-- Go to www.addthis.com/dashboard to customize your tools -->
+      <div class="addthis_inline_share_toolbox"></div>
+      
       {{ .Content }}
     </div>
+    <!-- Go to www.addthis.com/dashboard to customize your tools -->
+    <div class="addthis_inline_share_toolbox"></div>
 
     {{ partial "post-meta--feedback" (dict "page" . "page_type" "page" "branch" ($.Scratch.Get "branch") ) }}
     {{ partial "page-details" . }}

--- a/themes/digital.gov/layouts/services/single.html
+++ b/themes/digital.gov/layouts/services/single.html
@@ -14,6 +14,9 @@
 
     <div class="entry-content">
       {{ .Content }}
+
+      <!-- Go to www.addthis.com/dashboard to customize your tools -->
+      <div class="addthis_inline_share_toolbox"></div>
     </div>
 
     {{ partial "post-meta--feedback" (dict "page" . "page_type" "page" "branch" ($.Scratch.Get "branch") ) }}

--- a/themes/digital.gov/layouts/services/single.html
+++ b/themes/digital.gov/layouts/services/single.html
@@ -13,10 +13,10 @@
     </div>
 
     <div class="entry-content">
-      {{ .Content }}
-
       <!-- Go to www.addthis.com/dashboard to customize your tools -->
       <div class="addthis_inline_share_toolbox"></div>
+      
+      {{ .Content }}
     </div>
 
     {{ partial "post-meta--feedback" (dict "page" . "page_type" "page" "branch" ($.Scratch.Get "branch") ) }}


### PR DESCRIPTION
### Resources
**Fixing:** https://github.com/GSA/digitalgov.gov/issues/784
I added them only to the top of resource pages
**Preview:** https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/adding-addthis/resources/contact-center-guidelines/

### Event pages
I added them only to the tops of event pages since they are usually very short pages, and we'd likely see it twice.
**Fixing:** https://github.com/GSA/digitalgov.gov/issues/781
**Preview:** https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/adding-addthis/event/2018/12/12/december-plain-meeting-holiday-gathering/

### Community pages
I added them only to the top of community pages
**Fixing:** https://github.com/GSA/digitalgov.gov/issues/782
**Preview:** https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/adding-addthis/communities/open-government/

### Guide Templates
I added it to the top and bottom
**Preview:** https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/adding-addthis/resources/checklist-of-requirements-for-federal-digital-services/

### Services
**Fixing:** https://github.com/GSA/digitalgov.gov/issues/783
I added it to the top
**Preview:** https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/adding-addthis/services/data-gov/
