### PR TITLE
Certificates shutdown

### DIFF
--- a/content/resources/how-to-prevent-security-certificates-from-expiring-during-shutdown.md
+++ b/content/resources/how-to-prevent-security-certificates-from-expiring-during-shutdown.md
@@ -42,17 +42,18 @@ If the certificate is set to expire in the next three months (or the possible le
 ### Have Questions?
 [This overview on certificates from CIO.gov](https://https.cio.gov/certificates/) is one of the best resources for people in government who are wanting to learn more about getting SSL certificates right.
 
-**Q. Are security certificates and SSL certificates the same thing?**
+#### Q. Are security certificates and SSL certificates the same thing?
 Yep.
 
-**Q. What do certificates do exactly?**
+#### Q. What do certificates do exactly?
 [From CIO.gov](https://https.cio.gov/certificates/) —
 > "Websites use certificates to create an HTTPS connection. When signed by a trusted certificate authority (CA), certificates give confidence to browsers that they are visiting the “real” website."
 
-**Q. Can certificates be set to auto-renew?**
+#### Q. Can certificates be set to auto-renew?
 Yes, you should talk to your IT department about moving in the direction of auto-renewing certificates.
 
-We generally recommend that the certificates you do purchase be low cost, automatable, short-lived, and published to Certificate Transparency logs.  Furthermore, all certificates should be free of the following:
+We generally recommend that any certificate you do purchase be low cost, automatable, short-lived, and published to Certificate Transparency logs.  Furthermore, all certificates should be free of the following:
+
 - Domain name mismatch, including Subject Alternative Name (SAN) errors
 - Certiﬁcate not yet valid
 - Certiﬁcate expired
@@ -62,8 +63,6 @@ We generally recommend that the certificates you do purchase be low cost, automa
 - Use of a revoked certiﬁcate
 - Insecure certiﬁcate signature (MD2 or MD5 or SHA-1 [for new certificates])
 - Insecure key
-
-Yes! You should definitely talk to your IT department about moving in the direction of auto-renewing your certificates. The best method is to use the free, open-source tool “[Let’s Encrypt](https://letsencrypt.org/)”. Once implemented on your server, it auto-renews your certificate every three months — for free.
 
 At the GSA, we use a free, open-source option called “[Let’s Encrypt](https://letsencrypt.org/)”. Once implemented on your server, it auto-renews your certificate every three months.  And if you host your government site on [cloud.gov](https://cloud.gov/), [search.gov](https://search.gov/) or [federalist.18f.gov](https://federalist.18f.gov/), your certificates will automatically renewed.
 

--- a/content/resources/how-to-prevent-security-certificates-from-expiring-during-shutdown.md
+++ b/content/resources/how-to-prevent-security-certificates-from-expiring-during-shutdown.md
@@ -14,7 +14,7 @@ The easiest way to do this is to:
 - Download the CSV data of your domains
 - Open the CSV as a spreadsheet
 
-### 2. Ask your IT department which domains are auto-renewing?
+### 2. Ask your IT department which domains are auto-renewing
 Send them your new spreadsheet and have them mark which domains and sub-domains are auto-renewing.
 
 ### 3. Figure out who is responsible for purchasing security (SSL) certificates in your organization.
@@ -50,9 +50,22 @@ Yep.
 > "Websites use certificates to create an HTTPS connection. When signed by a trusted certificate authority (CA), certificates give confidence to browsers that they are visiting the “real” website."
 
 **Q. Can certificates be set to auto-renew?**
+Yes, you should talk to your IT department about moving in the direction of auto-renewing certificates.
+
+We generally recommend that the certificates you do purchase be low cost, automatable, short-lived, and published to Certificate Transparency logs.  Furthermore, all certificates should be free of the following:
+- Domain name mismatch, including Subject Alternative Name (SAN) errors
+- Certiﬁcate not yet valid
+- Certiﬁcate expired
+- Certificates lasting longer than three years
+- Use of a self-signed certiﬁcate
+- Use of a certiﬁcate that is not trusted (unknown CA or some other validation error)
+- Use of a revoked certiﬁcate
+- Insecure certiﬁcate signature (MD2 or MD5 or SHA-1 [for new certificates])
+- Insecure key
+
 Yes! You should definitely talk to your IT department about moving in the direction of auto-renewing your certificates. The best method is to use the free, open-source tool “[Let’s Encrypt](https://letsencrypt.org/)”. Once implemented on your server, it auto-renews your certificate every three months — for free.
 
-Or, host your government site on [cloud.gov](https://cloud.gov/), [search.gov](https://search.gov/) or [federalist.18f.gov](https://federalist.18f.gov/) and your certificates will automatically renew every three months with [Let’s Encrypt](https://letsencrypt.org/).
+At the GSA, we use a free, open-source option called “[Let’s Encrypt](https://letsencrypt.org/)”. Once implemented on your server, it auto-renews your certificate every three months.  And if you host your government site on [cloud.gov](https://cloud.gov/), [search.gov](https://search.gov/) or [federalist.18f.gov](https://federalist.18f.gov/), your certificates will automatically renewed.
 
 **Related reading:**
 - [Let’s Encrypt Those CNAMES, Shall We?](https://digital.gov/2016/09/07/lets-encrypt-those-cnames-shall-we/)

--- a/content/resources/how-to-prevent-security-certificates-from-expiring-during-shutdown.md
+++ b/content/resources/how-to-prevent-security-certificates-from-expiring-during-shutdown.md
@@ -1,8 +1,8 @@
 ---
 url: /resources/how-to-prevent-security-certificates-from-expiring-during-shutdown/
-date: 2019-02-06 10:00:00 -0400
-title: How to prevent security certificates from expiring during a shutdown
-summary: ""
+date: 2019-02-07 11:30:00 -0400
+title: "How to prevent security certificates from expiring during a lapse in operations"
+summary: "These are the steps that people in government can take to avoid having security certificates expire during a lapse in operations."
 ---
 
 ### 1. Gather a list of all of your domains
@@ -33,7 +33,7 @@ This is fairly easy:
 _Or you can also ask the person who regularly purchases your SSL certificates. They might keep a log._
 
 ### 5. Renew all upcoming SSL certificates
-If the certificate is set to expire in the next three months (or the possible length of a shutdown), make a request that those certificates be renewed now.
+If the certificate is set to expire in the next three months , make a request to get those certificates renewed now.
 
 :tada:
 

--- a/content/resources/how-to-prevent-security-certificates-from-expiring-during-shutdown.md
+++ b/content/resources/how-to-prevent-security-certificates-from-expiring-during-shutdown.md
@@ -18,23 +18,24 @@ The easiest way to do this is to:
 Send them your new spreadsheet and have them mark which domains and sub-domains are auto-renewing.
 
 ### 3. Figure out who is responsible for purchasing security (SSL) certificates in your organization.
-You are going to need to reach out to them.
-_NOTE: The person/people who usually buys your certificates (someone with purchasing authority) are usually different from the people who upload them (usually someone in IT)._
+You are going to need to reach out to the person/people who usually buys your certificates _(someone with purchasing authority)_. They are usually different from the people who upload your certificates _(usually someone in IT)_.
 
 ### 4. Identify when your SSL certificates will expire
 This is fairly easy:
 
 - Go to [https://transparencyreport.google.com/https/certificates?hl=en](https://transparencyreport.google.com/https/certificates?hl=en)
 - Scroll down to “Search certificates by hostname” and enter your parent domain
-- - ✓ Include certificates that have expired
-- - ✓ Include subdomains
-- - Press ‘enter’
+  - ✓ Include certificates that have expired
+  - ✓ Include subdomains
+  - Press ‘enter’
 - Note the “Valid to” date in your new domains spreadsheet
 
 _Or you can also ask the person who regularly purchases your SSL certificates. They might keep a log._
 
 ### 5. Renew all upcoming SSL certificates
 If the certificate is set to expire in the next three months (or the possible length of a shutdown), make a request that those certificates be renewed now.
+
+:tada:
 
 ---
 

--- a/content/resources/how-to-prevent-security-certificates-from-expiring-during-shutdown.md
+++ b/content/resources/how-to-prevent-security-certificates-from-expiring-during-shutdown.md
@@ -25,9 +25,8 @@ This is fairly easy:
 
 - Go to [https://transparencyreport.google.com/https/certificates?hl=en](https://transparencyreport.google.com/https/certificates?hl=en)
 - Scroll down to “Search certificates by hostname” and enter your parent domain
-  - ✓ Include certificates that have expired
-  - ✓ Include subdomains
-  - Press ‘enter’
+- Check both boxes ✓ for "Include certificates that have expired" and "Include subdomains"
+- Press ‘enter’
 - Note the “Valid to” date in your new domains spreadsheet
 
 _Or you can also ask the person who regularly purchases your SSL certificates. They might keep a log._

--- a/content/resources/how-to-prevent-security-certificates-from-expiring-during-shutdown.md
+++ b/content/resources/how-to-prevent-security-certificates-from-expiring-during-shutdown.md
@@ -1,5 +1,5 @@
 ---
-url: /resources/how-to-prevent-security-certificates-from-expiring-during-shutdown/
+url: /resources/how-to-prevent-security-certificates-from-expiring-during-a-lapse-in-operations/
 date: 2019-02-07 11:30:00 -0400
 title: "How to Prevent Security Certificates From Expiring During a Lapse in Operations"
 summary: "These are the steps that people in government can take to avoid having security certificates expire during a lapse in operations."

--- a/content/resources/how-to-prevent-security-certificates-from-expiring-during-shutdown.md
+++ b/content/resources/how-to-prevent-security-certificates-from-expiring-during-shutdown.md
@@ -47,7 +47,8 @@ Yep.
 
 #### Q. What do certificates do exactly?
 [From CIO.gov](https://https.cio.gov/certificates/) —
-> "Websites use certificates to create an HTTPS connection. When signed by a trusted certificate authority (CA), certificates give confidence to browsers that they are visiting the “real” website."
+
+>"Websites use certificates to create an HTTPS connection. When signed by a trusted certificate authority (CA), certificates give confidence to browsers that they are visiting the “real” website."
 
 #### Q. Can certificates be set to auto-renew?
 Yes, you should talk to your IT department about moving in the direction of auto-renewing certificates.
@@ -67,6 +68,7 @@ We generally recommend that any certificate you do purchase be low cost, automat
 At the GSA, we use a free, open-source option called “[Let’s Encrypt](https://letsencrypt.org/)”. Once implemented on your server, it auto-renews your certificate every three months.  And if you host your government site on [cloud.gov](https://cloud.gov/), [search.gov](https://search.gov/) or [federalist.18f.gov](https://federalist.18f.gov/), your certificates will automatically renewed.
 
 **Related reading:**
+
 - [Let’s Encrypt Those CNAMES, Shall We?](https://digital.gov/2016/09/07/lets-encrypt-those-cnames-shall-we/)
 
 **Still have questions?**

--- a/content/resources/how-to-prevent-security-certificates-from-expiring-during-shutdown.md
+++ b/content/resources/how-to-prevent-security-certificates-from-expiring-during-shutdown.md
@@ -1,0 +1,60 @@
+---
+url: /resources/how-to-prevent-security-certificates-from-expiring-during-shutdown/
+date: 2019-02-06 10:00:00 -0400
+title: How to prevent security certificates from expiring during a shutdown
+summary: ""
+---
+
+### 1. Gather a list of all of your domains
+The easiest way to do this is to:
+
+- Go to [https://pulse.cio.gov/https/domains/](https://pulse.cio.gov/https/domains/)
+- Find your parent domain
+- Click on your domain to show all your publicly available sub-domains
+- Download the CSV data of your domains
+- Open the CSV as a spreadsheet
+
+### 2. Ask your IT department which domains are auto-renewing?
+Send them your new spreadsheet and have them mark which domains and sub-domains are auto-renewing.
+
+### 3. Figure out who is responsible for purchasing security (SSL) certificates in your organization.
+You are going to need to reach out to them.
+_NOTE: The person/people who usually buys your certificates (someone with purchasing authority) are usually different from the people who upload them (usually someone in IT)._
+
+### 4. Identify when your SSL certificates will expire
+This is fairly easy:
+
+- Go to [https://transparencyreport.google.com/https/certificates?hl=en](https://transparencyreport.google.com/https/certificates?hl=en)
+- Scroll down to “Search certificates by hostname” and enter your parent domain
+- - ✓ Include certificates that have expired
+- - ✓ Include subdomains
+- - Press ‘enter’
+- Note the “Valid to” date in your new domains spreadsheet
+
+_Or you can also ask the person who regularly purchases your SSL certificates. They might keep a log._
+
+### 5. Renew all upcoming SSL certificates
+If the certificate is set to expire in the next three months (or the possible length of a shutdown), make a request that those certificates be renewed now.
+
+---
+
+### Have Questions?
+[This overview on certificates from CIO.gov](https://https.cio.gov/certificates/) is one of the best resources for people in government who are wanting to learn more about getting SSL certificates right.
+
+**Q. Are security certificates and SSL certificates the same thing?**
+Yep.
+
+**Q. What do certificates do exactly?**
+[From CIO.gov](https://https.cio.gov/certificates/) —
+> "Websites use certificates to create an HTTPS connection. When signed by a trusted certificate authority (CA), certificates give confidence to browsers that they are visiting the “real” website."
+
+**Q. Can certificates be set to auto-renew?**
+Yes! You should definitely talk to your IT department about moving in the direction of auto-renewing your certificates. The best method is to use the free, open-source tool “[Let’s Encrypt](https://letsencrypt.org/)”. Once implemented on your server, it auto-renews your certificate every three months — for free.
+
+Or, host your government site on [cloud.gov](https://cloud.gov/), [search.gov](https://search.gov/) or [federalist.18f.gov](https://federalist.18f.gov/) and your certificates will automatically renew every three months with [Let’s Encrypt](https://letsencrypt.org/).
+
+**Related reading:**
+- [Let’s Encrypt Those CNAMES, Shall We?](https://digital.gov/2016/09/07/lets-encrypt-those-cnames-shall-we/)
+
+**Still have questions?**
+E-mail us at [digitalgov@gsa.gov](mailto:digitalgov@gsa.gov) and we’ll try to get your questions answered.

--- a/content/resources/how-to-prevent-security-certificates-from-expiring-during-shutdown.md
+++ b/content/resources/how-to-prevent-security-certificates-from-expiring-during-shutdown.md
@@ -1,7 +1,7 @@
 ---
 url: /resources/how-to-prevent-security-certificates-from-expiring-during-shutdown/
 date: 2019-02-07 11:30:00 -0400
-title: "How to prevent security certificates from expiring during a lapse in operations"
+title: "How to Prevent Security Certificates From Expiring During a Lapse in Operations"
 summary: "These are the steps that people in government can take to avoid having security certificates expire during a lapse in operations."
 ---
 

--- a/content/resources/how-to-prevent-security-certificates-from-expiring-during-shutdown.md
+++ b/content/resources/how-to-prevent-security-certificates-from-expiring-during-shutdown.md
@@ -24,10 +24,11 @@ You are going to need to reach out to the person/people who usually buys your ce
 This is fairly easy:
 
 - Go to [https://transparencyreport.google.com/https/certificates?hl=en](https://transparencyreport.google.com/https/certificates?hl=en)
-- Scroll down to “Search certificates by hostname” and enter your parent domain
-- Check both boxes ✓ for "Include certificates that have expired" and "Include subdomains"
-- Press ‘enter’
-- Note the “Valid to” date in your new domains spreadsheet
+- Scroll down to “Search certificates by hostname” and enter your parent domain in the search box
+- Check both boxes for "Include certificates that have expired" and "Include subdomains" and click the magnifying glass icon on the right side of the search box
+- In the results, the “Valid to” column is the date that your certificate expires
+- Add this date your new domains spreadsheet
+
 
 _Or you can also ask the person who regularly purchases your SSL certificates. They might keep a log._
 


### PR DESCRIPTION
I would like to get this guidance out in-front of the people in govt who are actively preparing for the next shutdown.

The need for this guidance comes directly out of conversations we've had with people in the Web Council who are needing to find the best way to prevent security certificates from expiring during a shutdown period.

This is not guidance about managing domains and certificates long-term, but rather it's goal is to solve a number of impending problems for agencies in the near-term.

If this information got there tomorrow, agencies would have a significantly good chance of averting these types of errors before the next shutdown happens.

Preview: https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/cerificates-shutdown/resources/how-to-prevent-security-certificates-from-expiring-during-shutdown/

