### PR TITLE
Fixing flash on USWDS banner

### DIFF
--- a/themes/digital.gov/layouts/partials/usa-banner.html
+++ b/themes/digital.gov/layouts/partials/usa-banner.html
@@ -20,7 +20,7 @@
         </button>
       </div>
     </header>
-    <div class="usa-banner__content usa-accordion__content" id="gov-banner">
+    <div class="usa-banner__content usa-accordion__content" id="gov-banner" hidden>
       <div class="grid-row grid-gap-lg">
         <div class="usa-banner__guidance tablet:grid-col-6">
           {{- $uswds_asset := "icon-dot-gov.svg" -}}


### PR DESCRIPTION
From @eddietejeda —

> "Hey @thisisdano @jeremyzilar , since upgrading to 2.0, I noticed that the top government banner flickers on page reloads. This became very apparent in the new digital.gov site, the pages are a bit bigger than in our demo sites. Is there a solution to this?"

## What we made better

This change adds `hidden` to the element that contains the additional "Here's how you know" content in the USWDS Gov banner.

```
<div class="usa-banner__content usa-accordion__content" id="gov-banner" hidden>
```

This makes it so that the element is hidden by default when the page loads. After the USWDS JS loads, it still applies `hidden` to this element, but since it is already hidden, there is no visible effect and no flash