### PR TITLE
Agile CoP - fix subject line

### DIFF
--- a/content/communities/agile-lean.md
+++ b/content/communities/agile-lean.md
@@ -33,7 +33,7 @@ community_list:
   - platform: listserv
     type: government
     subscribe_email: "listserv@listserv.gsa.gov"
-    subscribe_email_subject: "Join: Accessibility / Section 508"
+    subscribe_email_subject: ""
     subscribe_email_body: "subscribe agile-lean-cop"
     members: 509
     emails_per_week: 1.58


### PR DESCRIPTION
Removed "Join: Accessibility / Section 508" from subject line in left column; wrong Community, and no subject line is required. See http://web.archive.org/web/20191213183020/https://digital.gov/communities/agile-lean/

---

**Preview:** 
https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/digitalgov.gov/fix-subject-line/communities/agile-lean/ 