### PR TITLE
New resources: Eight Principles of Mobile-Friendliness

### DIFF
--- a/content/resources/an-introduction-us-web-design-system.md
+++ b/content/resources/an-introduction-us-web-design-system.md
@@ -1,7 +1,6 @@
 ---
-slug: /resources/an-introduction-us-web-design-system
+slug: an-introduction-us-web-design-system
 date: 2019-04-11 23:37:00 -0500
-
 title: 'An Introduction to USWDS 2.0'
 deck: 'A design system for the federal government'
 summary: 'A design system for the federal government that makes it easier to build accessible, mobile-friendly government websites for the American public'

--- a/content/resources/customer-experience-toolkit.md
+++ b/content/resources/customer-experience-toolkit.md
@@ -3,7 +3,6 @@ slug: customer-experience-toolkit
 date: 2016-01-07 5:52:31 -0400
 title: Customer Experience Toolkit
 summary: 'Customer Experience (CX) is defined as the sum of all experiences a customer has with your organization. Since government is often a sole-source service provider (e.g., there&rsquo;s only one place to pay taxes, or get a driver&rsquo;s license), CX is even more important in the public sector than in other organizations. If that&rsquo;s not enough'
-weight: 3
 topics:
   - cx
 authors:

--- a/content/resources/eight-principles-mobile-friendliness
+++ b/content/resources/eight-principles-mobile-friendliness
@@ -1,0 +1,27 @@
+---
+# View this page at https://digital.gov/resources/eight-principles-mobilefriendliness
+# Learn how to edit our pages at https://workflow.digital.gov
+
+slug: eight-principles-mobile-friendliness
+date: 2019-12-19 14:000:00 -0500
+title: "Eight Principles of Mobile-Friendliness"
+deck: "In order to help agencies comply with mobile website requirements, we will share a principle of mobile-friendliness each week for eight weeks&mdash;and how adhering to these principles can greatly improve their sites."
+summary: "In order to help agencies comply with mobile website requirements, we will share a principle of mobile-friendliness each week for eight weeks&mdash;and how adhering to these principles can greatly improve their sites."
+
+# originally published at the following URL
+source_url: "https://digital.gov/guide/mobile-principles/"
+
+# Which team published this?
+# Learn about sources at https://workflow.digital.gov/sources
+source: digitalgov
+
+# see all topics at https://digital.gov/topics
+topics:
+  - mobile
+
+# see all authors at https://digital.gov/authors
+authors: 
+  - david-fern
+
+# Make it better ♥
+---

--- a/content/resources/eight-principles-mobile-friendliness.md
+++ b/content/resources/eight-principles-mobile-friendliness.md
@@ -5,8 +5,12 @@
 slug: eight-principles-mobile-friendliness
 date: 2019-12-19 14:000:00 -0500
 title: "Eight Principles of Mobile-Friendliness"
-deck: "In order to help agencies comply with mobile website requirements, we will share a principle of mobile-friendliness each week for eight weeks&mdash;and how adhering to these principles can greatly improve their sites."
-summary: "In order to help agencies comply with mobile website requirements, we will share a principle of mobile-friendliness each week for eight weeks&mdash;and how adhering to these principles can greatly improve their sites."
+deck: "In order to help agencies comply with mobile website requirements, we will share a principle of mobile-friendliness each week for eight weeks—and how adhering to these principles can greatly improve their sites."
+summary: "In order to help agencies comply with mobile website requirements, we will share a principle of mobile-friendliness each week for eight weeks—and how adhering to these principles can greatly improve their sites."
+
+topics:
+  - product-management
+  - mobile
 
 # originally published at the following URL
 source_url: "https://digital.gov/guide/mobile-principles/"
@@ -15,12 +19,8 @@ source_url: "https://digital.gov/guide/mobile-principles/"
 # Learn about sources at https://workflow.digital.gov/sources
 source: digitalgov
 
-# see all topics at https://digital.gov/topics
-topics:
-  - mobile
-
 # see all authors at https://digital.gov/authors
-authors: 
+authors:
   - david-fern
 
 # Make it better ♥

--- a/content/resources/eight-principles-mobile-friendliness.md
+++ b/content/resources/eight-principles-mobile-friendliness.md
@@ -5,8 +5,8 @@
 slug: eight-principles-mobile-friendliness
 date: 2019-12-19 14:000:00 -0500
 title: "Eight Principles of Mobile-Friendliness"
-deck: "In order to help agencies comply with mobile website requirements, we will share a principle of mobile-friendliness each week for eight weeks—and how adhering to these principles can greatly improve their sites."
-summary: "In order to help agencies comply with mobile website requirements, we will share a principle of mobile-friendliness each week for eight weeks—and how adhering to these principles can greatly improve their sites."
+deck: "Following these principles will help you make your site more usable and user-friendly."
+summary: "Following these principles will help you make your site more usable and user-friendly."
 
 topics:
   - product-management

--- a/content/resources/eight-principles-mobile-friendliness.md
+++ b/content/resources/eight-principles-mobile-friendliness.md
@@ -23,5 +23,6 @@ source: digitalgov
 authors:
   - david-fern
 
+weight: 3
 # Make it better ♥
 ---

--- a/content/sources/source_digitalgov.md
+++ b/content/sources/source_digitalgov.md
@@ -14,7 +14,7 @@ domain: 'https://demo.digital.gov'
 
 # To find the favicon, view source on the page you're pointing to and search for "favicon" or "icon". The path to the icon should be near the top.
 # Copy and paste that full path here:
-icon: "digit-indigo.png"
+icon: "digit-150.png"
 
 # Weight: control how services appear across the site
 # 2 == will be part of the rotation on the homepage


### PR DESCRIPTION
At the moment, we don't have a great way to add "Guides" to the topics pages.

So I am adding this page as a resource, but setting it to pointing to the Guide page directly in the same way that I would do for an external URL — https://digital.gov/guide/mobile-principles/

---

**Preview:** 
