### PR TITLE
adding in a redirect for a dap page

### DIFF
--- a/content/services/dap/become-a-dap-certified-analyst.md
+++ b/content/services/dap/become-a-dap-certified-analyst.md
@@ -7,6 +7,7 @@ type: guide
 guide: dap
 aliases:
   - /dap/certified-analyst/
+  - /services/dap/certified-analyst/
 
 ---
 


### PR DESCRIPTION
this URL is broken https://digital.gov/services/dap/certified-analyst/
Adding in a redirect to https://digital.gov/services/dap/become-a-dap-certified-analyst/

**Preview -- this should redirect** https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/digitalgov.gov/dap-redirect/services/dap/certified-analyst/