### PR TITLE
Updating the December USWDS Call Youtube Link

### DIFF
--- a/content/events/2019/12/2019-12-19-uswds-december-monthly-call.md
+++ b/content/events/2019/12/2019-12-19-uswds-december-monthly-call.md
@@ -10,8 +10,7 @@ date: 2019-12-19 14:30:00 -0500
 end_date: 2019-12-19 15:30:00 -0500
 event_organizer: DigitalGov University
 host: U.S. Web Design System
-registration_url: https://www.eventbrite.com/e/us-web-design-system-december-monthly-call-registration-83901699241
-youtube_id:
+youtube_id: iTEI1JTHt_Q&t=
 captions: 
 
 ---

--- a/content/events/2019/12/2019-12-19-uswds-december-monthly-call.md
+++ b/content/events/2019/12/2019-12-19-uswds-december-monthly-call.md
@@ -10,7 +10,7 @@ date: 2019-12-19 14:30:00 -0500
 end_date: 2019-12-19 15:30:00 -0500
 event_organizer: DigitalGov University
 host: U.S. Web Design System
-youtube_id: iTEI1JTHt_Q&t=
+youtube_id: iTEI1JTHt_Q
 captions: 
 
 ---


### PR DESCRIPTION
Here is the CORRECT youtube link for the december monthly call: https://www.youtube.com/watch?v=iTEI1JTHt_Q

Thank you!


A one-line description of the changes you're making and how they'll affect users.

---

**Preview:** 
https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/digitalgov.gov/DanielJPino-ux-patch-8/event/2019/12/19/uswds-december-monthly-call/