### PR TITLE
Add Support for Primary Image

### DIFF
--- a/content/posts/2020/01/2020-01-08-a-look-at-new-gsagov.md
+++ b/content/posts/2020/01/2020-01-08-a-look-at-new-gsagov.md
@@ -21,8 +21,8 @@ topics:
 authors:
   - amanda-dean
 
-featured_image:
-  uid: gsa-uswds
+# Primary Image (for social media)
+primary_image: "gsa-uswds"
 
 # Make it better ♥
 
@@ -36,7 +36,7 @@ To kick us off, we’re sitting down with Patrick Son and Sarah Bryant from the 
 -   What were your biggest challenges?
 -   What surprised you?
 -   What did you accomplish?
--   What is your best piece of advice for others? 
+-   What is your best piece of advice for others?
 
 ## What We Did for GSA.gov
 

--- a/themes/digital.gov/layouts/_default/list.json.json
+++ b/themes/digital.gov/layouts/_default/list.json.json
@@ -92,6 +92,10 @@
         {{- end -}}
         },
       {{- end -}}
+
+
+      {{- partial "api/primary_image" . -}}
+
       {{- if .Params.featured_image -}}
       "featured_image" : {
         "uid" : "{{- .Params.featured_image.uid -}}",

--- a/themes/digital.gov/layouts/_default/single.json.json
+++ b/themes/digital.gov/layouts/_default/single.json.json
@@ -86,6 +86,9 @@
         {{- end -}}
         },
       {{- end -}}
+
+      {{- partial "api/primary_image" . -}}
+
       {{- if .Params.featured_image -}}
       "featured_image" : {
         "uid" : "{{- .Params.featured_image.uid -}}",

--- a/themes/digital.gov/layouts/communities/list.json.json
+++ b/themes/digital.gov/layouts/communities/list.json.json
@@ -126,6 +126,9 @@
           {{- end -}}
         },
       {{- end -}}
+
+      {{- partial "api/primary_image" . -}}
+      
       {{- if .Params.featured_image -}}
       "featured_image" : {
         "uid" : "{{- .Params.featured_image.uid -}}",

--- a/themes/digital.gov/layouts/communities/single.json.json
+++ b/themes/digital.gov/layouts/communities/single.json.json
@@ -121,6 +121,9 @@
           {{- end -}}
         },
       {{- end -}}
+
+      {{- partial "api/primary_image" . -}}
+      
       {{- if .Params.featured_image -}}
       "featured_image" : {
         "uid" : "{{- .Params.featured_image.uid -}}",

--- a/themes/digital.gov/layouts/events/list.json.json
+++ b/themes/digital.gov/layouts/events/list.json.json
@@ -127,6 +127,9 @@
         {{- end -}}
         },
       {{- end -}}
+
+      {{- partial "api/primary_image" . -}}
+      
       {{- if .Params.featured_image -}}
       "featured_image" : {
         "uid" : "{{- .Params.featured_image.uid -}}",

--- a/themes/digital.gov/layouts/events/single.json.json
+++ b/themes/digital.gov/layouts/events/single.json.json
@@ -120,6 +120,9 @@
         {{- end -}}
         },
       {{- end -}}
+
+      {{- partial "api/primary_image" . -}}
+
       {{- if .Params.featured_image -}}
       "featured_image" : {
         "uid" : "{{- .Params.featured_image.uid -}}",

--- a/themes/digital.gov/layouts/partials/api/primary_image.html
+++ b/themes/digital.gov/layouts/partials/api/primary_image.html
@@ -1,0 +1,12 @@
+{{- if .Params.primary_image -}}
+{{- $thisimg := index $.Site.Data.images (default ($.Scratch.Get "defaultimg") .Params.primary_image | lower) -}}
+"primary_image" : {
+  "uid" : "{{- .Params.primary_image -}}",
+  "alt" : "{{- if $thisimg.alt -}}{{- $thisimg.alt -}}{{- end -}}",
+  "width" : "{{- if $thisimg.width -}}{{- $thisimg.width -}}{{- end -}}",
+  "height" : "{{- if $thisimg.height -}}{{- $thisimg.height -}}{{- end -}}",
+  "credit" : "{{- if $thisimg.credit -}}{{- $thisimg.credit -}}{{- end -}}",
+  "caption" : "{{- if $thisimg.caption -}}{{- $thisimg.caption -}}{{- end -}}",
+  "format" : "{{- if $thisimg.format -}}{{- $thisimg.format -}}{{- end -}}"
+},
+{{- end -}}

--- a/themes/digital.gov/layouts/partials/core/head.html
+++ b/themes/digital.gov/layouts/partials/core/head.html
@@ -1,8 +1,22 @@
 <!-- Logic for featured image -->
 {{/* Featured_image call */}}
+
+  {{/* Sets a variable for $primary_image */}}
+  {{- $primary_image := "" -}}
+  {{/* Checks if $primary_image exists
+       if not, it will use the featured_image.
+  */}}
+  {{- if .Params.primary_image -}}
+    {{- $primary_image = .Params.primary_image -}}
+  {{- else -}}
+    {{- if .Params.featured_image.uid -}}
+      {{- $primary_image = .Params.featured_image.uid -}}
+    {{- end -}}
+  {{- end -}}
+
   {{- $cdnurl := .Site.Params.cdnurl -}}
   {{- $dg_filename := print "digitalgov-card-" (index (seq 3 | shuffle) 0) -}}
-  {{- $featImg := index $.Site.Data.images (default $dg_filename .Params.featured_image.uid) -}}
+  {{- $featImg := index $.Site.Data.images (default $dg_filename $primary_image) -}}
   {{- $featImgBase := $featImg.uid -}}
   {{- $featImgExt := $featImg.format -}}
   {{- $featImgBaseCDN := printf "%s/%s" $cdnurl $featImgBase -}}
@@ -50,7 +64,6 @@
 
   {{ "<!-- Page Title -->" | safeHTML }}
   {{- $pagetitle := (printf "%s %s" .Title " / ") -}}
-
   {{- if .Title -}}
   {{/* if is a post or a page with a title */}}
   {{/* Page title – Digital.gov */}}
@@ -71,8 +84,8 @@
   <meta property="og:type" content="{{- $.Scratch.Get "pagetype" -}}">
   <meta property="og:url" content="{{- .Permalink -}}" />
   <meta property="og:site_name" content="Digital.gov">
-  {{- if $featImgURL -}}<meta property="og:image" content="{{ $featImgURL }}" />{{- end -}}
-  {{ if $.Params.youtube_id }}<meta property='og:video' content='https://www.youtube.com/v/{{ $.Params.youtube_id }}' />{{ end }}
+  {{ if $featImgURL -}}<meta property="og:image" content="{{- $featImgURL -}}" />{{- end }}
+  {{ if $.Params.youtube_id }}<meta property='og:video' content='https://www.youtube.com/v/{{ $.Params.youtube_id }}' />{{- end }}
   <meta property="fb:admins" content="100000569454928" />
   <meta property="article:publisher" content="https://www.facebook.com/digitalgov" />
   {{- if $.Params.date -}}<meta property="article:published_time" content="{{ ($.Params.date).Format "2006-01-02T15:04:05" }}-0500" />{{- end }}
@@ -82,7 +95,7 @@
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:site" content="@Digital_Gov" />
   <meta name="twitter:creator" content="@Digital_Gov" />
-  {{ if $featImgURL }}<meta name="twitter:image:src" content="{{- $featImgURL -}}">{{ end }}
+  {{ if $featImgURL -}}<meta name="twitter:image:src" content="{{- $featImgURL -}}">{{- end }}
   <meta property="twitter:description" content="{{- $.Params.summary | default $.Site.Params.description | markdownify -}}">
   <meta property="twitter:title" content="{{- $.Params.title | default $.Site.Title | markdownify -}}">
   {{ "<!-- End of Twitter -->" | safeHTML }}

--- a/themes/digital.gov/layouts/partials/core/img-featured.html
+++ b/themes/digital.gov/layouts/partials/core/img-featured.html
@@ -1,7 +1,21 @@
 {{- $cdnurl := .Site.Params.cdnurl -}}
-{{- if .Params.featured_image.uid -}}
+
+{{/* Sets a variable for $primary_image */}}
+{{- $primary_image := "" -}}
+{{/* Checks if $primary_image exists
+     if not, it will use the featured_image.
+*/}}
+{{- if .Params.primary_image -}}
+  {{- $primary_image = .Params.primary_image -}}
+{{- else -}}
+  {{- if .Params.featured_image.uid -}}
+    {{- $primary_image = .Params.featured_image.uid -}}
+  {{- end -}}
+{{- end -}}
+
+{{- if $primary_image -}}
   {{- $.Scratch.Set "defaultimg" "default" -}}
-  {{- $thisimg := index $.Site.Data.images (default ($.Scratch.Get "defaultimg") .Params.featured_image.uid | lower) -}}
+  {{- $thisimg := index $.Site.Data.images (default ($.Scratch.Get "defaultimg") $primary_image | lower) -}}
   {{- $imgBase := $thisimg.uid -}}
   {{- $imgExt := $thisimg.format -}}
   {{- $imgBaseCDN := printf "%s/%s" $cdnurl $imgBase -}}


### PR DESCRIPTION
This change will move us away from the the use of `featured_image` in posts, in favor of `primary_image`

We are moving from:
```
featured_image:
  uid: digitalgov-new-2019
  alt: ''

```

to

```
# Primary Image (for social media)
primary_image: "gsa-uswds"
```

## why this change?
- we don't need the additional `alt` field in the front matter
- it will be easier to support editing this in workflow, and in GitHub
- fewer bits to manage


At the moment, it checks to see if there is a `primary_image` and uses that.
If not, it will check to see if there is a `featured_image`.

Once this change is out and working, I can open a separate PR to change all of the `featured_image` in our pages to `primary_image`.

---

**Preview:** 
