### PR TITLE
Fixing the email link on all pages

### DIFF
--- a/themes/digital.gov/layouts/partials/core/get_sharetools.html
+++ b/themes/digital.gov/layouts/partials/core/get_sharetools.html
@@ -14,7 +14,7 @@
   </div>
   <div class="grid-row">
     <div class="grid-col-6">
-      <a class="email" href="mailto:?subject=Digital.gov%20%7C%20{{ .Title | urlize }}&body=%20%20{{ .Title | urlize }}%0A{{ .Permalink }}%2F%0A-------------%0A%0A&#9829; Sign-up%20for%20our%20newsletter%3A%20https%3A%2F%2Fdigital.gov%2Fsubscribe%2F"><i class="fas fa-envelope"></i> Email</a>
+      <a class="email" href="mailto:?subject=Digital.gov%20%7C%20{{ .Title | urlize }}&body=%20%20{{ .Title | urlize }}%0A{{ .Permalink }}%2F%3Fem0A-------------%0A%0A&#9829; Sign-up%20for%20our%20newsletter%3A%20https%3A%2F%2Fdigital.gov%2Fsubscribe%2F"><i class="fas fa-envelope"></i> Email</a>
     </div>
     <div class="grid-col-6">
       <a class="print" href="javascript:window.print()" onclick="window.print();return false;"><i class="fas fa-print"></i> Print</a>

--- a/themes/digital.gov/layouts/partials/core/get_sharetools.html
+++ b/themes/digital.gov/layouts/partials/core/get_sharetools.html
@@ -14,7 +14,7 @@
   </div>
   <div class="grid-row">
     <div class="grid-col-6">
-      <a target="_blank" title="Email this page" class="email" href="mailto:?subject=Digital.gov%20%7C%20{{ .Title }}&body=%20%20%0A-------------%0A{{ .Title }}%0A{{ .Site.BaseURL }}{{ .Permalink }}%2F%3Fem0A-------------%0A%0A&#9829; Sign-up%20for%20our%20newsletter%3A%20https%3A%2F%2Fdigital.gov%2Fsubscribe%2F"><i class="fas fa-envelope"></i> Email</a>
+      <a target="_blank" title="Email this page" class="email" href="mailto:?subject=Digital.gov%20%7C%20{{ .Title }}&body=%20%20%0A-------------%0A{{ .Title }}%0A{{ .Site.BaseURL }}{{ .Permalink }}%3Fem%0A-------------%0A%0A&#9829; Sign-up%20for%20our%20newsletter%3A%20https%3A%2F%2Fdigital.gov%2Fsubscribe%2F"><i class="fas fa-envelope"></i> Email</a>
     </div>
     <div class="grid-col-6">
       <a class="print" href="javascript:window.print()" onclick="window.print();return false;"><i class="fas fa-print"></i> Print</a>

--- a/themes/digital.gov/layouts/partials/core/get_sharetools.html
+++ b/themes/digital.gov/layouts/partials/core/get_sharetools.html
@@ -14,7 +14,7 @@
   </div>
   <div class="grid-row">
     <div class="grid-col-6">
-      <a target="_blank" title="Email this page" class="email" href="mailto:?subject=Digital.gov%20%7C%20{{ .Title }}&body=%20%20{{ .Title }}%0A{{ .Permalink }}%2F%3Fem0A-------------%0A%0A&#9829; Sign-up%20for%20our%20newsletter%3A%20https%3A%2F%2Fdigital.gov%2Fsubscribe%2F"><i class="fas fa-envelope"></i> Email</a>
+      <a target="_blank" title="Email this page" class="email" href="mailto:?subject=Digital.gov%20%7C%20{{ .Title }}&body=%20%20%0A-------------%0A{{ .Title }}%0A{{ .Site.BaseURL }}{{ .Permalink }}%2F%3Fem0A-------------%0A%0A&#9829; Sign-up%20for%20our%20newsletter%3A%20https%3A%2F%2Fdigital.gov%2Fsubscribe%2F"><i class="fas fa-envelope"></i> Email</a>
     </div>
     <div class="grid-col-6">
       <a class="print" href="javascript:window.print()" onclick="window.print();return false;"><i class="fas fa-print"></i> Print</a>

--- a/themes/digital.gov/layouts/partials/core/get_sharetools.html
+++ b/themes/digital.gov/layouts/partials/core/get_sharetools.html
@@ -14,7 +14,7 @@
   </div>
   <div class="grid-row">
     <div class="grid-col-6">
-      <a class="email" href="#"><i class="fas fa-envelope"></i> Email</a>
+      <a class="email" href="mailto:?subject=Digital.gov%20%7C%20{{ .Title | urlize }}&body=%20%20{{ .Title | urlize }}%0A{{ .Permalink }}%2F%0A-------------%0A%0A&#9829; Sign-up%20for%20our%20newsletter%3A%20https%3A%2F%2Fdigital.gov%2Fsubscribe%2F"><i class="fas fa-envelope"></i> Email</a>
     </div>
     <div class="grid-col-6">
       <a class="print" href="javascript:window.print()" onclick="window.print();return false;"><i class="fas fa-print"></i> Print</a>

--- a/themes/digital.gov/layouts/partials/core/get_sharetools.html
+++ b/themes/digital.gov/layouts/partials/core/get_sharetools.html
@@ -14,7 +14,7 @@
   </div>
   <div class="grid-row">
     <div class="grid-col-6">
-      <a target="_blank" title="Email this page" class="email" href="mailto:?subject=Digital.gov%20%7C%20{{ .Title }}&body=%20%20%0A-------------%0A{{ .Title }}%0A{{ .Site.BaseURL }}{{ .Permalink }}%3Fem%0A-------------%0A%0A&#9829; Sign-up%20for%20our%20newsletter%3A%20https%3A%2F%2Fdigital.gov%2Fsubscribe%2F"><i class="fas fa-envelope"></i> Email</a>
+      <a target="_blank" title="Email this page" class="email" href="mailto:?subject=Digital.gov%20%7C%20{{ .Title }}&body=%20%20%0A-------%0A{{ .Title }}%0A{{ .Site.BaseURL }}{{ .Permalink }}%3Fem%0A-------%0A%0A&#9829; Sign-up%20for%20the%20Digital.gov%20newsletter%3A%20https%3A%2F%2Fdigital.gov%2Fsubscribe%2F"><i class="fas fa-envelope"></i> Email</a>
     </div>
     <div class="grid-col-6">
       <a class="print" href="javascript:window.print()" onclick="window.print();return false;"><i class="fas fa-print"></i> Print</a>

--- a/themes/digital.gov/layouts/partials/core/get_sharetools.html
+++ b/themes/digital.gov/layouts/partials/core/get_sharetools.html
@@ -14,7 +14,7 @@
   </div>
   <div class="grid-row">
     <div class="grid-col-6">
-      <a target="_blank" title="Email this page" class="email" href="mailto:?subject=Digital.gov%20%7C%20{{ .Title }}&body=%20%20%0A-------%0A{{ .Title }}%0A{{ .Site.BaseURL }}{{ .Permalink }}%3Fem%0A-------%0A%0A&#9829; Sign-up%20for%20the%20Digital.gov%20newsletter%3A%20https%3A%2F%2Fdigital.gov%2Fsubscribe%2F"><i class="fas fa-envelope"></i> Email</a>
+      <a target="_blank" title="Email this page" class="email" href="mailto:?subject={{ .Title }}%20%7C%20Digital.gov&body=%20%20%0A-------%0A{{ .Title }}%0A{{ .Site.BaseURL }}{{ .Permalink }}%3Fem%0A-------%0A%0A&#9829; Sign-up%20for%20the%20Digital.gov%20newsletter%3A%20https%3A%2F%2Fdigital.gov%2Fsubscribe%2F"><i class="fas fa-envelope"></i> Email</a>
     </div>
     <div class="grid-col-6">
       <a class="print" href="javascript:window.print()" onclick="window.print();return false;"><i class="fas fa-print"></i> Print</a>

--- a/themes/digital.gov/layouts/partials/core/get_sharetools.html
+++ b/themes/digital.gov/layouts/partials/core/get_sharetools.html
@@ -14,7 +14,7 @@
   </div>
   <div class="grid-row">
     <div class="grid-col-6">
-      <a class="email" href="mailto:?subject=Digital.gov%20%7C%20{{ .Title }}&body=%20%20{{ .Title }}%0A{{ .Permalink }}%2F%3Fem0A-------------%0A%0A&#9829; Sign-up%20for%20our%20newsletter%3A%20https%3A%2F%2Fdigital.gov%2Fsubscribe%2F"><i class="fas fa-envelope"></i> Email</a>
+      <a target="_blank" title="Email this page" class="email" href="mailto:?subject=Digital.gov%20%7C%20{{ .Title }}&body=%20%20{{ .Title }}%0A{{ .Permalink }}%2F%3Fem0A-------------%0A%0A&#9829; Sign-up%20for%20our%20newsletter%3A%20https%3A%2F%2Fdigital.gov%2Fsubscribe%2F"><i class="fas fa-envelope"></i> Email</a>
     </div>
     <div class="grid-col-6">
       <a class="print" href="javascript:window.print()" onclick="window.print();return false;"><i class="fas fa-print"></i> Print</a>

--- a/themes/digital.gov/layouts/partials/core/get_sharetools.html
+++ b/themes/digital.gov/layouts/partials/core/get_sharetools.html
@@ -14,7 +14,7 @@
   </div>
   <div class="grid-row">
     <div class="grid-col-6">
-      <a class="email" href="mailto:?subject=Digital.gov%20%7C%20{{ .Title | urlize }}&body=%20%20{{ .Title | urlize }}%0A{{ .Permalink }}%2F%3Fem0A-------------%0A%0A&#9829; Sign-up%20for%20our%20newsletter%3A%20https%3A%2F%2Fdigital.gov%2Fsubscribe%2F"><i class="fas fa-envelope"></i> Email</a>
+      <a class="email" href="mailto:?subject=Digital.gov%20%7C%20{{ .Title }}&body=%20%20{{ .Title }}%0A{{ .Permalink }}%2F%3Fem0A-------------%0A%0A&#9829; Sign-up%20for%20our%20newsletter%3A%20https%3A%2F%2Fdigital.gov%2Fsubscribe%2F"><i class="fas fa-envelope"></i> Email</a>
     </div>
     <div class="grid-col-6">
       <a class="print" href="javascript:window.print()" onclick="window.print();return false;"><i class="fas fa-print"></i> Print</a>


### PR DESCRIPTION
Fixing: https://github.com/GSA/digitalgov.gov/issues/1637

This makes it possible for people to email the page to a friend.

```
Subject: Digital.gov | An Introduction to Accessibility
```

```
An Introduction to Accessibility
https://digital.gov/resources/required-web-content-and-links/?em
-------------

Sign-up for our newsletter: https://digital.gov/subscribe/


```

---

**Preview:** 
