### PR TITLE
adding new zoom recording language

### DIFF
--- a/content/events/2019/08/2019-08-28-a-deep-dive-into-guide-paperwork-reduction-act.md
+++ b/content/events/2019/08/2019-08-28-a-deep-dive-into-guide-paperwork-reduction-act.md
@@ -24,10 +24,10 @@ The PRA Guide is a product of [10x](https://10x.gsa.gov/), a new and innovative 
 
 In this talk, we’ll cover how the PRA guide came about and explore the methods that the team used to break down the complexity around this complicated requirement and get a product launched in just a few months. We’ll also be taking questions.
 
-We’ll also talk with the team from OIRA about how they arrived at the idea to submit a pitch to 10x in the first place, and what new things they’ve learned about building a product from the ground up. 
+We’ll also talk with the team from OIRA about how they arrived at the idea to submit a pitch to 10x in the first place, and what new things they’ve learned about building a product from the ground up.
 
-_Questions about this event or future events? Send them to [digitalgovu@gsa.gov](mailto:digitalgovu@gsa.gov)._ 
+_Questions about this event or future events? Send them to [digitalgovu@gsa.gov](mailto:digitalgovu@gsa.gov)._
 
---- 
+---
 
-_This event will be held over [Zoom](https://www.zoom.us/) (see the Zoom [computer and device requirements](https://support.zoom.us/hc/en-us/articles/201362023-System-Requirements-for-PC-Mac-and-Linux), and [FAQs](https://support.zoom.us/hc/en-us/sections/200277708-Frequently-Asked-Questions)). You can [download Zoom Client for Meetings](https://zoom.us/download#client&#95;4meeting) to install the Zoom web browser client beforehand._ 
+_This event will be held and recorded over [Zoom](https://www.zoom.us/). Make sure you install the [Zoom Client ](https://zoom.us/download#client&#95;4meeting) beforehand. (See the Zoom [computer and device requirements](https://support.zoom.us/hc/en-us/articles/201362023-System-Requirements-for-PC-Mac-and-Linux), and [FAQs](https://support.zoom.us/hc/en-us/sections/200277708-Frequently-Asked-Questions))_ 

--- a/content/events/2019/08/2019-08-29-socialgov-talks-leveraging-pop-culture-with-paul-lester-doe.md
+++ b/content/events/2019/08/2019-08-29-socialgov-talks-leveraging-pop-culture-with-paul-lester-doe.md
@@ -2,15 +2,15 @@
 slug: socialgov-talks-leveraging-pop-culture-with-paul-lester-doe
 title: 'SocialGov Talks&#58; Leveraging Pop Culture With Paul Lester of the DOE'
 summary: 'Learn from a social media expert at Department of Energy how to use pop culture references as a jumping off point to talk about your agency’s work&#46;  '
-featured_image: 
-  uid: 
+featured_image:
+  uid:
   alt: ''
-event_type: 
+event_type:
   - Zoom
 date: 2019-08-29 13:00:00 -0500
 end_date: 2019-08-29 14:00:00 -0500
 event_organizer: DigitalGov University
-host: Socialgov 
+host: Socialgov
 registration_url: https://www.eventbrite.com/e/socialgov-talks-leveraging-pop-culture-with-paul-lester-of-the-doe-registration-66348428937
 draft: true
 
@@ -18,28 +18,28 @@ draft: true
 
 _[View live captioning for this event ](https://www.captionedtext.com/client/event.aspx?EventID=4113418&CustomerID=321)_
 
-Join Paul Lester, Digital Content Specialist for the [Department of Energy](https://www.energy.gov/) (DOE), to discuss how DOE leveraged the popular TV show, “Stranger Things” as a conversation starter about the agency’s mission and work using digital media (social media, blog, podcast, etc.). Mr. Lester will also discuss how he got management buy-in to use a pop culture phenomenon to promote the agency’s work. 
+Join Paul Lester, Digital Content Specialist for the [Department of Energy](https://www.energy.gov/) (DOE), to discuss how DOE leveraged the popular TV show, “Stranger Things” as a conversation starter about the agency’s mission and work using digital media (social media, blog, podcast, etc.). Mr. Lester will also discuss how he got management buy-in to use a pop culture phenomenon to promote the agency’s work.
 
-**Related links:** 
+**Related links:**
 
-- The blog that started it all… [https://www.energy.gov/articles/what-stranger-things-didn-t-get-quite-so-right-about-energy-department](https://www.energy.gov/articles/what-stranger-things-didn-t-get-quite-so-right-about-energy-department) 
--  …that resulted in press like this Wired interview: [https://www.wired.com/2016/08/energy-department-responds-stranger-things/](https://www.wired.com/2016/08/energy-department-responds-stranger-things/) 
--  We kept it going with our #StrangerThings-themed Halloween! [https://twitter.com/ENERGY/status/793185809549631488](https://twitter.com/ENERGY/status/793185809549631488) 
-- The next year, we delved deeper into the Upside Down and the work DOE is doing in particle physics with a podcast segment… [https://www.energy.gov/podcasts/direct-current-energygov-podcast/s2-e7-energy-secrets](https://www.energy.gov/podcasts/direct-current-energygov-podcast/s2-e7-energy-secrets) 
+- The blog that started it all… [https://www.energy.gov/articles/what-stranger-things-didn-t-get-quite-so-right-about-energy-department](https://www.energy.gov/articles/what-stranger-things-didn-t-get-quite-so-right-about-energy-department)
+-  …that resulted in press like this Wired interview: [https://www.wired.com/2016/08/energy-department-responds-stranger-things/](https://www.wired.com/2016/08/energy-department-responds-stranger-things/)
+-  We kept it going with our #StrangerThings-themed Halloween! [https://twitter.com/ENERGY/status/793185809549631488](https://twitter.com/ENERGY/status/793185809549631488)
+- The next year, we delved deeper into the Upside Down and the work DOE is doing in particle physics with a podcast segment… [https://www.energy.gov/podcasts/direct-current-energygov-podcast/s2-e7-energy-secrets](https://www.energy.gov/podcasts/direct-current-energygov-podcast/s2-e7-energy-secrets)
 -  …and blog post from the director of High Energy Physics: [https://www.energy.gov/articles/searching-upside-down](https://www.energy.gov/articles/searching-upside-down)
 
 **Paul Lester, Digital Content Specialist for the Department of Energy**
 
-Paul Lester is a digital content specialist in the Department of Energy’s Office of Public Affairs. Paul was born in Ohio but spent most of his life in Florida, where he worked as a news researcher-slash-archivist and online editor for the [Orlando Sentinel](http://www.orlandosentinel.com/). 
+Paul Lester is a digital content specialist in the Department of Energy’s Office of Public Affairs. Paul was born in Ohio but spent most of his life in Florida, where he worked as a news researcher-slash-archivist and online editor for the [Orlando Sentinel](http://www.orlandosentinel.com/).
 
 He moved to Washington in 2008 for a web editor role with [The Guardian](http://www.theguardian.com/us) before working as a contractor for the [Wind](https://www.energy.gov/node/779761) and [Water](https://www.energy.gov/node/779756) Technologies Office, the [Small Business Administration](https://www.sba.gov/), and DOE’s [Office of Energy Efficiency and Renewable Energy](https://www.energy.gov/eere/office-energy-efficiency-renewable-energy). Paul joined the Energy.gov team in March 2015, contributing to [Energy Blog](https://www.energy.gov/blog-archive) and assisting with managing the Energy Department’s [social media channels](https://www.energy.gov/about-us/web-policies/social-media). When he’s not in the office, Paul can be seen slowly running around D.C. training for his next half marathon.
 
-_Questions about this event or future events? Send them to [digitalgovu@gsa.gov](mailto:digitalgovu@gsa.gov)._ 
+_Questions about this event or future events? Send them to [digitalgovu@gsa.gov](mailto:digitalgovu@gsa.gov)._
 
 This SocialGov Talk is hosted by [SocialGov](https://digital.gov/communities/social-media/), the federal government’s social media Community of Practice (CoP). SocialGov has over 1,200 members from 90+ departments and agencies across the federal government. 
 
 Our team will send a reminder email prior to the event that includes your link to join the video. 
 
---- 
+---
 
-_This event will be held over [Zoom](https://www.zoom.us/) (see the Zoom [computer and device requirements](https://support.zoom.us/hc/en-us/articles/201362023-System-Requirements-for-PC-Mac-and-Linux), and [FAQs](https://support.zoom.us/hc/en-us/sections/200277708-Frequently-Asked-Questions)). You can [download Zoom Client for Meetings](https://zoom.us/download#client&#95;4meeting) to install the Zoom web browser client beforehand._ 
+_This event will be held and recorded over [Zoom](https://www.zoom.us/). Make sure you install the [Zoom Client ](https://zoom.us/download#client&#95;4meeting) beforehand. (See the Zoom [computer and device requirements](https://support.zoom.us/hc/en-us/articles/201362023-System-Requirements-for-PC-Mac-and-Linux), and [FAQs](https://support.zoom.us/hc/en-us/sections/200277708-Frequently-Asked-Questions))_ 

--- a/content/events/2019/09/2019-09-03-quantifying-value-innovation.md
+++ b/content/events/2019/09/2019-09-03-quantifying-value-innovation.md
@@ -43,8 +43,4 @@ _Questions about this event or future events?_ Send them to [digitalgovu@gsa.gov
 
 ---
 
-_This event will be held over [Zoom](https://www.zoom.us/) &#40;see the Zoom [computer and device requirements](https://support.zoom.us/hc/en-us/articles/201362023-System-Requirements-for-PC-Mac-and-Linux), and [FAQs](https://support.zoom.us/hc/en-us/sections/200277708-Frequently-Asked-Questions)&#41;. You can [download Zoom Client for Meetings](https://zoom.us/download#client&#95;4meeting) to install the Zoom web browser client beforehand._
-
----
-
 _This event will be held and recorded over [Zoom](https://www.zoom.us/). Make sure you install the [Zoom Client ](https://zoom.us/download#client&#95;4meeting) beforehand. (See the Zoom [computer and device requirements](https://support.zoom.us/hc/en-us/articles/201362023-System-Requirements-for-PC-Mac-and-Linux), and [FAQs](https://support.zoom.us/hc/en-us/sections/200277708-Frequently-Asked-Questions))_

--- a/content/events/2019/09/2019-09-03-quantifying-value-innovation.md
+++ b/content/events/2019/09/2019-09-03-quantifying-value-innovation.md
@@ -2,10 +2,10 @@
 slug: quantifying-value-innovation
 title: 'Quantifying the Value of Innovation'
 summary: 'We know that the value of &quot;innovation&quot; can be difficult to communicate&#46; How might we better tell the story of our work&#63; Join our webinar to learn more about data storytelling, tagging text and quantifying the value of innovation&#46; '
-featured_image: 
-  uid: 
+featured_image:
+  uid:
   alt: ''
-event_type: 
+event_type:
   - Zoom
 date: 2019-09-03 13:00:00 -0500
 end_date: 2019-09-03 14:00:00 -0500
@@ -33,7 +33,7 @@ We began the PIF Storybank in April 2019 as a prototype. Each week, PIFs answer 
 
 We now have 135 entries from 25 PIFs. We know what percentage of PIFs are working on AI, autonomous vehicles, communications, cross-agency collaboration, data accountability, data science, data transparency, public-private collaborations, human-centered design, investment, twenty-first-century workforce, product management, and tech infrastructure. We know that 18 PIFs have worked on AI projects across 16 agencies. We also know what blockers have arisen.
 
-Join our webinar to learn more about data storytelling, tagging text, and quantifying the value of innovation. 
+Join our webinar to learn more about data storytelling, tagging text, and quantifying the value of innovation.
 
 This talk is hosted by the [Presidential Innovation Fellows](https://www.presidentialinnovationfellows.gov/) and [18F](https://www.18f.gov/). 
 
@@ -41,6 +41,10 @@ Our team will send a reminder email prior to the event that includes your link t
 
 _Questions about this event or future events?_ Send them to [digitalgovu@gsa.gov](mailto:digitalgovu@gsa.gov). 
 
---- 
+---
 
-_This event will be held over [Zoom](https://www.zoom.us/) &#40;see the Zoom [computer and device requirements](https://support.zoom.us/hc/en-us/articles/201362023-System-Requirements-for-PC-Mac-and-Linux), and [FAQs](https://support.zoom.us/hc/en-us/sections/200277708-Frequently-Asked-Questions)&#41;. You can [download Zoom Client for Meetings](https://zoom.us/download#client&#95;4meeting) to install the Zoom web browser client beforehand._ 
+_This event will be held over [Zoom](https://www.zoom.us/) &#40;see the Zoom [computer and device requirements](https://support.zoom.us/hc/en-us/articles/201362023-System-Requirements-for-PC-Mac-and-Linux), and [FAQs](https://support.zoom.us/hc/en-us/sections/200277708-Frequently-Asked-Questions)&#41;. You can [download Zoom Client for Meetings](https://zoom.us/download#client&#95;4meeting) to install the Zoom web browser client beforehand._
+
+---
+
+_This event will be held and recorded over [Zoom](https://www.zoom.us/). Make sure you install the [Zoom Client ](https://zoom.us/download#client&#95;4meeting) beforehand. (See the Zoom [computer and device requirements](https://support.zoom.us/hc/en-us/articles/201362023-System-Requirements-for-PC-Mac-and-Linux), and [FAQs](https://support.zoom.us/hc/en-us/sections/200277708-Frequently-Asked-Questions))_

--- a/content/events/2019/09/2019-09-05-plain-language-summit.md
+++ b/content/events/2019/09/2019-09-05-plain-language-summit.md
@@ -88,10 +88,10 @@ The Plain Language Action and Information Network (PLAIN) is a group of federal 
 
 **NOTE:** In-person tickets are limited and going quickly, so sign-up fast!
 
-_Questions about this event or future events? Send them to [digitalgovu@gsa.gov](mailto:digitalgovu@gsa.gov)._ 
+_Questions about this event or future events? Send them to [digitalgovu@gsa.gov](mailto:digitalgovu@gsa.gov)._
 
 Our team will send a reminder email prior to the event that includes your link to join the video. 
 
---- 
+---
 
-_This event will be held over [Zoom](https://www.zoom.us/) (see the Zoom [computer and device requirements](https://support.zoom.us/hc/en-us/articles/201362023-System-Requirements-for-PC-Mac-and-Linux), and [FAQs](https://support.zoom.us/hc/en-us/sections/200277708-Frequently-Asked-Questions)). You can [download Zoom Client for Meetings](https://zoom.us/download#client&#95;4meeting) to install the Zoom web browser client beforehand._ 
+_This event will be held and recorded over [Zoom](https://www.zoom.us/). Make sure you install the [Zoom Client ](https://zoom.us/download#client&#95;4meeting) beforehand. (See the Zoom [computer and device requirements](https://support.zoom.us/hc/en-us/articles/201362023-System-Requirements-for-PC-Mac-and-Linux), and [FAQs](https://support.zoom.us/hc/en-us/sections/200277708-Frequently-Asked-Questions))_ 

--- a/content/events/2019/09/2019-09-25-dap-learning-series-a-deep-dive-into-acquisition-reports.md
+++ b/content/events/2019/09/2019-09-25-dap-learning-series-a-deep-dive-into-acquisition-reports.md
@@ -32,3 +32,7 @@ _The Digital Analytics Program (DAP) offers advanced, easy web analytics to fede
 - [Getting Started](https://github.com/digital-analytics-program/gov-wide-code)
 - [View digital analytics training videos](https://www.youtube.com/playlist?list=PLd9b-GuOJ3nFwlyvLFUtmDpYFKezhot8P)
 - [Contact the DAP team](mailto:dap@support.digitalgov.gov)
+
+---
+
+_This event will be held and recorded over [Zoom](https://www.zoom.us/). Make sure you install the [Zoom Client ](https://zoom.us/download#client&#95;4meeting) beforehand. (See the Zoom [computer and device requirements](https://support.zoom.us/hc/en-us/articles/201362023-System-Requirements-for-PC-Mac-and-Linux), and [FAQs](https://support.zoom.us/hc/en-us/sections/200277708-Frequently-Asked-Questions))_ 

--- a/content/events/2019/10/2019-10-23-dap-learning-series-a-deep-dive-into-behavior-reports.md
+++ b/content/events/2019/10/2019-10-23-dap-learning-series-a-deep-dive-into-behavior-reports.md
@@ -35,3 +35,7 @@ _The Digital Analytics Program (DAP) offers advanced, easy web analytics to fede
 - [Getting Started](https://github.com/digital-analytics-program/gov-wide-code)
 - [View digital analytics training videos](https://www.youtube.com/playlist?list=PLd9b-GuOJ3nFwlyvLFUtmDpYFKezhot8P)
 - [Contact the DAP team](mailto:dap@support.digitalgov.gov)
+
+---
+
+_This event will be held and recorded over [Zoom](https://www.zoom.us/). Make sure you install the [Zoom Client ](https://zoom.us/download#client&#95;4meeting) beforehand. (See the Zoom [computer and device requirements](https://support.zoom.us/hc/en-us/articles/201362023-System-Requirements-for-PC-Mac-and-Linux), and [FAQs](https://support.zoom.us/hc/en-us/sections/200277708-Frequently-Asked-Questions))_ 

--- a/content/events/2019/11/2019-11-20-dap-learning-series-site-analysis-live.md
+++ b/content/events/2019/11/2019-11-20-dap-learning-series-site-analysis-live.md
@@ -31,3 +31,7 @@ _The Digital Analytics Program (DAP) offers advanced, easy web analytics to fede
 - [Getting Started](https://github.com/digital-analytics-program/gov-wide-code)
 - [View digital analytics training videos](https://www.youtube.com/playlist?list=PLd9b-GuOJ3nFwlyvLFUtmDpYFKezhot8P)
 - [Contact the DAP team](mailto:dap@support.digitalgov.gov)
+
+---
+
+_This event will be held and recorded over [Zoom](https://www.zoom.us/). Make sure you install the [Zoom Client ](https://zoom.us/download#client&#95;4meeting) beforehand. (See the Zoom [computer and device requirements](https://support.zoom.us/hc/en-us/articles/201362023-System-Requirements-for-PC-Mac-and-Linux), and [FAQs](https://support.zoom.us/hc/en-us/sections/200277708-Frequently-Asked-Questions))_ 

--- a/content/events/2019/11/2019-11-20-dap-learning-series-site-analysis-live.md
+++ b/content/events/2019/11/2019-11-20-dap-learning-series-site-analysis-live.md
@@ -34,4 +34,4 @@ _The Digital Analytics Program (DAP) offers advanced, easy web analytics to fede
 
 ---
 
-_This event will be held and recorded over [Zoom](https://www.zoom.us/). Make sure you install the [Zoom Client ](https://zoom.us/download#client&#95;4meeting) beforehand. (See the Zoom [computer and device requirements](https://support.zoom.us/hc/en-us/articles/201362023-System-Requirements-for-PC-Mac-and-Linux), and [FAQs](https://support.zoom.us/hc/en-us/sections/200277708-Frequently-Asked-Questions))_ 
+_This event will be held and recorded over [Zoom](https://www.zoom.us/). Make sure you install the [Zoom Client ](https://zoom.us/download#client&#95;4meeting) beforehand. (See the Zoom [computer and device requirements](https://support.zoom.us/hc/en-us/articles/201362023-System-Requirements-for-PC-Mac-and-Linux), and [FAQs](https://support.zoom.us/hc/en-us/sections/200277708-Frequently-Asked-Questions))_


### PR DESCRIPTION
This change introduces new language to event pages that use Zoom.

**From Richard Spidel at the GSA privacy office:**
> **1. Let Attendees Know A Meeting is Being Recorded** — If you plan to record a meeting, you must alert attendees in the calendar invitation, in the meeting chat window, and periodically announce it over the phone line once the meeting has started.  This way, everyone becomes aware they are being recorded, even if they were not able to see the “recording” notice when the meeting began. Each participant must have an opportunity to consent or ask questions before recording begins.

The new change clarifies the existing zoom language and adds to signal that it will be recorded.

> _This event will be held and recorded over  [Zoom](https://www.zoom.us/). Make sure you install the  [Zoom Client](https://zoom.us/download#client&#95;4meeting) beforehand. (See the Zoom  [computer and device requirements](https://support.zoom.us/hc/en-us/articles/201362023-System-Requirements-for-PC-Mac-and-Linux), and  [FAQs](https://support.zoom.us/hc/en-us/sections/200277708-Frequently-Asked-Questions))_

---

**Preview:** https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/digitalgov.gov/video-notices/events/