### PR TITLE
Updates CFPB's web content management to Wagtail

### DIFF
--- a/content/resources/content-management-systems-used-by-government-agencies.md
+++ b/content/resources/content-management-systems-used-by-government-agencies.md
@@ -47,7 +47,7 @@ We do our best to keep the list current based on information we get from agencie
  * [SmartCheck.gov](https://www.smartcheck.gov) (Drupal 8)
  * [Whistleblower.gov](https://www.whistleblower.gov) (Drupal 8)
 
-[Consumer Financial Protection Bureau](http://www.consumerfinance.gov/) (WordPress/PHP)
+[Consumer Financial Protection Bureau](http://www.consumerfinance.gov/) (Wagtail)
 
 [Consumer Product Safety Commission](http://www.cpsc.gov/) (EpiServer)
 


### PR DESCRIPTION
The agency [moved to wagtail.io for their primary CMS](https://github.com/cfpb/cfgov-refresh) in 2016.