### PR TITLE
Adding a DAP service page

### DIFF
--- a/content/services/service_dap.md
+++ b/content/services/service_dap.md
@@ -7,7 +7,7 @@ summary: 'A free analytics tool for measuring digital services in the federal go
 
 # What is the URL for this product or service?
 # Note: We'll add a ?dg to the end of the URL in the code for tracking purposes
-source_url: '/guide/dap'
+source_url: 'https://digital.gov/guide/dap'
 
 # Images need to be at 200x200px with a transparent background
 # Upload new images to Github in the /static/logos/ folder

--- a/content/services/service_dap.md
+++ b/content/services/service_dap.md
@@ -1,0 +1,32 @@
+---
+# What is the name of the product or service?
+title: 'Digital Analytics Program'
+
+# Keep it short — should be no longer than 10 words.
+summary: 'A free analytics tool for measuring digital services in the federal government.'
+
+# What is the URL for this product or service?
+# Note: We'll add a ?dg to the end of the URL in the code for tracking purposes
+source_url: '/guide/dap'
+
+# Images need to be at 200x200px with a transparent background
+# Upload new images to Github in the /static/logos/ folder
+# https://github.com/GSA/digitalgov.gov/tree/master/static/promos/
+# The filename should reflect the name of the product or service (e.g., challenge-gov.png)
+icon: 'digit-150.png'
+
+# Weight: control how services appear across the site
+# 2 == will be part of the rotation on the homepage
+# 1 == will show on the all services page
+# 0 == hidden promo
+weight: 2
+
+# Topics that best describe this product or service
+topics:
+  - metrics
+  - product-management
+  - analytics
+  - analytics-usa-gov
+  - dap
+  - digital-analytics-program
+---

--- a/themes/digital.gov/layouts/services/list.html
+++ b/themes/digital.gov/layouts/services/list.html
@@ -35,15 +35,24 @@
       {{- with $services -}}
 
         {{- range $i, $e := . -}}
+
+          <!-- This checks to see if the source_url is pointing to https://digital.gov and strips it out so that it will function on localhost and Federalist previews -->
+          {{- if .Params.source_url -}}
+            {{- .Scratch.Set "source_url" .Params.source_url -}}
+            {{- if in .Params.source_url "https://digital.gov" -}}
+              {{- .Scratch.Set "source_url" (replace .Params.source_url "https://digital.gov" "") -}}
+            {{- end -}}
+          {{- end -}}
+          
           <div class="grid-col-12 tablet:grid-col-6 tablet:flex-6">
             <div class="promo promo-card " data-edit-this="/edit/{{- .Type -}}/?page=https://demo.digital.gov{{- (urls.Parse .Permalink).Path -}}">
               {{- if .Params.icon -}}
               {{- $src := (print "/logos/" .Params.icon) -}}
               <img class="float-right margin-left-1 margin-bottom-1 width-7" src="{{- $src | relURL -}}" alt="{{- .Params.name }} Logo">
               {{- end -}}
-              <h3><a href="{{- if .Params.source_url -}}{{- .Params.source_url -}}{{- else -}}{{- .URL -}}{{- end -}}?dg" title="{{- .Params.title -}}">{{- .Params.title -}}</a></h3>
+              <h3><a href="{{- if .Scratch.Get "source_url" -}}{{- .Scratch.Get "source_url" -}}{{- else -}}{{- .URL -}}{{- end -}}?dg" title="{{- .Params.title -}}">{{- .Params.title -}}</a></h3>
               <p>{{- .Params.summary | markdownify -}}</p>
-              <a class="overlay" href="{{- if .Params.source_url -}}{{- .Params.source_url -}}{{- else -}}{{- .URL -}}{{- end -}}?dg" title="{{- .Params.title -}}"><span></span></a>
+              <a class="overlay" href="{{- if .Scratch.Get "source_url" -}}{{- .Scratch.Get "source_url" -}}{{- else -}}{{- .URL -}}{{- end -}}?dg" title="{{- .Params.title -}}"><span></span></a>
             </div>
           </div>
         {{- end -}}


### PR DESCRIPTION
This adds in a DAP service page that makes it possible for DAP to be listed on the services page and in promos around the site. It links directly to the DAP guide.

Fixes: https://github.com/GSA/digitalgov.gov/issues/1574

---

**Preview:** https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/digitalgov.gov/dap-service-page/services/