### PR TITLE
adding on_hold to pull event from feed

### DIFF
--- a/content/events/2019/08/2019-08-29-socialgov-talks-leveraging-pop-culture-with-paul-lester-doe.md
+++ b/content/events/2019/08/2019-08-29-socialgov-talks-leveraging-pop-culture-with-paul-lester-doe.md
@@ -12,7 +12,7 @@ end_date: 2019-08-29 14:00:00 -0500
 event_organizer: DigitalGov University
 host: Socialgov
 registration_url: https://www.eventbrite.com/e/socialgov-talks-leveraging-pop-culture-with-paul-lester-of-the-doe-registration-66348428937
-on_hold: true
+draft: true
 
 ---
 

--- a/content/events/2019/08/2019-08-29-socialgov-talks-leveraging-pop-culture-with-paul-lester-doe.md
+++ b/content/events/2019/08/2019-08-29-socialgov-talks-leveraging-pop-culture-with-paul-lester-doe.md
@@ -12,7 +12,7 @@ end_date: 2019-08-29 14:00:00 -0500
 event_organizer: DigitalGov University
 host: Socialgov
 registration_url: https://www.eventbrite.com/e/socialgov-talks-leveraging-pop-culture-with-paul-lester-of-the-doe-registration-66348428937
-on-hold: true
+on_hold: true
 
 ---
 

--- a/content/events/2019/08/2019-08-29-socialgov-talks-leveraging-pop-culture-with-paul-lester-doe.md
+++ b/content/events/2019/08/2019-08-29-socialgov-talks-leveraging-pop-culture-with-paul-lester-doe.md
@@ -2,44 +2,44 @@
 slug: socialgov-talks-leveraging-pop-culture-with-paul-lester-doe
 title: 'SocialGov Talks&#58; Leveraging Pop Culture With Paul Lester of the DOE'
 summary: 'Learn from a social media expert at Department of Energy how to use pop culture references as a jumping off point to talk about your agency’s work&#46;  '
-featured_image: 
-  uid: 
+featured_image:
+  uid:
   alt: ''
-event_type: 
+event_type:
   - Zoom
 date: 2019-08-29 13:00:00 -0500
 end_date: 2019-08-29 14:00:00 -0500
 event_organizer: DigitalGov University
-host: Socialgov 
+host: Socialgov
 registration_url: https://www.eventbrite.com/e/socialgov-talks-leveraging-pop-culture-with-paul-lester-of-the-doe-registration-66348428937
-draft: true
+on-hold: true
 
 ---
 
 _[View live captioning for this event ](https://www.captionedtext.com/client/event.aspx?EventID=4113418&CustomerID=321)_
 
-Join Paul Lester, Digital Content Specialist for the [Department of Energy](https://www.energy.gov/) (DOE), to discuss how DOE leveraged the popular TV show, “Stranger Things” as a conversation starter about the agency’s mission and work using digital media (social media, blog, podcast, etc.). Mr. Lester will also discuss how he got management buy-in to use a pop culture phenomenon to promote the agency’s work. 
+Join Paul Lester, Digital Content Specialist for the [Department of Energy](https://www.energy.gov/) (DOE), to discuss how DOE leveraged the popular TV show, “Stranger Things” as a conversation starter about the agency’s mission and work using digital media (social media, blog, podcast, etc.). Mr. Lester will also discuss how he got management buy-in to use a pop culture phenomenon to promote the agency’s work.
 
-**Related links:** 
+**Related links:**
 
-- The blog that started it all… [https://www.energy.gov/articles/what-stranger-things-didn-t-get-quite-so-right-about-energy-department](https://www.energy.gov/articles/what-stranger-things-didn-t-get-quite-so-right-about-energy-department) 
--  …that resulted in press like this Wired interview: [https://www.wired.com/2016/08/energy-department-responds-stranger-things/](https://www.wired.com/2016/08/energy-department-responds-stranger-things/) 
--  We kept it going with our #StrangerThings-themed Halloween! [https://twitter.com/ENERGY/status/793185809549631488](https://twitter.com/ENERGY/status/793185809549631488) 
-- The next year, we delved deeper into the Upside Down and the work DOE is doing in particle physics with a podcast segment… [https://www.energy.gov/podcasts/direct-current-energygov-podcast/s2-e7-energy-secrets](https://www.energy.gov/podcasts/direct-current-energygov-podcast/s2-e7-energy-secrets) 
+- The blog that started it all… [https://www.energy.gov/articles/what-stranger-things-didn-t-get-quite-so-right-about-energy-department](https://www.energy.gov/articles/what-stranger-things-didn-t-get-quite-so-right-about-energy-department)
+-  …that resulted in press like this Wired interview: [https://www.wired.com/2016/08/energy-department-responds-stranger-things/](https://www.wired.com/2016/08/energy-department-responds-stranger-things/)
+-  We kept it going with our #StrangerThings-themed Halloween! [https://twitter.com/ENERGY/status/793185809549631488](https://twitter.com/ENERGY/status/793185809549631488)
+- The next year, we delved deeper into the Upside Down and the work DOE is doing in particle physics with a podcast segment… [https://www.energy.gov/podcasts/direct-current-energygov-podcast/s2-e7-energy-secrets](https://www.energy.gov/podcasts/direct-current-energygov-podcast/s2-e7-energy-secrets)
 -  …and blog post from the director of High Energy Physics: [https://www.energy.gov/articles/searching-upside-down](https://www.energy.gov/articles/searching-upside-down)
 
 **Paul Lester, Digital Content Specialist for the Department of Energy**
 
-Paul Lester is a digital content specialist in the Department of Energy’s Office of Public Affairs. Paul was born in Ohio but spent most of his life in Florida, where he worked as a news researcher-slash-archivist and online editor for the [Orlando Sentinel](http://www.orlandosentinel.com/). 
+Paul Lester is a digital content specialist in the Department of Energy’s Office of Public Affairs. Paul was born in Ohio but spent most of his life in Florida, where he worked as a news researcher-slash-archivist and online editor for the [Orlando Sentinel](http://www.orlandosentinel.com/).
 
 He moved to Washington in 2008 for a web editor role with [The Guardian](http://www.theguardian.com/us) before working as a contractor for the [Wind](https://www.energy.gov/node/779761) and [Water](https://www.energy.gov/node/779756) Technologies Office, the [Small Business Administration](https://www.sba.gov/), and DOE’s [Office of Energy Efficiency and Renewable Energy](https://www.energy.gov/eere/office-energy-efficiency-renewable-energy). Paul joined the Energy.gov team in March 2015, contributing to [Energy Blog](https://www.energy.gov/blog-archive) and assisting with managing the Energy Department’s [social media channels](https://www.energy.gov/about-us/web-policies/social-media). When he’s not in the office, Paul can be seen slowly running around D.C. training for his next half marathon.
 
-_Questions about this event or future events? Send them to [digitalgovu@gsa.gov](mailto:digitalgovu@gsa.gov)._ 
+_Questions about this event or future events? Send them to [digitalgovu@gsa.gov](mailto:digitalgovu@gsa.gov)._
 
 This SocialGov Talk is hosted by [SocialGov](https://digital.gov/communities/social-media/), the federal government’s social media Community of Practice (CoP). SocialGov has over 1,200 members from 90+ departments and agencies across the federal government. 
 
 Our team will send a reminder email prior to the event that includes your link to join the video. 
 
---- 
+---
 
-_This event will be held over [Zoom](https://www.zoom.us/) (see the Zoom [computer and device requirements](https://support.zoom.us/hc/en-us/articles/201362023-System-Requirements-for-PC-Mac-and-Linux), and [FAQs](https://support.zoom.us/hc/en-us/sections/200277708-Frequently-Asked-Questions)). You can [download Zoom Client for Meetings](https://zoom.us/download#client&#95;4meeting) to install the Zoom web browser client beforehand._ 
+_This event will be held over [Zoom](https://www.zoom.us/) (see the Zoom [computer and device requirements](https://support.zoom.us/hc/en-us/articles/201362023-System-Requirements-for-PC-Mac-and-Linux), and [FAQs](https://support.zoom.us/hc/en-us/sections/200277708-Frequently-Asked-Questions)). You can [download Zoom Client for Meetings](https://zoom.us/download#client&#95;4meeting) to install the Zoom web browser client beforehand._

--- a/content/events/2019/09/2019-09-03-quantifying-value-innovation.md
+++ b/content/events/2019/09/2019-09-03-quantifying-value-innovation.md
@@ -12,7 +12,7 @@ end_date: 2019-09-03 14:00:00 -0500
 event_organizer: DigitalGov University
 host: Presidential Innovation Fellows, 18F
 registration_url: https://www.eventbrite.com/e/quantifying-the-value-of-innovation-registration-68315857569
-on-hold: true
+on_hold: true
 
 ---
 

--- a/content/events/2019/09/2019-09-03-quantifying-value-innovation.md
+++ b/content/events/2019/09/2019-09-03-quantifying-value-innovation.md
@@ -2,16 +2,17 @@
 slug: quantifying-value-innovation
 title: 'Quantifying the Value of Innovation'
 summary: 'We know that the value of &quot;innovation&quot; can be difficult to communicate&#46; How might we better tell the story of our work&#63; Join our webinar to learn more about data storytelling, tagging text and quantifying the value of innovation&#46; '
-featured_image: 
-  uid: 
+featured_image:
+  uid:
   alt: ''
-event_type: 
+event_type:
   - Zoom
 date: 2019-09-03 13:00:00 -0500
 end_date: 2019-09-03 14:00:00 -0500
 event_organizer: DigitalGov University
 host: Presidential Innovation Fellows, 18F
 registration_url: https://www.eventbrite.com/e/quantifying-the-value-of-innovation-registration-68315857569
+on-hold: true
 
 ---
 
@@ -33,7 +34,7 @@ We began the PIF Storybank in April 2019 as a prototype. Each week, PIFs answer 
 
 We now have 135 entries from 25 PIFs. We know what percentage of PIFs are working on AI, autonomous vehicles, communications, cross-agency collaboration, data accountability, data science, data transparency, public-private collaborations, human-centered design, investment, twenty-first-century workforce, product management, and tech infrastructure. We know that 18 PIFs have worked on AI projects across 16 agencies. We also know what blockers have arisen.
 
-Join our webinar to learn more about data storytelling, tagging text, and quantifying the value of innovation. 
+Join our webinar to learn more about data storytelling, tagging text, and quantifying the value of innovation.
 
 This talk is hosted by the [Presidential Innovation Fellows](https://www.presidentialinnovationfellows.gov/) and [18F](https://www.18f.gov/). 
 
@@ -41,6 +42,6 @@ Our team will send a reminder email prior to the event that includes your link t
 
 _Questions about this event or future events?_ Send them to [digitalgovu@gsa.gov](mailto:digitalgovu@gsa.gov). 
 
---- 
+---
 
-_This event will be held over [Zoom](https://www.zoom.us/) &#40;see the Zoom [computer and device requirements](https://support.zoom.us/hc/en-us/articles/201362023-System-Requirements-for-PC-Mac-and-Linux), and [FAQs](https://support.zoom.us/hc/en-us/sections/200277708-Frequently-Asked-Questions)&#41;. You can [download Zoom Client for Meetings](https://zoom.us/download#client&#95;4meeting) to install the Zoom web browser client beforehand._ 
+_This event will be held over [Zoom](https://www.zoom.us/) &#40;see the Zoom [computer and device requirements](https://support.zoom.us/hc/en-us/articles/201362023-System-Requirements-for-PC-Mac-and-Linux), and [FAQs](https://support.zoom.us/hc/en-us/sections/200277708-Frequently-Asked-Questions)&#41;. You can [download Zoom Client for Meetings](https://zoom.us/download#client&#95;4meeting) to install the Zoom web browser client beforehand._

--- a/themes/digital.gov/layouts/events/list.html
+++ b/themes/digital.gov/layouts/events/list.html
@@ -26,7 +26,7 @@
             {{ if .Params.End_date }}
               {{ $end := dateFormat "2006-01-02" .Params.End_date }}
               {{ if or (ge $start $now) (ge $end $now)}}
-                {{ if not .Params.on-hold }}
+                {{ if not .Params.on_hold }}
                   {{ .Render "li"}}
                 {{ end }}
               {{ end }}
@@ -47,7 +47,7 @@
 
             {{ $events := where .Site.RegularPages.ByDate "Section" "events" }}
             {{ range where $events.Reverse ".Date.Unix" "<" now.Unix }}
-              {{ if not .Params.on-hold }}
+              {{ if not .Params.on_hold }}
                 {{ .Render "past"}}
               {{ end }}
             {{ end }}

--- a/themes/digital.gov/layouts/events/list.html
+++ b/themes/digital.gov/layouts/events/list.html
@@ -26,7 +26,9 @@
             {{ if .Params.End_date }}
               {{ $end := dateFormat "2006-01-02" .Params.End_date }}
               {{ if or (ge $start $now) (ge $end $now)}}
-                {{ .Render "li"}}
+                {{ if not .Params.on-hold }}
+                  {{ .Render "li"}}
+                {{ end }}
               {{ end }}
 
               {{ else if ge $start $now }}
@@ -45,7 +47,9 @@
 
             {{ $events := where .Site.RegularPages.ByDate "Section" "events" }}
             {{ range where $events.Reverse ".Date.Unix" "<" now.Unix }}
-              {{ .Render "past"}}
+              {{ if not .Params.on-hold }}
+                {{ .Render "past"}}
+              {{ end }}
             {{ end }}
 
           </div>


### PR DESCRIPTION

This change introduces `on_hold:true` as a parameter to pull an event from the list of events on the event page
