### PR TITLE
PIF headline edit

### DIFF
--- a/content/posts/2019/05/2019-05-07-two-complementary-teams-with-same-goal.md
+++ b/content/posts/2019/05/2019-05-07-two-complementary-teams-with-same-goal.md
@@ -2,7 +2,7 @@
 slug: two-complementary-teams-with-same-goal
 date: 2019-05-07 11:00:00 -0500
 title: 'How 18F and PIF Work Together in Agencies'
-summary: 'See how two work together to help agencies become more effective at meeting the needs of citizens.'
+summary: 'Two teams working together to help agencies become more effective at meeting the needs of citizens.'
 authors:
   - justin-koufopoulos
   - angela-colter

--- a/content/posts/2019/05/2019-05-07-two-complementary-teams-with-same-goal.md
+++ b/content/posts/2019/05/2019-05-07-two-complementary-teams-with-same-goal.md
@@ -2,6 +2,7 @@
 slug: two-complementary-teams-with-same-goal
 date: 2019-05-07 11:00:00 -0500
 title: 'How 18F and PIF Work Together in Agencies'
+deck: 'Two teams working together to help agencies become more effective at meeting the needs of citizens'
 summary: 'Two teams working together to help agencies become more effective at meeting the needs of citizens.'
 authors:
   - justin-koufopoulos

--- a/content/posts/2019/05/2019-05-07-two-complementary-teams-with-same-goal.md
+++ b/content/posts/2019/05/2019-05-07-two-complementary-teams-with-same-goal.md
@@ -1,8 +1,8 @@
 ---
 slug: two-complementary-teams-with-same-goal
 date: 2019-05-07 11:00:00 -0500
-title: 'Two Complementary Teams With the Same Goal'
-summary: 'How the Presidential Innovation Fellows and 18F teams support each other at agencies&#46;'
+title: 'How 18F and PIF Work Together in Agencies'
+summary: 'See how two work together to help agencies become more effective at meeting the needs of citizens.'
 authors:
   - justin-koufopoulos
   - angela-colter

--- a/content/posts/2019/05/2019-05-07-two-complementary-teams-with-same-goal.md
+++ b/content/posts/2019/05/2019-05-07-two-complementary-teams-with-same-goal.md
@@ -1,7 +1,7 @@
 ---
 slug: two-complementary-teams-with-same-goal
 date: 2019-05-07 11:00:00 -0500
-title: 'How 18F and PIF Work Together in Agencies'
+title: 'How Presidential Innovation Fellows and 18F Support One Another in Agencies'
 deck: 'Two teams working together to help agencies become more effective at meeting the needs of citizens'
 summary: 'Two teams working together to help agencies become more effective at meeting the needs of citizens.'
 authors:


### PR DESCRIPTION
A change to the headline on this blog post: https://digital.gov/2019/05/07/two-complementary-teams-with-same-goal/

Preview: https://federalist-proxy.app.cloud.gov/preview/gsa/digitalgov.gov/pif-headline-edit/2019/05/07/two-complementary-teams-with-same-goal/