### PR TITLE
youtube video synch troubleshooting

### DIFF
--- a/content/events/2019/11/2019-11-21-us-web-design-system-november-monthly-call.md
+++ b/content/events/2019/11/2019-11-21-us-web-design-system-november-monthly-call.md
@@ -11,7 +11,7 @@ date: 2019-11-21 14:30:00 -0500
 end_date: 2019-11-21 15:30:00 -0500
 event_organizer: DigitalGov University
 host: U.S. Web Design System
-registration_url: https://www.eventbrite.com/e/us-web-design-system-november-monthly-call-registration-79794691069
+youtube_id: -mWm-2V-DLA
 
 ---
 


### PR DESCRIPTION
video was not shown on google chrome and when checked link (https://digital.gov/event/2019/11/21/us-web-design-system-november-monthly-call/)

The link sent on slack the video was featured and when started it did not start at 0:00 (https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/digitalgov.gov/DanielJPino-ux-patch-6/event/2019/11/21/us-web-design-system-november-monthly-call/)

Reuploading here: https://www.youtube.com/watch?v=-mWm-2V-DLA

Hope this resolves it. THANK YOU!


A one-line description of the changes you're making and how they'll affect users.

**Doc:** URL

---

**Preview URL:** URL
