### PR TITLE
adding a check around events, when there are no current events

### DIFF
--- a/content/events/2019/12/2019-12-03-devops-holiday-special-event-nicolas-chaillan.md
+++ b/content/events/2019/12/2019-12-03-devops-holiday-special-event-nicolas-chaillan.md
@@ -12,7 +12,6 @@ end_date: 2019-12-03 14:30:00 -0500
 event_organizer: DigitalGov University
 host: DevOps COP
 registration_url: https://www.eventbrite.com/e/devops-holiday-special-event-nicolas-chaillan-registration-83635186093
-draft: true
 
 ---
 

--- a/content/events/2019/12/2019-12-03-devops-holiday-special-event-nicolas-chaillan.md
+++ b/content/events/2019/12/2019-12-03-devops-holiday-special-event-nicolas-chaillan.md
@@ -2,16 +2,17 @@
 slug: devops-holiday-special-event-nicolas-chaillan
 title: 'DevOps Holiday Special Event&#58; Nicolas Chaillan'
 summary: 'Join the Chief Software Officer of the USAF to learn&#58; How the DoD moved to Kubernetes and Istio&#46;'
-featured_image: 
-  uid: 
+featured_image:
+  uid:
   alt: ''
-event_type: 
+event_type:
   - zoom
 date: 2019-12-03 14:00:00 -0500
 end_date: 2019-12-03 14:30:00 -0500
 event_organizer: DigitalGov University
 host: DevOps COP
 registration_url: https://www.eventbrite.com/e/devops-holiday-special-event-nicolas-chaillan-registration-83635186093
+draft: true
 
 ---
 
@@ -21,9 +22,9 @@ It demonstrates how 37 weapon, business and cyber systems are moving to DevSecOp
 
 ## About the Speaker
 
-**Mr. Nicolas Chaillan** is the first [Air Force](https://www.af.mil/) Chief Software Officer (CSO), under Dr. William Roper, the Assistant Secretary of the Air Force for **Acquisition, Technology and Logistics**, Arlington, Virginia. He is also the co-lead for the DoD Enterprise DevSecOps Initiative with the DoD Chief Information Officer (CIO). Mr. Chaillan is responsible for enabling Air Force programs in the transition to Agile and DevSecOps to establish force-wide DevSecOps capabilities and best practices, including continuous Authority to Operate processes and faster, streamlined technology adoption. 
+**Mr. Nicolas Chaillan** is the first [Air Force](https://www.af.mil/) Chief Software Officer (CSO), under Dr. William Roper, the Assistant Secretary of the Air Force for **Acquisition, Technology and Logistics**, Arlington, Virginia. He is also the co-lead for the DoD Enterprise DevSecOps Initiative with the DoD Chief Information Officer (CIO). Mr. Chaillan is responsible for enabling Air Force programs in the transition to Agile and DevSecOps to establish force-wide DevSecOps capabilities and best practices, including continuous Authority to Operate processes and faster, streamlined technology adoption.
 
-In addition to his public service, Mr. Chaillan is a technology entrepreneur, software developer, cyber expert and inventor. He has over 19 years of domestic and international experience with strong technical and subject matter expertise in cybersecurity, software development, product innovation, governance, risk management and compliance. Specifically, these fields include Cloud computing, Cybersecurity, DevSecOps, Big Data, multi-touch, mobile, Internet of Things (IoT), Mixed Reality, virtual reality, and wearables. 
+In addition to his public service, Mr. Chaillan is a technology entrepreneur, software developer, cyber expert and inventor. He has over 19 years of domestic and international experience with strong technical and subject matter expertise in cybersecurity, software development, product innovation, governance, risk management and compliance. Specifically, these fields include Cloud computing, Cybersecurity, DevSecOps, Big Data, multi-touch, mobile, Internet of Things (IoT), Mixed Reality, virtual reality, and wearables.
 
 * [Full biography](https://www.af.mil/About-Us/Biographies/Display/Article/1926281/nicolas-m-chaillan/)
 * Air Force [Office of the Chief Software Officer](https://software.af.mil/) (OCSO)

--- a/themes/digital.gov/layouts/events/list.html
+++ b/themes/digital.gov/layouts/events/list.html
@@ -19,22 +19,25 @@
               </p>
             </div>
 
-            {{ range .Data.Pages.Reverse }}
-            {{ $now := now.Format "2006-01-02" }}
-            {{ $start := .Date.Format "2006-01-02"  }}
+            {{/* Future Events ===========================  */}}
+            {{- $events := where .Site.RegularPages.Reverse  "Section" "events" -}}
+            {{- $events := $events | intersect (where $events "Date" "ge" (now.AddDate 0 0 0))  -}}
 
-            {{ if .Params.End_date }}
-              {{ $end := dateFormat "2006-01-02" .Params.End_date }}
-              {{ if or (ge $start $now) (ge $end $now)}}
-                {{ if not .Params.on_hold }}
-                  {{ .Render "li"}}
-                {{ end }}
-              {{ end }}
+            {{/* Past Events =========================== */}}
+            {{- $past_events := where (where .Site.RegularPages.ByDate.Reverse "Section" "events") ".Date.Unix" "<" now.Unix -}}
 
-              {{ else if ge $start $now }}
-                  {{ .Render "li"}}
-              {{ end }}
-            {{ end }}
+            {{- with $events -}}
+              {{- range $events -}}
+                {{ .Render "li"}}
+              {{- end -}}
+            {{- else -}}
+              <div class="box">
+
+                {{- $copy := printf "**There are no scheduled events at this time.** We’re working on scheduling events for the near future.<br /> Contact us about [hosting a training or event]({{< link 'contribute.md' >}})." -}}
+                {{- $copy | markdownify -}}
+
+              </div>
+            {{- end -}}
 
           </div>
 
@@ -45,12 +48,11 @@
               <p><a href="https://www.youtube.com/digitalgov" title="View all Digital.gov videos and training">All training & videos »</a></p>
             </div>
 
-            {{ $events := where .Site.RegularPages.ByDate "Section" "events" }}
-            {{ range where $events.Reverse ".Date.Unix" "<" now.Unix }}
-              {{ if not .Params.on_hold }}
-                {{ .Render "past"}}
-              {{ end }}
-            {{ end }}
+            {{- with $past_events -}}
+              {{- range $past_events -}}
+                {{ .Render "li"}}
+              {{- end -}}
+            {{- end -}}
 
           </div>
 

--- a/themes/digital.gov/layouts/partials/body-featured-events.html
+++ b/themes/digital.gov/layouts/partials/body-featured-events.html
@@ -1,3 +1,7 @@
+{{/* Future Events ===========================  */}}
+{{- $events := where .Site.RegularPages.Reverse  "Section" "events" -}}
+{{- $events := $events | intersect (where $events "Date" "ge" (now.AddDate 0 0 0))  -}}
+{{- with $events -}}
 <section id="events">
   <div class="container">
     <div class="row">
@@ -12,19 +16,11 @@
               </p>
             </div>
 
-            {{ $events := where .Site.RegularPages.ByDate "Section" "events" }}
-            {{ range where $events "Date" "ge" (now.AddDate 0 0 -1) | first 4 }}
-              {{ $now := now.Format "2006-01-02" }}
-              {{ $start := .Date.Format "2006-01-02"  }}
-              {{ if .Params.End_date }}
-                {{ $end := dateFormat "2006-01-02" .Params.End_date }}
-                {{ if or (ge $start $now) (ge $end $now)}}
-                  {{ .Render "li"}}
-                {{ end }}
-              {{ else if ge $start $now }}
+            {{- with $events -}}
+              {{- range $events -}}
                 {{ .Render "li"}}
-              {{ end }}
-            {{end}}
+              {{- end -}}
+            {{- end -}}
 
           </div>
 
@@ -36,3 +32,4 @@
     </div>
   </div>
 </section>
+{{- end -}}


### PR DESCRIPTION
**Fixing** https://github.com/GSA/digitalgov.gov/issues/169

**On the events page**
added a check around the list of current events. If there are no events, it displays the text:> 
> **There are no scheduled events at this time.** We’re working on scheduling events for the near future. [Contact us about hosting a training or event](https://digital.gov/about/contribute/).

![image](https://user-images.githubusercontent.com/395641/69654941-9fea3100-1043-11ea-8b91-9e68586d0596.png)


**On the home page**
The check is around the whole section. 
- If there are no events, the whole events section does not display.


---

**Preview URL:** URL
