### PR TITLE
Remove live captioning link; add link to Caroline's blog post

### DIFF
--- a/content/events/2019/04/2019-04-09-caroline-jarrett-on-how-design-a-better-form.md
+++ b/content/events/2019/04/2019-04-09-caroline-jarrett-on-how-design-a-better-form.md
@@ -16,7 +16,9 @@ youtube_id: Br5O0hAaqt8
 
 ---
 
-_[View live captioning for this event](https://www.captionedtext.com/client/event.aspx?EventID=3944823&CustomerID=321)._ 
+_Watch the video on [YouTube](https://www.youtube.com/watch?v=Br5O0hAaqt8) to read the live chat comments that Caroline Jarrett explains in detail in her [recap of the event](http://www.effortmark.co.uk/discussing-a-topic-map-for-how-to-design-better-a-form/)._ 
+
+***
 
 We have a lot of forms in government, and many of them would benefit from better design. In this talk, Caroline Jarrett will explore a curriculum she’s working on about how to design a form. She’ll be asking for our feedback about whether [the curriculum](http://www.effortmark.co.uk/a-draft-curriculum-for-how-to-design-a-form/) contains the right topics and whether it might be useful in U.S. government.
 


### PR DESCRIPTION
Replaced live captioning link with a note that you can read the live chat comments if you watch on YouTube. Also linked to Caroline's recap of the event from her blog.

Preview: https://federalist-proxy-staging.app.cloud.gov/preview/gsa/digitalgov.gov/lcrabb419-patch-1/event/2019/04/09/caroline-jarrett-on-how-design-a-better-form/