### PR TITLE
Adding authors to event pages

### DIFF
--- a/themes/digital.gov/layouts/events/single.html
+++ b/themes/digital.gov/layouts/events/single.html
@@ -137,6 +137,13 @@
           </div>
 
           <div class="grid-col-12 tablet:grid-col-3">
+
+            {{/* Authors */}}
+            {{- if .Params.authors -}}
+            <h4>In this talk</h4>
+            {{- partial "core/get_authors" . -}}
+            {{- end -}}
+
             {{- if eq .Params.event_platform "youtube_live" -}}
               {{- if eq $future_event true -}}
               <div class="actions actions-stacked">


### PR DESCRIPTION
This adds in the list of "authors" to event pages.

If there are authors listed in the event page, it will display them.

![image](https://user-images.githubusercontent.com/395641/71922710-78fe3f00-3159-11ea-8500-3623fc01edb9.png)

Thoughts on the **"In this talk"** heading? 


---

**Preview:** https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/digitalgov.gov/authors-events/event/2020/01/08/plain-language-in-2020/
