### PR TITLE
Allowing raw HTML to be inserted into markdown

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -48,8 +48,12 @@ outputs:
   page: ["HTML","RSS", "JSON"]
   taxonomy: ["HTML","RSS", "json"]
 
-blackfriday:
-  fractions: false
+# Goldmark is from Hugo 0.60 the default library used for Markdown.
+# https://gohugo.io/getting-started/configuration-markup/#goldmark
+markup:
+  goldmark:
+    renderer:
+      unsafe: true #this allows raw HTML to be inserted into markdown posts
 
 params:
   description: "Guidance on building better digital services in government"

--- a/config.yml
+++ b/config.yml
@@ -51,9 +51,9 @@ outputs:
 # Goldmark is from Hugo 0.60 the default library used for Markdown.
 # https://gohugo.io/getting-started/configuration-markup/#goldmark
 markup:
-  goldmark:
-    renderer:
-      unsafe: true #this allows raw HTML to be inserted into markdown posts
+  defaultMarkdownHandler: blackfriday
+
+
 
 params:
   description: "Guidance on building better digital services in government"


### PR DESCRIPTION
By default, the new markdown processor in HUGO removes raw HTML if it is inserted into a post/page. This setting reveres that, and now enables HTML to be inserted into markdown pages

https://gohugo.io/getting-started/configuration-markup/#goldmark

## To test this change:

Check a number of the older posts/pages that have HTML inserted into them to see that they are still rendering that HTML. If they are (and it's not missing), then this should be good. This will not fix previously broken HTML, so if you find anything like that, it's a separate bug.

**LIVE Examples:**
- https://digital.gov/2016/02/29/the-content-corner-facebook-expands-access-to-instant-articles/
- https://digital.gov/lost-and-found-mapping-page/

**Preview Examples:**
- https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/digitalgov.gov/goldmark-settings/2016/02/29/the-content-corner-facebook-expands-access-to-instant-articles/
- https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/digitalgov.gov/goldmark-settings/lost-and-found-mapping-page/
