### PR TITLE
Remove hyperlinks in Community Updates section

### DIFF
--- a/content/communities/results-oriented-accountability-for-grants.md
+++ b/content/communities/results-oriented-accountability-for-grants.md
@@ -32,24 +32,11 @@ As the [President’s Management Agenda](https://www.performance.gov/PMA/) (PMA)
 
 ## Community Updates 
 
-**12/17/18 - Register Today for the Single Audit & Risk Management Demo Days!**
+**3/7/19:** 
 
-The Results-Oriented Accountability for Grants CAP Goal Team is hosting **Single Audit and Risk Management Industry Demonstration Days** beginning on April 3, 2019 through April 5, 2019. All interested parties experienced in creating automated solutions for data management are encouraged to attend. 
+- *Single Audit & Risk Management Demo Days* <br />Vendor registration and employee registration are now closed for the Single Audit and Risk Management Industry Demonstration Days that will take place from April 3, 2019 through April 5, 2019.
 
-For more information, visit FedBizOpps.gov and join the **Virtual Pre-Demonstration Day** session on March 4, 2019. All attendees are welcome to ask questions during the session or submit them via email to the Grants Team. 
-
-**Important Links:** 
- - Register for the Virtual Pre-Demonstration Day on January 8, 2019
- - Register for Industry Demonstration Days beginning on January 29, 2019. (**Deadline**: January 17, 2019 at 6 pm, EST)
-   - Vendor Registration
-   - Federal Employee Registration
-   - FedBizOpps.gov Announcement 
-
----
-
-**Now Open for Public Comments: Federal Grants Management Draft Data Standards** 
-
-The Results-Oriented Accountability for Grants CAP Goal Team is excited to release the **draft** Data Standards for public comment. The public comment period will stay open for 60 days beginning **November 16, 2018**, through **January 16, 2019** as noted on the Federal Register. You can submit comments through the Grants Feedback Site powered by GitHub. 
+- *Federal Grants Management Draft Data Standards* <br />The public comment period for the draft Data Standards is now closed.
 
 ## Key resources
 

--- a/content/communities/results-oriented-accountability-for-grants.md
+++ b/content/communities/results-oriented-accountability-for-grants.md
@@ -32,7 +32,7 @@ As the [President’s Management Agenda](https://www.performance.gov/PMA/) (PMA)
 
 ## Community Updates 
 
-**3/7/19:** 
+**Last updated: 3/14/19:** 
 
 - **Single Audit & Risk Management Demo Days** <br />Registration for vendors and federal employees is now closed for the Single Audit and Risk Management Industry Demonstration Days that will take place from April 3, 2019 through April 5, 2019.
 

--- a/content/communities/results-oriented-accountability-for-grants.md
+++ b/content/communities/results-oriented-accountability-for-grants.md
@@ -34,9 +34,9 @@ As the [President’s Management Agenda](https://www.performance.gov/PMA/) (PMA)
 
 **3/7/19:** 
 
-- *Single Audit & Risk Management Demo Days* <br />Vendor registration and employee registration are now closed for the Single Audit and Risk Management Industry Demonstration Days that will take place from April 3, 2019 through April 5, 2019.
+- **Single Audit & Risk Management Demo Days** <br />Registration for vendors and federal employees is now closed for the Single Audit and Risk Management Industry Demonstration Days that will take place from April 3, 2019 through April 5, 2019.
 
-- *Federal Grants Management Draft Data Standards* <br />The public comment period for the draft Data Standards is now closed.
+- **Federal Grants Management Draft Data Standards** <br />The public comment period for the draft Data Standards is now closed.
 
 ## Key resources
 

--- a/content/communities/results-oriented-accountability-for-grants.md
+++ b/content/communities/results-oriented-accountability-for-grants.md
@@ -36,20 +36,20 @@ As the [President’s Management Agenda](https://www.performance.gov/PMA/) (PMA)
 
 The Results-Oriented Accountability for Grants CAP Goal Team is hosting **Single Audit and Risk Management Industry Demonstration Days** beginning on April 3, 2019 through April 5, 2019. All interested parties experienced in creating automated solutions for data management are encouraged to attend. 
 
-For more information, visit [FedBizOpps.gov](https://www.fbo.gov/index.php?s=opportunity&mode=form&id=18e2112bca64cdd1d3b72eed5f1e4560&tab=core&_cview=0) and join the **Virtual Pre-Demonstration Day** session on March 4, 2019. All attendees are welcome to ask questions during the session or [submit them via email to the Grants Team](mailto:GrantsTeam@omb.eop.gov). 
+For more information, visit FedBizOpps.gov and join the **Virtual Pre-Demonstration Day** session on March 4, 2019. All attendees are welcome to ask questions during the session or submit them via email to the Grants Team. 
 
 **Important Links:** 
- - [Register](https://www.eventbrite.com/e/grants-single-audit-and-risk-mgmt-virtual-pre-demonstration-conference-tickets-52866219285) for the Virtual Pre-Demonstration Day on January 8, 2019
+ - Register for the Virtual Pre-Demonstration Day on January 8, 2019
  - Register for Industry Demonstration Days beginning on January 29, 2019. (**Deadline**: January 17, 2019 at 6 pm, EST)
-   - [Vendor Registration](https://www.eventbrite.com/e/grants-single-audit-and-risk-mgmt-industry-demonstration-days-vendor-signup-tickets-53749926477)
-   - [Federal Employee Registration](https://www.eventbrite.com/e/grants-single-audit-and-risk-mgmt-industry-demonstration-days-registration-tickets-52866314570)
-   - [FedBizOpps.gov Announcement](https://www.fbo.gov/index.php?s=opportunity&mode=form&id=18e2112bca64cdd1d3b72eed5f1e4560&tab=core&_cview=0) 
+   - Vendor Registration
+   - Federal Employee Registration
+   - FedBizOpps.gov Announcement 
 
 ---
 
 **Now Open for Public Comments: Federal Grants Management Draft Data Standards** 
 
-The Results-Oriented Accountability for Grants CAP Goal Team is excited to release the **draft** Data Standards for public comment. The public comment period will stay open for 60 days beginning **November 16, 2018**, through **January 16, 2019** as noted on the [Federal Register](https://www.federalregister.gov/documents/2018/11/16/2018-24927/draft-federal-grants-management-data-standards-for-feedback). You can submit comments through the [Grants Feedback Site](https://grantsfeedback.cfo.gov/) powered by GitHub. 
+The Results-Oriented Accountability for Grants CAP Goal Team is excited to release the **draft** Data Standards for public comment. The public comment period will stay open for 60 days beginning **November 16, 2018**, through **January 16, 2019** as noted on the Federal Register. You can submit comments through the Grants Feedback Site powered by GitHub. 
 
 ## Key resources
 


### PR DESCRIPTION
Removed hyperlinks pertaining to past events, at request of community manager.

Preview: https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/lcrabb419-patch-1/communities/results-oriented-accountability-for-grants/