### PR TITLE
Adds the summary to past events

### DIFF
--- a/themes/digital.gov/layouts/events/past.html
+++ b/themes/digital.gov/layouts/events/past.html
@@ -11,6 +11,7 @@
   <!-- Event Meta -->
   <div class="event-details">
     <span class="event-date">{{ dateFormat "January 02, 2006 3:04 PM" .Date }} - {{ dateFormat "3:04 PM ET" .Params.end_date }}</span>
+    <p class="summary">{{ .Params.summary | markdownify }}</p>
   </div>
 
   <!-- Event actions -->


### PR DESCRIPTION
## Fixing https://github.com/GSA/digitalgov.gov/issues/1199

This change adds the summary back to the "**Past Events**" listing.

**Preview:** https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/digitalgov.gov/event-summaries/events/
