### PR TITLE
Updating the copy on the Open Innovation Summit

### DIFF
--- a/content/events/2019/06/2019-06-14-us-government-open-innovation-summit-transformation-through-citizen-science-prize-competitions.md
+++ b/content/events/2019/06/2019-06-14-us-government-open-innovation-summit-transformation-through-citizen-science-prize-competitions.md
@@ -1,6 +1,7 @@
 ---
 slug: us-government-open-innovation-summit-transformation-through-citizen-science-prize-competitions
-title: "U.S. Government Open Innovation Summit&#58; Transformation Through Citizen Science and Prize Competitions"
+title: "U.S. Government Open Innovation Summit"
+deck: "Transformation Through Citizen Science and Prize Competitions"
 summary: 'Engage in a series of exciting dialogues on how the public is helping to reshape government&#46;'
 featured_image:
   uid: open-innovation-summit-lockup
@@ -26,106 +27,62 @@ Speakers, panels, and interactive events will explore the use of these approache
 
 ## Event Agenda
 
-<ul>
-<li><strong>8:30 - 9:10 a.m.</strong> - Registration and Arrivals </li>
-	</ul>
+**8:30 - 9:10 a.m.** - Registration and Arrivals
 
-<ul>
-<li><strong>9:10 - 9:15 a.m.</strong> - Welcome </li>
-    <ul>
-	  <li>Jarah Meador - Director of Challenge.gov and CitizenScience.gov (GSA) </li>
-	  <li>Jay Huie - Acting Director, Office of Products and Programs (GSA) </li>
-	</ul>
-  </li>
-	</ul>
+**9:10 - 9:15 a.m.** - Welcome
 
-<ul>
-<li><strong>9:15 - 9:30 a.m.</strong> - Opening Remarks </li>
-    <ul>
-	  <li>Dr. Kelvin Droegemeier - Director of the White House Office of Science and Technology Policy </li>
-	</ul>
-  </li>
-	</ul>
+-   Jarah Meador - Director of Challenge.gov and CitizenScience.gov (GSA)
+-   Jay Huie - Acting Director, Office of Products and Programs (GSA)
 
-<ul>
-<li><strong>9:30 - 10 a.m.</strong> - A Primer on Open Innovation in Government
-<ul>
-	  <li>Jarah Meador (GSA) - Federal Prize Competitions: Crowdsourcing Innovation</li>
-	  <li>John McLaughlin (GSA &amp; NOAA) - Citizen Science: Accelerating Innovation Through Public Participation</li>
-	  <li>Jennifer Shieh (OSTP) - Highlights of the Implementation of Federal Prize and Citizen Science Authority, Fiscal Years 2017-2019</li>
-	</ul>
-</li>
-	</ul>
+**9:15 - 9:30 a.m.** - Opening Remarks
 
-<ul>
-<li><strong>10:00 - 10:40 a.m.</strong> - Examples of Impact Through Crowdsourcing
-<ul>
-	  <li>Marc Kuchner (NASA) - NASA’s Citizen Scientists </li>
-	  <li>Ellen Ryan (NIST) - NIST Public Safety Communications (PSCR): Prize Challenges </li>
-	  <li>Sophia B. Liu (USGS) - Leveraging Social Media and Digital Volunteers to Inform Hazard Science and Emergency Management </li>
-	</ul> 
-</li>
-	</ul>
+-   Dr. Kelvin Droegemeier - Director of the White House Office of Science and Technology Policy
 
-<ul>
-<li><strong>10:40 - 11:00 a.m.</strong> - Break </li>
-	</ul>
+**9:30 - 10 a.m.** - A Primer on Open Innovation in Government
 
-<ul>
-<li><strong>11:00 - 11:45 a.m.</strong> - Panel Discussion: Innovation and the Power of Public Engagement
-<ul>
-	  <li>Moderator: Jenn Gustetic (NASA) </li>
-		<li>Panelists: 
-			<ul>
-				<li>Dr. Caren Cooper (North Carolina State University) </li>
-				<li>Jim Reuter (NASA) </li>
-				<li>Alexis Bonnell (USAID) </li>
-			</ul>
-	</ul>
-</li>
-</ul>
+-   Jarah Meador (GSA) - Federal Prize Competitions: Crowdsourcing Innovation
+-   John McLaughlin (GSA & NOAA) - Citizen Science: Accelerating Innovation Through Public Participation
+-   Jennifer Shieh (OSTP) - Highlights of the Implementation of Federal Prize and Citizen Science Authority, Fiscal Years 2017-2019
 
-<ul>
-<li><strong>11:45 a.m. -1:00 p.m.</strong> Break
-</ul>
+**10:00 - 10:40 a.m.** - Examples of Impact Through Crowdsourcing
 
-<ul>
-<li><strong>1:00 - 1:50 p.m.</strong> - Concurrent Sessions
-  <ul>
-    <li>Agency Innovation Showcase (Atrium) - Agencies represented will be NSF, NASA, USAID, Commerce, DHS, DOI, HHS, DoD, GSA, DOE, Library of Congress, EPA, and IARPA </li>
-    <li>Breakouts: How U.S. Agencies Use Open Innovation
-      <ul>
-        <li><em>Session A</em>: How U.S. Agencies Use Open Innovation to Enable Disaster Resilience (Hosted by Sophia B. Liu, USGS) </li>
-        <li><em>Session B</em>: Catalyzing Health Through The Crowd (Hosted by Taylor Gilliland, HHS) </li>
-        <li><em>Session C</em>: The Power of Prizes and the Future of Work (Hosted by Sarah-Lloyd Stevenson, White House Office of Science and Technology Policy) </li>
-      </ul>
-    </li>
-  </ul>
-</ul>
+-   Marc Kuchner (NASA) - NASA’s Citizen Scientists
+-   Ellen Ryan (NIST) - NIST Public Safety Communications (PSCR): Prize Challenges
+-   Sophia B. Liu (USGS) - Leveraging Social Media and Digital Volunteers to Inform Hazard Science and Emergency Management
 
-<ul>
-<li><strong>1:50 - 2:00 p.m.</strong> - Break </li>
-	</ul>
+**10:40 - 11:00 a.m.** - Break
 
-<ul>
-<li><strong>2:00 - 2:45 p.m.</strong> - Transformational Partnership and Engagement Models
-	<ul>
-		<li>Drew Zachary (U.S. Census Bureau): Crowdsourcing Digital Solutions Through Tech Partnerships: The Opportunity Project</li>
-		<li>Lauren Algee (Library of Congress): Creating an Innovation Culture at the Library of Congress</li>
-		<li>Ku McMahan (USAID): Accelerating Innovation: Securing Water for Food Grand Challenge Model </li>
-	</ul>
-</li>
-	</ul>
+**11:00 - 11:45 a.m.** - Panel Discussion: Innovation and the Power of Public Engagement
 
-<ul>
-<li> <strong>2:45 - 3:00 p.m.</strong> - Concluding Remarks </li>
-	</ul>
+-   Moderator: Jenn Gustetic (NASA)
+-   Panelists:
+    -   Dr. Caren Cooper (North Carolina State University)
+    -   Jim Reuter (NASA)
+    -   Alexis Bonnell (USAID)
 
-<ul>
-<li> <strong>3:00 - 4:00 p.m.</strong> - Open Networking</li>
-</ul>
+**11:45 a.m. -1:00 p.m.** Break
 
-## Related links 
+**1:00 - 1:50 p.m.** - Concurrent Sessions
+
+-   Agency Innovation Showcase (Atrium) - Agencies represented will be NSF, NASA, USAID, Commerce, DHS, DOI, HHS, DoD, GSA, DOE, Library of Congress, EPA, and IARPA
+-   Breakouts: How U.S. Agencies Use Open Innovation
+    -   _Session A_: How U.S. Agencies Use Open Innovation to Enable Disaster Resilience (Hosted by Sophia B. Liu, USGS)
+    -   _Session B_: Catalyzing Health Through The Crowd (Hosted by Taylor Gilliland, HHS)
+    -   _Session C_: The Power of Prizes and the Future of Work (Hosted by Sarah-Lloyd Stevenson, White House Office of Science and Technology Policy)
+
+**1:50 - 2:00 p.m.** - Break
+
+**2:00 - 2:45 p.m.** - Transformational Partnership and Engagement Models
+
+-   Drew Zachary (U.S. Census Bureau): Crowdsourcing Digital Solutions Through Tech Partnerships: The Opportunity Project
+-   Lauren Algee (Library of Congress): Creating an Innovation Culture at the Library of Congress
+-   Ku McMahan (USAID): Accelerating Innovation: Securing Water for Food Grand Challenge Model
+
+**2:45 - 3:00 p.m.** - Concluding Remarks
+
+**3:00 - 4:00 p.m.** - Open Networking
+
+## Related links
 
 - [CitizenScience.gov](http://www.citizenscience.gov)
 - [Challenge.gov](http://www.challenge.gov)

--- a/content/events/2019/06/2019-06-14-us-government-open-innovation-summit-transformation-through-citizen-science-prize-competitions.md
+++ b/content/events/2019/06/2019-06-14-us-government-open-innovation-summit-transformation-through-citizen-science-prize-competitions.md
@@ -14,10 +14,9 @@ event_organizer: DigitalGov University
 host: Federal Community of Practice for Crowdsourcing and Citizen Science (FedCCS), Challenges and Prizes Federal Community of Practice
 registration_url: https://www.eventbrite.com/e/us-government-open-innovation-summit-transformation-through-citizen-science-and-prizes-registration-61872290687
 youtube_id: 5ORul6NslyE
+# caption_url: https://www.captionedtext.com/client/event.aspx?EventID=4043837&CustomerID=321
 
 ---
-
-_[View live captioning for this event ](https://www.captionedtext.com/client/event.aspx?EventID=4043837&CustomerID=321)_
 
 {{< img src="open-innovation-summit-lockup" >}}
 
@@ -25,7 +24,11 @@ Join innovators from across the public and private sectors for an event designed
 
 Speakers, panels, and interactive events will explore the use of these approaches to innovation, the opportunities and benefits they offer, and hurdles faced in integrating them into existing federal agency processes. This event will complement an upcoming crowdsourcing report to Congress that details how prize competitions and citizen science are transforming government.
 
+---
+
 ## Event Agenda
+
+{{< box >}}
 
 **8:30 - 9:10 a.m.** - Registration and Arrivals
 
@@ -81,6 +84,8 @@ Speakers, panels, and interactive events will explore the use of these approache
 **2:45 - 3:00 p.m.** - Concluding Remarks
 
 **3:00 - 4:00 p.m.** - Open Networking
+
+{{< /box >}}
 
 ## Related links
 


### PR DESCRIPTION
Updating the copy on the **U.S. Government Open Innovation Summit** page

- adding in a deck
- converted schedule into markdown to make it easier for others to edit

**Preview:** https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/digitalgov.gov/innovating/event/2019/06/14/us-government-open-innovation-summit-transformation-through-citizen-science-prize-competitions/
