### PR TITLE
Fixing terms text across communities

### DIFF
--- a/content/communities/artificial-intelligence.md
+++ b/content/communities/artificial-intelligence.md
@@ -23,9 +23,8 @@ community_list:
     type: government
     subscribe_email: "AI-subscribe-request@listserv.gsa.gov"
     subscribe_email_subject: "AI Listserv"
-    terms: "Open to anyone with a .gov or .mil email address."
     members: 476
-    emails_per_week: 
+    emails_per_week:
 
 # Make it better ♥
 

--- a/content/communities/devops.md
+++ b/content/communities/devops.md
@@ -27,7 +27,6 @@ community_list:
     type: government
     subscribe_email: "devops-today-subscribe-request@listserv.gsa.gov"
     subscribe_email_subject: "Subscribe to DevOps"
-    terms: "Open to anyone with a .gov or .mil email address."
     members: 297
     emails_per_week:
   - platform: listserv

--- a/content/communities/mobilegov.md
+++ b/content/communities/mobilegov.md
@@ -26,7 +26,6 @@ weight: 1
 community_list:
   - platform: listserv
     type: government
-    terms: "Federal employees can send an [email to David Fern](mailto:mobilegov-request@listserv.gsa.gov) with “Subscribe to MobileGov” in the subject line."
     subscribe_email: "mobilegov-request@listserv.gsa.gov"
     subscribe_email_subject: "Subscribe to MobileGov"
     members: 1070

--- a/content/communities/multilingual.md
+++ b/content/communities/multilingual.md
@@ -19,7 +19,6 @@ community_list:
     subscribe_email: laura.godfrey@gsa.gov
     subscribe_email_subject: "Join: Multilingual"
     subscribe_form: "https://docs.google.com/forms/d/e/1FAIpQLSfUmDyzqqzRnvh1pAuPzZsYg-3BIwT7H6xVt-c7r4eHfjum_A/viewform?formkey=dHI0aTEwWXh2NURMR0gzR3ozVlJ2T2c6MQ"
-    terms: "All government employees (federal, state, local, tribal) or contractors with a .gov or .mil email address are eligible to join."
     members: 267
     emails_per_week: 1.33
 

--- a/content/communities/open-gov.md
+++ b/content/communities/open-gov.md
@@ -11,11 +11,10 @@ aliases:
 weight: 1
 community_list:
   - platform: "google-group"
-    type: "Public"
+    type: public
     subscribe_form: "https://groups.google.com/forum/#!forum/us-open-government"
-    terms: "Anyone is welcome to join."
   - platform: "listserv"
-    type: "Government only"
+    type: government
     subscribe_email: opengov-subscribe-request@listserv.gsa.gov
     subscribe_email_subject: "Join: OpenGov"
     members: 232

--- a/content/communities/plain-language-community-of-practice.md
+++ b/content/communities/plain-language-community-of-practice.md
@@ -17,7 +17,6 @@ community_list:
   - platform: "listserv"
     type: government
     subscribe_form: "https://listserv.gsa.gov/cgi-bin/wa.exe?SUBED1=PL-COP-MAIN"
-    terms: "*You'll need to [register for an account](https://listserv.gsa.gov/cgi-bin/wa.exe?GETPW1=SUBED1%3DPL-COP-MAIN&X=&Y=) before filling out our form. Open to anyone with a .gov or .mil email address."
     members: 1104
     emails_per_week: 1.1
 

--- a/content/communities/results-oriented-accountability-for-grants.md
+++ b/content/communities/results-oriented-accountability-for-grants.md
@@ -6,18 +6,17 @@ summary: "Our community engages stakeholders around the President’s Management
 weight: 1
 community_list:
   - platform: "listserv"
-    type: "Government only"
+    type: government
     subscribe_email: grantsfed-subscribe-request@listserv.gsa.gov
     subscribe_email_subject: "Federal Join: Results-Oriented Accountability for Grants Community of Practice"
     members: 539
     emails_per_week: .3
   - platform: "listserv"
-    type: "Public"
+    type: public
     subscribe_email: grantscommunity-subscribe-request@listserv.gsa.gov
     subscribe_email_subject: "Non-Federal Join: Results-Oriented Accountability for Grants Community of Practice"
-    terms: "Anyone is welcome to join"
-    members: 
-    emails_per_week: 
+    members:
+    emails_per_week:
 
 ---
 

--- a/content/communities/rpa-community.md
+++ b/content/communities/rpa-community.md
@@ -22,7 +22,6 @@ community_list:
   - platform: listserv
     type: government
     subscribe_email: "FedRPA-subscribe-request@listserv.gsa.gov"
-    terms: "Open to anyone with a .gov or .mil email address."
     members: 721
     emails_per_week:
 

--- a/content/communities/uswds.md
+++ b/content/communities/uswds.md
@@ -33,7 +33,6 @@ community_list:
     subscribe_email: uswds@gsa.gov
     subscribe_email_subject: "Join USWDS Slack"
     subscribe_form: https://chat.18f.gov/
-    terms: "Open to the public."
     members: 114
     emails_per_week:
 


### PR DESCRIPTION
## Fixes 
- https://github.com/GSA/digitalgov.gov/issues/1681
- https://github.com/GSA/digitalgov.gov/issues/1680

This removes the `terms: ` text from the communities, which is now a default setting in the template.

## Logic

**if the community type** is `type: government` —
- use "Open to anyone with a .gov or .mil email address."

**if the community type** is `type: public` —
- use "Open to the public."

### Override

If you do use `type: "something"`, it will override the default.

---

**Preview:** 
