### PR TITLE
broken link

### DIFF
--- a/content/events/2019/11/2019-11-05-foundations-agile-ii.md
+++ b/content/events/2019/11/2019-11-05-foundations-agile-ii.md
@@ -28,7 +28,7 @@ This second session will take a quick look at the external view of producing cus
 #### More talks in this series:
 
 - [**Foundations of Agile, Part I**]({{< link "/event/2019/11/04/foundations-agile-i/" >}}) — Monday, November 4, 1:30 - 2:30 pm, ET 
-- [**Foundations of Agile, Part II**]({{< link "/event/2019/11/05/basic-scrum-i/" >}}) — Tuesday, November 5, 3:30 - 4:30 pm, ET 
+- [**Foundations of Agile, Part II**]({{< link "/ievent/2019/11/04/foundations-agile-ii" >}}) — Tuesday, November 5, 3:30 - 4:30 pm, ET 
 - [**Basics of Scrum, Part I**]({{< link "/event/2019/11/08/basic-scrum-i/" >}}) — Friday, November 8, 1:30 - 2:30 pm, ET 
 - [**Basics of Scrum, Part II**]({{< link "/event/2019/11/12/basics-scrum-ii/" >}}) — Tuesday, November 12, 3:00 - 4:00 pm, ET 
 - [**Intro to Kanban, Part I**]({{< link "/event/2019/11/13/intro-kanban-i/" >}}) — Monday, November 13, 3:00 - 4:00 pm, ET 


### PR DESCRIPTION
Hey @jeremyzilar - i noticed an error in the body of the list of events that there was a broken link. The agile talks II went to a broken link for scrum II -- just wanted to toss it your way for review (i think i corrected it but wanted to follow up as I think it is something to crosscheck on all of the agile pages)