### PR TITLE
New post: Journey Maps as Communication Tools

### DIFF
--- a/content/posts/2019/05/2019-05-07-journey-maps-as-communication-tools.md
+++ b/content/posts/2019/05/2019-05-07-journey-maps-as-communication-tools.md
@@ -1,0 +1,30 @@
+---
+# View this page at https://digital.gov/2019/05/journey-maps-as-communication-tools
+# Learn how to edit our pages at https://workflow.digital.gov
+
+slug: journey-maps-as-communication-tools
+date: 2019-05-07 10:00
+title: "Journey Maps as Communication Tools"
+deck: "The team at Office of Natural Resources Revenue wrote about how they use journey mapping to help teams look at their agency’s processes in a more comprehensive way."
+summary: "The team at Office of Natural Resources Revenue wrote about how they use journey mapping to help teams look at their agency’s processes in a more comprehensive way."
+
+# originally published at the following URL
+source_url: "https://revenuedata.doi.gov/blog/journey-mapping/"
+
+# Which team published this?
+# Learn about sources at https://workflow.digital.gov/sources
+source: doi-revenuedata
+
+# see all topics at https://digital.gov/topics
+topics: 
+  - design
+  - product-management
+  - user-experience
+  - ux
+
+# see all authors at https://digital.gov/authors
+authors: 
+  - jeremyzilar
+
+# ♥♥♥ Make it better ♥♥♥
+---

--- a/content/posts/2019/05/2019-05-07-journey-maps-as-communication-tools.md
+++ b/content/posts/2019/05/2019-05-07-journey-maps-as-communication-tools.md
@@ -3,7 +3,7 @@
 # Learn how to edit our pages at https://workflow.digital.gov
 
 slug: journey-maps-as-communication-tools
-date: 2019-05-07 10:00
+date: 2019-05-07 10:00:00
 title: "Journey Maps as Communication Tools"
 deck: "The team at Office of Natural Resources Revenue wrote about how they use journey mapping to help teams look at their agency’s processes in a more comprehensive way."
 summary: "The team at Office of Natural Resources Revenue wrote about how they use journey mapping to help teams look at their agency’s processes in a more comprehensive way."
@@ -16,14 +16,14 @@ source_url: "https://revenuedata.doi.gov/blog/journey-mapping/"
 source: doi-revenuedata
 
 # see all topics at https://digital.gov/topics
-topics: 
+topics:
   - design
   - product-management
   - user-experience
   - ux
 
 # see all authors at https://digital.gov/authors
-authors: 
+authors:
   - jeremyzilar
 
 # ♥♥♥ Make it better ♥♥♥


### PR DESCRIPTION
The team at Office of Natural Resources Revenue wrote about how they use journey mapping to help teams look at their agency’s processes in a more comprehensive way.

Preview: https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/doi-post/
