### PR TITLE
adding links to 21c IDEA overview page

### DIFF
--- a/content/posts/2019/11/2019-11-12-meet-your-federal-web-council.md
+++ b/content/posts/2019/11/2019-11-12-meet-your-federal-web-council.md
@@ -9,6 +9,7 @@ authors:
 featured_image:
   uid: this-weeks-idea-card-wk2
   alt: ''
+  
 ---
 
 _“Alone we can do so little; together we can do so much.” — Helen Keller_
@@ -17,7 +18,7 @@ _“Alone we can do so little; together we can do so much.” — Helen Keller_
 
 Welcome to this week’s idea, where we explain one essential topic around 21st Century IDEA and give you the resources and tools to start making focused changes to your digital products.
 
-This week, we’d like to introduce you to the [**Federal Web Council**](https://digital.gov/resources/federal-web-council/), your partners in making 21st Century IDEA happen.
+This week, we’d like to introduce you to the [**Federal Web Council**](https://digital.gov/resources/federal-web-council/), your partners in making [21st Century IDEA](https://digital.gov/resources/21st-century-integrated-digital-experience-act/) happen.
 
 When there is something important that needs to be coordinated across the federal web space, the Federal Web Council has been the vehicle for getting those things done. Since it launched in 2004, it has been a forum for high-level cross-agency collaboration, and has helped to develop and shape policies and guidelines for U.S. federal websites, much of which are documented here on [Digital.gov](https://digital.gov/resources).
 
@@ -26,6 +27,7 @@ Around [21st Century IDEA](https://digital.gov/resources/21st-century-integrated
 Over the summer, the Council worked to better understand how to help federal agencies meet the requirements of 21st Century IDEA. They gathered questions and feedback from the government Web Content Managers Community with the goal of identifying the areas of the law where agencies need more clarification on their responsibilities under the Act. In the coming weeks, we’ll be helping the Council to surface a lot of the findings from their work with you.
 
 - [View our new page on the Federal Web Council, meet the members »](https://digital.gov/resources/federal-web-council/)
+- [An overview of 21st Century IDEA](https://digital.gov/resources/21st-century-integrated-digital-experience-act/)
 
 ## Up Next
 


### PR DESCRIPTION
From a note in the web content managers listserv —

> "Many on this list have no idea what 21st Century IDEA is.  You might want to grease the skids a little!"

This change adds in links to our 21st Century IDEA overview page.