### PR TITLE
adding Teri Greene as the Treasury representative

### DIFF
--- a/content/resources/federal-web-council.md
+++ b/content/resources/federal-web-council.md
@@ -61,7 +61,7 @@ You are encouraged to reach out to your agency’s Web Council member if you hav
 -   Department of Labor — Stan Olshefski
 -   Department of State — Monica Perry
 -   Department of Transportation — Andrea Bouchard
--   Department of the Treasury — _VACANT_
+-   Department of the Treasury — Teri Greene
 -   Department of Veterans Affairs — Joshua Tuscher
 -   Environmental Protection Agency — Lin Darlington
 -   General Services Administration — Sarah Bryant


### PR DESCRIPTION
Current page: https://digital.gov/resources/federal-web-council/

Preview: https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/digitalgov.gov/fwc-member/resources/federal-web-council/