### PR TITLE
adding a comment counter to the prompt box

### DIFF
--- a/themes/digital.gov/layouts/shortcodes/card-prompt.html
+++ b/themes/digital.gov/layouts/shortcodes/card-prompt.html
@@ -13,7 +13,12 @@
     {{- .Inner | markdownify -}}
   </div>
   {{- end -}}
-  {{- if (.Get "button") -}}<button class="usa-button"><a href="{{- .Get "url" -}}" title="{{- .Get "button" -}}">{{- .Get "button" -}}</a></button>{{- end -}}
+  {{- if (.Get "button") -}}
+  <div class="submit">
+    <button class="usa-button"><a href="{{- .Get "url" -}}" title="{{- .Get "button" -}}">{{- .Get "button" -}}</a></button>
+    <span></span>
+  </div>
+  {{- end -}}
   {{- if (.Get "fallback") -}}<p class="fallback">{{- .Get "fallback" | markdownify -}}</p>{{- end -}}
 </div>
 {{- end -}}

--- a/themes/digital.gov/static/js/external.js
+++ b/themes/digital.gov/static/js/external.js
@@ -42,6 +42,29 @@ function build_edit_file_link(){
 }
 build_edit_file_link();
 
+
+
+function get_issue_comments(){
+	var issue_id = '1517';
+	var issue_comments_api = "https://api.github.com/repos/GSA/digitalgov.gov/issues/" + issue_id + "/comments";
+	if (issue_comments_api !== undefined) {
+		$.ajax({
+		  url: issue_comments_api,
+		 	dataType: 'json',
+		}).done(function(data) {
+			if (typeof data !== 'undefined') {
+				var count = $(data).length;
+				if (count > 1) {
+					$('.card-prompt .submit span').html('<strong>+'+count+'</strong> submissions');
+				}
+			}
+		});
+	}
+}
+get_issue_comments();
+
+
+
 function get_commit_data(){
 	if (branch == "master") {
 		branchpath = "";
@@ -49,7 +72,6 @@ function get_commit_data(){
 		branchpath = "/" + branch;
 	}
 	var commit_api_path  = "https://api.github.com/repos/" + git_org + "/" + git_repo + "/commits" + branchpath + "?path=/content/" + filepath;
-	console.log(commit_api_path);
 	if (commit_api_path !== undefined) {
 		$.ajax({
 		  url: commit_api_path,
@@ -78,7 +100,6 @@ function get_branch_link(branch){
 
 function show_last_commit(data, branch){
 	var branch_link = get_branch_link(branch);
-	console.log(data);
 	if (data[0] == null) {
 		var commit_date = data['commit']['committer']['date'];
 		var commit_author = data['author']['login'];

--- a/themes/digital.gov/static/js/external.js
+++ b/themes/digital.gov/static/js/external.js
@@ -55,7 +55,7 @@ function get_issue_comments(){
 			if (typeof data !== 'undefined') {
 				var count = $(data).length;
 				if (count > 1) {
-					$('.card-prompt .submit span').html('<strong>+'+count+'</strong> submissions');
+					$('.card-prompt .submit span').html('<strong>'+count+'+</strong> submissions');
 				}
 			}
 		});

--- a/themes/digital.gov/static/js/external.js
+++ b/themes/digital.gov/static/js/external.js
@@ -55,7 +55,7 @@ function get_issue_comments(){
 			if (typeof data !== 'undefined') {
 				var count = $(data).length;
 				if (count > 1) {
-					$('.card-prompt .submit span').html('<strong>'+count+'+</strong> submissions');
+					$('.card-prompt .submit span').html('<strong>'+count+'</strong> submissions');
 				}
 			}
 		});


### PR DESCRIPTION
This change adds a comment counter to the prompt box. It will only appear if there is more than 1 comment. 
![image](https://user-images.githubusercontent.com/395641/69095501-7700e500-0a20-11ea-9a2a-77f4de7a708b.png)


---

**Preview URL:** https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/digitalgov.gov/comment-counter/2019/11/18/building-elements-that-earn-trust/
