### PR TITLE
adding conditional around video kicker

### DIFF
--- a/themes/digital.gov/layouts/events/card-event-past.html
+++ b/themes/digital.gov/layouts/events/card-event-past.html
@@ -1,14 +1,16 @@
 <article class="card card-event card-event-past card-linked" data-edit-this="{{- .File.Path -}}" {{- if .Params.short_url -}}data-short_url="{{- .Params.short_url -}}"{{- end -}}>
   <div class="grid-row grid-gap-4">
 
+    {{ if .Params.youtube_id }}
     <div class="grid-col-12 tablet:grid-col-4 tablet:order-last">
-      {{ if .Params.youtube_id }}
       <div class="image-featured youtube-player" data-id="{{ .Params.youtube_id }}" data-link="{{ .Permalink }}"></div>
-      {{ end }}
     </div>
+    {{ end }}
 
     <div class="grid-col-12 tablet:grid-col-8">
+      {{ if .Params.youtube_id }}
       <h6>Video</h6>
+      {{ end }}
       <h3>
         <a href="{{ .Permalink }}" title="{{ .Title | markdownify }}" rel="bookmark">{{ .Title | markdownify }}</a>
       </h3>


### PR DESCRIPTION
I added a conditional statement around the **VIDEO** kicker at the top of video cards.

This change makes it so that
- [ ] events that have a video component to display the VIDEO kicker
- [ ] events that do not have a video, will not display the VIDEO kicker

Preview: https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/events-cards/events/