### PR TITLE
Edits to the Intro to Accessibility resource page

### DIFF
--- a/content/resources/intro-accessibility.md
+++ b/content/resources/intro-accessibility.md
@@ -162,12 +162,12 @@ If you are able to test screen readers with multiple browsers, the following is 
 
 ## Recommended Resources
 
-- [WCAG 2.0](https://www.w3.org/TR/WCAG20/) — This outlines the principles, guidelines, testable success criteria, and techniques needed to optimize content.
-- [W3C’s WCAG quick reference guide](https://www.w3.org/WAI/WCAG21/quickref/) — A compliance checklist; it will help you satisfy your Section 508 obligations. Be sure to review the white “Understanding” button given in each criteria section for more in-depth information. Remember: the success criteria are just the baseline. We are encouraged to surpass the values specified; not see them as a ceiling to build to.
-- [W3C’s Web Accessibility Initiative (WAI) perspective videos](https://www.w3.org/WAI/perspective-videos/) — A variety of short videos that give examples of different kinds of disabilities.
 - [Section508.gov](https://www.section508.gov/) — Provides guidance to federal agency staff who play a role in IT accessibility. Key topics include program management, procurement, tools & training, and policy compliance.
 - [Accessibility for Teams](https://accessibility.digital.gov/) — A guide to incorporating accessibility into product development teams.
 - [18F Accessibility Guide](https://accessibility.18f.gov/?=dg) — A resource for developing accessible products.
+- [WCAG 2.0](https://www.w3.org/TR/WCAG20/) — This outlines the principles, guidelines, testable success criteria, and techniques needed to optimize content.
+- [W3C’s WCAG quick reference guide](https://www.w3.org/WAI/WCAG21/quickref/) — A compliance checklist; it will help you satisfy your Section 508 obligations. Be sure to review the white “Understanding” button given in each criteria section for more in-depth information. Remember: the success criteria are just the baseline. We are encouraged to surpass the values specified; not see them as a ceiling to build to.
+- [W3C’s Web Accessibility Initiative (WAI) perspective videos](https://www.w3.org/WAI/perspective-videos/) — A variety of short videos that give examples of different kinds of disabilities.
 - [Microsoft’s Inclusive Design Toolkit](https://download.microsoft.com/download/b/0/d/b0d4bf87-09ce-4417-8f28-d60703d672ed/inclusive_toolkit_manual_final.pdf) (PDF, 22 MB, 32 pages) — An approachable introduction to the history and principles of inclusive design ([they also have a full site about Inclusive Design](https://www.microsoft.com/design/inclusive/)).
 - [U.S. Web Design System](https://designsystem.digital.gov/) — Our design system for the federal government was built with accessibility first.
 - [Eight Principles of Mobile-Friendliness: Accessibility](https://digital.gov/resources/mobile/principles/accessibility/) — Created by the [MobileGov Community of Practice](https://digital.gov/communities/mobile/) to highlight ways we can ensure that our mobile products also meet accessibility standards.

--- a/content/resources/intro-accessibility.md
+++ b/content/resources/intro-accessibility.md
@@ -160,20 +160,20 @@ If you are able to test screen readers with multiple browsers, the following is 
 -   Windows 10 Narrator and Edge
 -   VoiceOver (Mac) and Safari (Mac)
 
-## Recommended Resources
+## Additional Resources
 
 - [Section508.gov](https://www.section508.gov/) — Provides guidance to federal agency staff who play a role in IT accessibility. Key topics include program management, procurement, tools & training, and policy compliance.
 - [Accessibility for Teams](https://accessibility.digital.gov/) — A guide to incorporating accessibility into product development teams.
 - [18F Accessibility Guide](https://accessibility.18f.gov/?=dg) — A resource for developing accessible products.
-- [WCAG 2.0](https://www.w3.org/TR/WCAG20/) — This outlines the principles, guidelines, testable success criteria, and techniques needed to optimize content.
-- [W3C’s WCAG quick reference guide](https://www.w3.org/WAI/WCAG21/quickref/) — A compliance checklist; it will help you satisfy your Section 508 obligations. Be sure to review the white “Understanding” button given in each criteria section for more in-depth information. Remember: the success criteria are just the baseline. We are encouraged to surpass the values specified; not see them as a ceiling to build to.
-- [W3C’s Web Accessibility Initiative (WAI) perspective videos](https://www.w3.org/WAI/perspective-videos/) — A variety of short videos that give examples of different kinds of disabilities.
-- [Microsoft’s Inclusive Design Toolkit](https://download.microsoft.com/download/b/0/d/b0d4bf87-09ce-4417-8f28-d60703d672ed/inclusive_toolkit_manual_final.pdf) (PDF, 22 MB, 32 pages) — An approachable introduction to the history and principles of inclusive design ([they also have a full site about Inclusive Design](https://www.microsoft.com/design/inclusive/)).
 - [U.S. Web Design System](https://designsystem.digital.gov/) — Our design system for the federal government was built with accessibility first.
 - [Eight Principles of Mobile-Friendliness: Accessibility](https://digital.gov/resources/mobile/principles/accessibility/) — Created by the [MobileGov Community of Practice](https://digital.gov/communities/mobile/) to highlight ways we can ensure that our mobile products also meet accessibility standards.
 - [Accessibility Literacy](https://www.youtube.com/playlist?list=PLd9b-GuOJ3nFHykZgRBZ7_bzwfZ526rxm) — A DigitalGov playlist on YouTube
 - [Accessibility How-to](https://www.youtube.com/playlist?list=PLd9b-GuOJ3nH01BSXgJZv6uoCDJMyVvuT) — A second DigitalGov playlist on YouTube
+- [WCAG 2.0](https://www.w3.org/TR/WCAG20/) — This outlines the principles, guidelines, testable success criteria, and techniques needed to optimize content.
+- [W3C’s WCAG quick reference guide](https://www.w3.org/WAI/WCAG21/quickref/) — A compliance checklist; it will help you satisfy your Section 508 obligations. Be sure to review the white “Understanding” button given in each criteria section for more in-depth information. Remember: the success criteria are just the baseline. We are encouraged to surpass the values specified; not see them as a ceiling to build to.
+- [W3C’s Web Accessibility Initiative (WAI) perspective videos](https://www.w3.org/WAI/perspective-videos/) — A variety of short videos that give examples of different kinds of disabilities.
 - [How People with Disabilities Use the Web](https://www.w3.org/WAI/people-use-web/) — An introduction to how people with disabilities, including people with age-related impairments, use the Web. It describes assistive technology tools and approaches that people with different kinds of disabilities use to browse the Web (and the barriers they encounter due to poor design).
+- [Microsoft’s Inclusive Design Toolkit](https://download.microsoft.com/download/b/0/d/b0d4bf87-09ce-4417-8f28-d60703d672ed/inclusive_toolkit_manual_final.pdf) (PDF, 22 MB, 32 pages) — An approachable introduction to the history and principles of inclusive design ([they also have a full site about Inclusive Design](https://www.microsoft.com/design/inclusive/)).
 - [Web Almanac, Part II, Chapter 9: Accessibility](https://almanac.httparchive.org/en/2019/accessibility) - Covers additional topics, including readability, navigation, and form controls.
 
 _This introduction to accessibility was based on content created by the Technology Transformation Services (TTS) **Accessibility Guild**. Many thanks to former and current guild co-leads, **Nikki Lee (18F)** and **David Stenger (USAgov)**, and **Jacklynn Pham (18F)** and **Toni Bonitto (TTS Solutions)**, for creating and iterating on this!_

--- a/content/resources/intro-accessibility.md
+++ b/content/resources/intro-accessibility.md
@@ -20,7 +20,7 @@ This page is an introduction to why accessibility matters, and we hope that you 
 
 ## Accessibility is the Law
 
-[Section 508 Standards](https://www.access-board.gov/guidelines-and-standards/communications-and-it) are established and maintained by the [U. S. Access Board](https://www.access-board.gov/). Under Section 508 of the Rehabilitation Act of 1973, agencies must give disabled employees and members of the public access to information that is comparable to the access available to others.
+[Section 508 Standards](https://www.access-board.gov/guidelines-and-standards/communications-and-it/about-the-ict-refresh) are established and maintained by the [U. S. Access Board](https://www.access-board.gov/). Under Section 508 of the Rehabilitation Act of 1973, agencies must give disabled employees and members of the public access to information that is comparable to the access available to others.
 
 How do we get there? The shortest version is to make sure that everyone ensures that their products meet the minimum [Level-A](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_overview&versions=2.0&levels=aa%2Caaa#top) and [Level-AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_overview&versions=2.0&levels=a%2Caaa#top) Success Criteria (SC) of the Web Content Accessibility Guidelines (WCAG) — the globally recognized guidelines for creating accessible digital experiences from the [World Wide Web Consortium](https://www.w3.org/) (W3C).
 


### PR DESCRIPTION
Fixing: https://github.com/GSA/digitalgov.gov/issues/1625

## what was fixed

- [x] changed the URL in the first sentence of the Accessibility is the Law section, "Section 508 Standards are established and maintained..." to https://www.access-board.gov/guidelines-and-standards/communications-and-it/about-the-ict-refresh
- [x] moved the GSA resources to the top of the Recommended Resources list, starting with Section508.gov

---

**Preview:** https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/digitalgov.gov/intro-access-edits/resources/intro-accessibility/
