### PR TITLE
Fixing the base URL path in share_tools

### DIFF
--- a/themes/digital.gov/layouts/partials/core/get_sharetools.html
+++ b/themes/digital.gov/layouts/partials/core/get_sharetools.html
@@ -3,13 +3,13 @@
 <section class="share_tools">
   <div class="grid-row">
     <div class="grid-col-4">
-      <a class="twitter" href="http://twitter.com/share?url={{- .Site.BaseURL -}}{{ .Permalink | absURL }}&amp;text={{ .Title }}"><i class="fab fa-twitter"></i></a>
+      <a class="twitter" href="http://twitter.com/share?url={{ .Permalink }}&amp;text={{ .Title }}"><i class="fab fa-twitter"></i></a>
     </div>
     <div class="grid-col-4">
-      <a class="facebook" href="http://www.facebook.com/sharer.php?u={{- .Site.BaseURL -}}{{ .Permalink | absURL }}&t={{ .Title | urlize }}"><i class="fab fa-facebook-f"></i></a>
+      <a class="facebook" href="http://www.facebook.com/sharer.php?u={{ .Permalink }}&t={{ .Title | urlize }}"><i class="fab fa-facebook-f"></i></a>
     </div>
     <div class="grid-col-4">
-      <a class="linkedin" href="https://www.linkedin.com/shareArticle?mini=true&url={{- .Site.BaseURL -}}{{ .Permalink | absURL }}&title={{ .Title | urlize }}&summary={{ .Params.summary | urlize }}&source={{ "Digital.gov" | urlize }}"><i class="fab fa-linkedin-in"></i></a>
+      <a class="linkedin" href="https://www.linkedin.com/shareArticle?mini=true&url={{ .Permalink }}&title={{ .Title | urlize }}&summary={{ .Params.summary | urlize }}&source={{ "Digital.gov" | urlize }}"><i class="fab fa-linkedin-in"></i></a>
     </div>
   </div>
   <div class="grid-row">

--- a/themes/digital.gov/layouts/partials/core/get_sharetools.html
+++ b/themes/digital.gov/layouts/partials/core/get_sharetools.html
@@ -3,13 +3,13 @@
 <section class="share_tools">
   <div class="grid-row">
     <div class="grid-col-4">
-      <a class="twitter" href="http://twitter.com/share?url={{- $.Site.BaseURL -}}{{ .Permalink | absURL }}&amp;text={{ .Title }}"><i class="fab fa-twitter"></i></a>
+      <a class="twitter" href="http://twitter.com/share?url={{- .Site.BaseURL -}}{{ .Permalink | absURL }}&amp;text={{ .Title }}"><i class="fab fa-twitter"></i></a>
     </div>
     <div class="grid-col-4">
-      <a class="facebook" href="http://www.facebook.com/sharer.php?u={{- $.Site.BaseURL -}}{{ .Permalink | absURL }}&t={{ .Title | urlize }}"><i class="fab fa-facebook-f"></i></a>
+      <a class="facebook" href="http://www.facebook.com/sharer.php?u={{- .Site.BaseURL -}}{{ .Permalink | absURL }}&t={{ .Title | urlize }}"><i class="fab fa-facebook-f"></i></a>
     </div>
     <div class="grid-col-4">
-      <a class="linkedin" href="https://www.linkedin.com/shareArticle?mini=true&url={{- $.Site.BaseURL -}}{{ .Permalink | absURL }}&title={{ .Title | urlize }}&summary={{ .Params.summary | urlize }}&source={{ "Digital.gov" | urlize }}"><i class="fab fa-linkedin-in"></i></a>
+      <a class="linkedin" href="https://www.linkedin.com/shareArticle?mini=true&url={{- .Site.BaseURL -}}{{ .Permalink | absURL }}&title={{ .Title | urlize }}&summary={{ .Params.summary | urlize }}&source={{ "Digital.gov" | urlize }}"><i class="fab fa-linkedin-in"></i></a>
     </div>
   </div>
   <div class="grid-row">


### PR DESCRIPTION
**Fixes** https://github.com/GSA/digitalgov.gov/issues/1643

This fixes the BASE URL in the social media share tools.
Unfortunately, it might not be visible till it is on the LIVE site.

---

**Preview:** 
