### PR TITLE
adding in a redirect

### DIFF
--- a/content/posts/2014/12/2014-12-08-from-taste-testers-to-explorers-developing-personas-for-open-opportunities.md
+++ b/content/posts/2014/12/2014-12-08-from-taste-testers-to-explorers-developing-personas-for-open-opportunities.md
@@ -1,16 +1,31 @@
 ---
+# View this page at https://digital.gov/2014/12/08/from-tastetesters-explorers-developing-personas-for
+# Learn how to edit our pages at https://workflow.digital.gov
+
 slug: from-taste-testers-to-explorers-developing-personas-for-open-opportunities
-date: 2014-12-08 10:00:45 -0400
-title: 'From Taste-Testers to Explorers: Developing Personas for Open Opportunities'
-summary: 'Being customer-focused means doing the gumshoe work of research and rounds of analysis to find gold by understanding user goals. For the task-based innovation network, Open Opportunities for DigitalGov, that meant developing personas in order to overcome our own biases and learn about the different motivations of our participants. In this article, we&#8217;ll talk about'
-authors:
-  - lnelson
-  - awichman
-topics:
+date: 2014-12-08 9:00:00 -0500
+kicker: "Open Opportunities"
+title: "From Taste-Testers to Explorers: Developing Personas for Open Opportunities"
+deck: ""
+summary: "Being customer-focused means doing the gumshoe work of research and rounds of analysis to find gold by understanding user goals. For the task-based innovation network, Open Opportunities for DigitalGov, that meant developing personas in order to overcome our own biases and learn about the different motivations of our participants. In this article, we’ll talk about"
+
+# see all topics at https://digital.gov/topics
+topics: 
   - content
-  - our-work
   - open-opportunities-program
+  - our-work
   - personas
+
+# see all authors at https://digital.gov/authors
+authors: 
+  - awichman
+  - lnelson
+
+# Redirects: enter the path of the URL that you want redirected to this page
+aliases: 
+  - /2014/12/08/from-taste-testers-to-explorers-developing-personas-for-open-opportunities.md
+
+# Make it better ♥
 ---
 
 Being customer-focused means doing the gumshoe work of research and rounds of analysis to find gold by understanding user goals. For the task-based innovation network, [Open Opportunities for DigitalGov]({{< ref "open-opportunities.md" >}}), that meant developing personas in order to overcome our own biases and learn about the different motivations of our participants. In this article, we&#8217;ll talk about how we created our personas and how we plan to use them to meet both innovators&#8217; and program needs.


### PR DESCRIPTION
# fixing https://github.com/GSA/digitalgov.gov/issues/276

Adds in a redirect and updates the front matter 

---

**Preview:** 

This: https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/digitalgov.gov/openops-redir/2014/12/08/from-taste-testers-to-explorers-developing-personas-for-open-opportunities.md

Should redirect to:
https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/digitalgov.gov/openops-redir/2014/12/08/from-taste-testers-to-explorers-developing-personas-for-open-opportunities/
