### PR TITLE
Add new post: Prototyping Engagement Workshops

### DIFF
--- a/content/posts/2019/08/2019-08-21-prototyping-engagement-workshops-for-future-federal-data-dashboards-storytelling.md
+++ b/content/posts/2019/08/2019-08-21-prototyping-engagement-workshops-for-future-federal-data-dashboards-storytelling.md
@@ -1,0 +1,17 @@
+---
+slug: prototyping-engagement-workshops-for-future-federal-data-dashboards-storytelling
+date: 2019-08-21 18:06:00 -0500
+title: 'Prototyping Engagement Workshops for the Future of Federal Data, Dashboards, and Storytelling'
+summary: 'User-centered design is critical for meetings—from the front lines to C-suite&#46; How might we host more hands-on learning sessions and experience exchanges to improve and customize the way the federal workforce communicates to diverse stakeholders&#63;'
+authors: 
+  - 
+categories: 
+  - 
+tag: 
+  - 
+featured_image: 
+  uid: 
+  alt: ''
+---
+
+***Paste body content here. Delete this line**


### PR DESCRIPTION
**Prototyping Engagement Workshops for the Future of Federal Data, Dashboards, and Storytelling** 
User-centered design is critical for meetings—from the front lines to C-suite


---

**Preview:** 