### PR TITLE
Updating the site title in layouts

### DIFF
--- a/themes/digital.gov/layouts/events/list.html
+++ b/themes/digital.gov/layouts/events/list.html
@@ -1,6 +1,6 @@
 {{ define "pagevars" }}
   {{ $.Scratch.Set "bodyclasses" "top archive post-type-archive post-type-archive-tribe_events tribe-js tribe-filter-live c-sw unboxed centercatnav bodybg1 events-list events-archive tribe-events-style-full tribe-events-style-theme tribe-theme-wp-enlightened tribe-events-page-template tribe-is-responsive" }}
-  {{ $.Scratch.Set "headtitle" "Events | DigitalGov" }}
+  {{ $.Scratch.Set "headtitle" "Events | Digital.gov" }}
 {{ end }}
 
 {{ define "content" }}
@@ -15,7 +15,7 @@
             <div class="events-head">
               <h1>Upcoming Training & Events</h1>
               <p>
-                <a href="https://www.youtube.com/digitalgov" title="View all DigitalGov videos and training">All training & videos »</a>
+                <a href="https://www.youtube.com/digitalgov" title="View all Digital.gov videos and training">All training & videos »</a>
               </p>
             </div>
 
@@ -42,7 +42,7 @@
 
             <div class="events-head">
               <h1>Past Events</h1>
-              <p><a href="https://www.youtube.com/digitalgov" title="View all DigitalGov videos and training">All training & videos »</a></p>
+              <p><a href="https://www.youtube.com/digitalgov" title="View all Digital.gov videos and training">All training & videos »</a></p>
             </div>
 
             {{ $events := where .Site.RegularPages.ByDate "Section" "events" }}

--- a/themes/digital.gov/layouts/partials/body-featured-events.html
+++ b/themes/digital.gov/layouts/partials/body-featured-events.html
@@ -7,8 +7,8 @@
             <div class="events-head">
               <h2>Upcoming Training & Events</h2>
               <p>
-                <a href="{{ "events/" | absURL }}" title="View all DigitalGov Events">All Events</a> |
-                <a href="https://www.youtube.com/digitalgov" title="View all DigitalGov videos and training">All training & videos</a>
+                <a href="{{ "events/" | absURL }}" title="View all Digital.gov Events">All Events</a> |
+                <a href="https://www.youtube.com/digitalgov" title="View all Digital.gov videos and training">All training & videos</a>
               </p>
             </div>
 

--- a/themes/digital.gov/layouts/partials/event-actions.html
+++ b/themes/digital.gov/layouts/partials/event-actions.html
@@ -24,7 +24,7 @@
       <var class="atc_title">{{ $event_title }}</var>
       <var class="atc_description">{{ htmlUnescape $event_description | safeHTML }}</var>
       <var class="atc_location">{{ $event_location }}</var>
-      <var class="atc_organizer">DigitalGov</var>
+      <var class="atc_organizer">Digital.gov</var>
       <var class="atc_organizer_email">digitalgov@gsa.gov</var>
     </var>
   </span>

--- a/themes/digital.gov/layouts/partials/head-comment.html
+++ b/themes/digital.gov/layouts/partials/head-comment.html
@@ -1,5 +1,5 @@
 {{ "<!--" | safeHTML }}
-Welcome to DigitalGov
+Welcome to Digital.gov
 
 Our goal is to transform how government learns, builds, delivers and measures digital services in the 21st century.
 
@@ -12,10 +12,10 @@ Follow us on Twitter: @digital_gov
 ===
 Digital.gov was last updated on {{ now.Format "Jan 2, 2006 at 3:04pm ET" }}
 
-Built by the DigitalGov team in the GSA, using modern development practices.
+Built by the Digital.gov team in the GSA, using modern development practices.
 See the full source code: https://github.com/GSA/digitalgov.gov
 
-DigitalGov is hosted on Federalist
+Digital.gov is hosted on Federalist
 Learn more here: https://federalist.18f.gov/
 .
 .

--- a/themes/digital.gov/layouts/partials/head.html
+++ b/themes/digital.gov/layouts/partials/head.html
@@ -59,7 +59,7 @@
   <meta property="og:description" content="{{ $.Params.summary | default $.Site.Params.description | markdownify }}">
   <meta property="og:type" content="{{ $.Scratch.Get "pagetype" }}">
   <meta property="og:url" content="{{ .Permalink }}" />
-  <meta property="og:site_name" content="DigitalGov">
+  <meta property="og:site_name" content="Digital.gov">
   {{ if $featImgURL }}<meta property="og:image" content="{{ $featImgURL }}" />{{ end }}
   {{ if $.Params.youtube_id }}<meta property='og:video' content='https://www.youtube.com/v/{{ $.Params.youtube_id }}' />{{ end }}
   <meta property="fb:admins" content="100000569454928" />
@@ -80,7 +80,7 @@
   <link href="{{ "feed/index.xml" | absURL }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
 
   {{ "<!-- Sitemap-->" | safeHTML }}
-  <link rel="sitemap" type="application/xml" title="DigitalGov Sitemap" href="{{ "sitemap.xml" | absURL }}" />
+  <link rel="sitemap" type="application/xml" title="Digital.gov Sitemap" href="{{ "sitemap.xml" | absURL }}" />
   {{ if .RSSLink }}
   <link href="{{ .RSSLink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
   {{ end }}

--- a/themes/digital.gov/layouts/posts/list.html
+++ b/themes/digital.gov/layouts/posts/list.html
@@ -1,6 +1,6 @@
 {{ define "pagevars" }}
   {{ $.Scratch.Set "bodyclasses" "top archive post-type-archive post-type-archive-tribe_events tribe-js tribe-filter-live c-sw unboxed centercatnav bodybg1 events-list events-archive tribe-events-style-full tribe-events-style-theme tribe-theme-wp-enlightened tribe-events-page-template tribe-is-responsive" }}
-  {{ $.Scratch.Set "headtitle" "Posts | DigitalGov" }}
+  {{ $.Scratch.Set "headtitle" "Posts | Digital.gov" }}
 {{ end }}
 
 {{ define "content" }}


### PR DESCRIPTION
I updated the site title to `Digital.gov` from `DigitalGov` in all the layout files, including the title tags of the site.

No need to go in and replace out the names in all the blog posts (yet).