### PR TITLE
fixing additional page margin on mobile

### DIFF
--- a/themes/digital.gov/layouts/posts/single.html
+++ b/themes/digital.gov/layouts/posts/single.html
@@ -33,7 +33,7 @@
 
     <section>
       <div class="grid-container grid-container-desktop" data-edit-this="/edit/{{- .Type -}}/?page=https://demo.digital.gov{{- (urls.Parse .Permalink).Path -}}">
-        <div class="grid-row margin-y-2 grid-gap-6">
+        <div class="grid-row tablet-lg:grid-gap-6">
 
           <div class="grid-col-12 tablet-lg:grid-col-9 tablet-lg:order-last">
 

--- a/themes/digital.gov/layouts/topics/list.html
+++ b/themes/digital.gov/layouts/topics/list.html
@@ -21,7 +21,7 @@
       {{/* If the topic page has Content */}}
       {{- if .Content -}}
       <section>
-        <div class="grid-row margin-y-2 grid-gap-6">
+        <div class="grid-row tablet-lg:grid-gap-6">
           <div class="content">
             {{- .Content -}}
           </div>


### PR DESCRIPTION
There is a bug on mobile where if you slide left, a purple border appears on the right side and stays there. Something on the page is a little too wide and pushing out beyond the container

**Before:** https://demo.digital.gov/2019/12/31/typography/
**FIXED:** https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/digitalgov.gov/page-margin-fix/2019/12/31/typography/

---

![image](https://user-images.githubusercontent.com/395641/70258590-78d5e280-175a-11ea-890c-820bdf78ee59.png)


