### PR TITLE
Removing widgets from Footer

### DIFF
--- a/themes/digital.gov/layouts/partials/footer-widgets.html
+++ b/themes/digital.gov/layouts/partials/footer-widgets.html
@@ -6,20 +6,6 @@
       {{ partial "footer--info.html" . }}
 
     </div>
-    <div class="footer-widget2">
 
-      {{/* Content missing */}}
-
-    </div>
-    <div class="footer-widget3">
-
-      {{ partial "footer--recent-posts.html" . }}
-
-    </div>
-    <div class="footer-widget4" id="tribe-events-list-widget-7">
-
-      {{ partial "sidebar--events.html" . }}
-
-    </div>
   </div>
 </div>


### PR DESCRIPTION
## Addressing https://github.com/GSA/digitalgov.gov/issues/773
I am removing the Footer widgets from the footer that are causing issues.
It is too much work to fix the formatting and CSS for these at this time, only to wipe them out in the new design

**Preview:** https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/Footer-Fixes/