### PR TITLE
Fixing typo in topics API

### DIFF
--- a/content/communities/rpa-community.md
+++ b/content/communities/rpa-community.md
@@ -11,7 +11,6 @@ summary: "We are a group who is working to accelearate robotic process automatio
 # see all topics at https://digital.gov/topics
 topics:
   - emerging-tech
-  - rpa
 
 # Page weight: controls how this page appears across the site
 # 0 -- hidden

--- a/content/posts/2019/06/2019-06-18-introducing-a-guide-paperwork-reduction-act.md
+++ b/content/posts/2019/06/2019-06-18-introducing-a-guide-paperwork-reduction-act.md
@@ -11,7 +11,7 @@ authors:
   - sharon-mar
   - jeremyzilar
 topics:
-  - managing-digital
+  - product-management
   - pra
   - policy
 

--- a/content/services/service_logingov.md
+++ b/content/services/service_logingov.md
@@ -27,7 +27,7 @@ topics:
   - login-gov
   - product-management
   - security
-  - authenication
+  - authentication
   - online-proofing
 
 

--- a/content/sources/source_logingov.md
+++ b/content/sources/source_logingov.md
@@ -30,7 +30,7 @@ topics:
   - login-gov
   - product-management
   - security
-  - authenication
+  - authentication
   - online-proofing
 
 ---


### PR DESCRIPTION
Fixing typo in topics "authentication" which will fix the Topics API —https://digital.gov/topics/v1/json/

---

**Preview:** https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/digitalgov.gov/fixing-authentication/topics/v1/json/
