### PR TITLE
Reduce events items count on homepage

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -62,6 +62,9 @@ params:
   # Homepage settings
   dg_tagline: "Guidance for making digital services in government better"
 
+  # number of events to include on the homepage
+  events_count: 3
+  
 permalinks:
   posts                 : ":year/:month/:day/:slug/"
   events                : "event/:year/:month/:day/:slug/"

--- a/config_dev.yml
+++ b/config_dev.yml
@@ -72,6 +72,9 @@ params:
   # Homepage settings
   dg_tagline: "Guidance for making _better_ digital services in government"
 
+  # number of events to include on the homepage
+  events_count: 3 
+
 permalinks:
   posts                 : ":year/:month/:day/:slug/"
   events                : "event/:year/:month/:day/:slug/"

--- a/themes/digital.gov/layouts/partials/core/home/events_featured.html
+++ b/themes/digital.gov/layouts/partials/core/home/events_featured.html
@@ -11,9 +11,14 @@
       </div>
       <div class="grid-col-12 tablet:grid-col-7">
         <section>
-          {{/* {{- $events := (where .Data.Pages "Section" "events").Reverse -}} */}}
+
           {{ $events := where .Site.RegularPages.Reverse  "Section" "events" }}
-          {{ $events := $events | intersect (where $events "Date" "ge" now) | first 5 }}
+
+          {{/* gets the # of news items to display from the config.yml */}}
+          {{ $events_count := .Site.Params.events_count }}
+
+          {{ $events := $events | intersect (where $events "Date" "ge" now) | first $events_count }}
+          
           {{- range $events -}}
             {{- $now := now.Format "2006-01-02" -}}
             {{- $start := .Date.Format "2006-01-02" -}}


### PR DESCRIPTION
This change adds the # of items to show in the events section on the home page to 3

Preview: https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/events-feed/