### PR TITLE
adding captions to APIs

### DIFF
--- a/themes/digital.gov/layouts/events/list.json.json
+++ b/themes/digital.gov/layouts/events/list.json.json
@@ -81,6 +81,8 @@
       "registration_url" : "{{- .Params.registration_url -}}",
       {{- end -}}
 
+      {{- partial "api/captions" . -}}
+
       {{- partial "api/youtube_id" . -}}
 
       {{- if (isset .Params "zoom_id") -}}

--- a/themes/digital.gov/layouts/events/single.json.json
+++ b/themes/digital.gov/layouts/events/single.json.json
@@ -75,6 +75,8 @@
       "registration_url" : "{{- .Params.registration_url -}}",
       {{- end -}}
 
+      {{- partial "api/captions" . -}}
+      
       {{- partial "api/youtube_id" . -}}
 
       {{- if (isset .Params "zoom_id") -}}

--- a/themes/digital.gov/layouts/partials/api/captions.html
+++ b/themes/digital.gov/layouts/partials/api/captions.html
@@ -1,0 +1,3 @@
+{{- with .Params.captions -}}
+"captions" : "{{- . -}}",
+{{- end -}}


### PR DESCRIPTION
The `captions` was missing from the event APIs. This adds those in.

---

**Preview:** 
