### PR TITLE
DEMO Header Test

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -78,7 +78,7 @@ params:
     - civic-tech
 
 
-relativeURLs: true
+# relativeURLs: true
 refLinksNotFoundURL: https://digital.gov/resources/
 
 permalinks:

--- a/readme.md
+++ b/readme.md
@@ -31,8 +31,8 @@ _see https://gohugo.io/getting-started/installing/ for other OSs_
 
 #### Run
 
-`hugo serve --config=config.yml` _(can take 2-3 minutes to launch)_
+`hugo serve` _(can take 30 secs to launch)_
 or
-`hugo serve --config=config_dev.yml` _(can take 20 secs to launch but only builds a portion of the content)_
+`hugo serve --config=config_dev.yml` _(can take 5 secs to launch but only builds a portion of the content)_
 
 **visit** http://localhost:1313/


### PR DESCRIPTION

This is a change to test out some build issues in Federalist with the `DEMO` branch.
- [x] Edited the readme file
- [x] removed `relativeURLs: true` (FIXED)

---

**Preview:** https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/digitalgov.gov/demo-header-test/