### PR TITLE
fixing layout on some resource pages

### DIFF
--- a/content/resources/federal-compatible-terms-of-service-agreements.md
+++ b/content/resources/federal-compatible-terms-of-service-agreements.md
@@ -2,7 +2,6 @@
 url: /resources/federal-compatible-terms-of-service-agreements/
 date: 2014-01-09 2:40:58 -0400
 title: Federal-Compatible Terms of Service Agreements
-type: guide
 guidenav: termsofservice
 summary: 'Agreements negotiated between the federal government and vendors who offer digital tools and services.'
 deck: "A guide to the agreements negotiated between the federal government and vendors who offer digital tools and services."

--- a/content/resources/federal-web-council.md
+++ b/content/resources/federal-web-council.md
@@ -4,7 +4,6 @@ date: 2019-06-25 9:00:00 -0400
 title: "Federal Web Council"
 summary: "A cross-agency group that is working together to improve the delivery of U.S. government information and services online."
 deck: "A cross-agency group that is working to improve the delivery of government information and digital services."
-type: guide
 
 ---
 

--- a/content/resources/getting-started-with-your-contact-center.md
+++ b/content/resources/getting-started-with-your-contact-center.md
@@ -2,7 +2,6 @@
 slug: contact-center-guidelines/getting-started-with-your-contact-center
 date: 2014-02-05 10:25:54 -0400
 title: 'Getting Started with your Contact Center'
-type: guide
 summary: 'This guide provides you with the information to get a governement contact center started'
 deck: 'Planning and creating a successful government contact center is a complex endeavor. This guide will provide you with the information and tools to get you started.'
 topics:

--- a/content/resources/guide-create-mobile-friendly-websites.md
+++ b/content/resources/guide-create-mobile-friendly-websites.md
@@ -5,7 +5,6 @@ title: 'A Guide to Creating Mobile-Friendly Websites'
 summary: 'Based on a recent six-month study, this guide outlines the top five practices needed to improve the mobile-friendliness of federal websites&#58; the optimization of JavaScript, CSS, and images, caching, and pop-ups&#46;'
 featured_image:
   uid: army-mobile
-type: guide
 topics:
   - mobile
   - strategy
@@ -19,7 +18,7 @@ JavaScript usage, CSS usage, image and resource sizing, caching/network usage, a
 
 For six months, from September 22, 2017 to March 22, 2018, the [Federal Crowdsource Mobile Testing Program](https://digital.gov/services/mobile-application-testing-program/) tested the 26 U.S. federal government websites that are most visited on mobile devices (smartphones and tablets) using seven mobile-friendly automated test tools. The results indicated that these were the common practices that make these sites not as mobile-friendly as a user might expect or want in a mobile experience. Most of these areas do not directly relate to usability issues, but instead, concern how the site is built (which can lead to poor performance). For more information on how we conducted the tests, see the Methodology section at the end.
 
-The information here outlines the top five practices we found across these sites: 
+The information here outlines the top five practices we found across these sites:
 
 <ol>
   <li><strong>Optimize JavaScript</strong> </li>
@@ -49,7 +48,7 @@ The information here outlines the top five practices we found across these sites
   <li><strong>Avoid Pop-ups</strong> </li>
 </ol>
 
-Keep in mind, if a website is developed using a content management system (CMS) or development framework, not all of these settings may be configurable. However, we suggest that developers research the capabilities of the system to determine if they can be. Some of these recommendations may occur in the web server layer, which may be separate from the program code. 
+Keep in mind, if a website is developed using a content management system (CMS) or development framework, not all of these settings may be configurable. However, we suggest that developers research the capabilities of the system to determine if they can be. Some of these recommendations may occur in the web server layer, which may be separate from the program code.
 
 {{< img src="army-mobile" >}}
 

--- a/content/resources/intro-accessibility.md
+++ b/content/resources/intro-accessibility.md
@@ -3,7 +3,6 @@ url: /resources/intro-accessibility/
 date: 2019-12-04 9:00:00 -0400
 title: "Intro to Accessibility"
 summary: "An introduction to accessibility, and why it matters."
-type: guide
 featured_image:
   uid: accessibility-101-card
 authors:

--- a/content/resources/mobile-user-experience-guidelines-and-recommendations.md
+++ b/content/resources/mobile-user-experience-guidelines-and-recommendations.md
@@ -4,7 +4,6 @@ date: 2013-12-11 4:13:00 -0400
 title: Mobile User Experience Guidelines
 summary: 'Six user experience guidelines for creating a mobile product.'
 deck: 'Six user experience guidelines for creating a mobile product.'
-type: guide
 guidenav: connected-government
 authors:
   - jparcell

--- a/content/resources/negotiated-terms-of-service-agreements.md
+++ b/content/resources/negotiated-terms-of-service-agreements.md
@@ -3,7 +3,6 @@ url: /resources/negotiated-terms-of-service-agreements/
 date: 2014-01-13 10:50:02 -0400
 uid: negotiated-terms-of-service-agreements
 title: 'Negotiated Terms of Service Agreements'
-type: guide
 guide: terms-of-service
 summary: 'The list of free tools that have federal-compatible terms of service agreements.'
 deck: 'A list of free tools that have federal-compatible terms of service agreements.'


### PR DESCRIPTION
### Fixing https://github.com/GSA/digitalgov.gov/issues/1690

Some of the resource pages had `type: guide` in them, which is causing them to break.
This change removes that.

- https://digital.gov/resources/intro-accessibility/
- /resources/federal-compatible-terms-of-service-agreements/




---

**Preview:** 
