### PR TITLE
adding zoom as an event type in event generator

### DIFF
--- a/content/pages/new-event.html
+++ b/content/pages/new-event.html
@@ -38,10 +38,10 @@ css: [front-matter.css]
         <h4>Event</h4>
         <div class="btn-group event_types">
           <div class="checkbox">
-            <label for="youtube-live"><input type="checkbox" class="fm" checked id="youtube-live" name="event_type" value="youtube-live"> YouTube LIVE</label>
+            <label for="zoom"><input type="checkbox" class="fm" id="zoom"checked name="event_type" value="zoom"> Zoom</label>
           </div>
           <div class="checkbox">
-            <label for="online"><input type="checkbox" class="fm" id="online" name="event_type" value="online"> Online</label>
+            <label for="youtube-live"><input type="checkbox" class="fm" id="youtube-live" name="event_type" value="youtube-live"> YouTube LIVE</label>
           </div>
           <div class="checkbox">
             <label for="in-person"><input type="checkbox" class="fm" id="in-person" name="event_type" value="in-person"> In Person</label>


### PR DESCRIPTION
This change adds "zoom" as an event type in the event creator page and removes "online" as an option. Zoom is also selected by default.

![image](https://user-images.githubusercontent.com/395641/66507722-bb9e7580-ea9d-11e9-8fcb-375bd1564def.png)

**Preview:** https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/digitalgov.gov/event-editor/new-event