### PR TITLE
Adding USWDS footer on events

### DIFF
--- a/content/events/2020/01/2020-01-16-uswds-january-monthly-call.md
+++ b/content/events/2020/01/2020-01-16-uswds-january-monthly-call.md
@@ -47,12 +47,12 @@ The January 2020 U.S. Web Design System (USWDS) monthly call is all about the US
 
 This event is part of a monthly series that takes place on the third Thursday of each month. We post the video on Digital.gov shortly after each event.
 
-USWDS is a library of principles, guidance, and code to help government teams design and build fast, accessible, mobile-friendly government websites backed by user research and modern best practices.
+## About the USWDS
+[**The U.S. Web Design System**](https://designsystem.digital.gov/) is a library of principles, guidance, and code to help government teams design and build fast, accessible, mobile-friendly government websites backed by user research and modern best practices.
 
 - [The U.S. Web Design System](https://designsystem.digital.gov/)
+- [The USWDS Maturity Model](https://designsystem.digital.gov/maturity-model/)
 - [Contribute GitHub](https://github.com/uswds/uswds/issues)
-- [Email Us](mailto:uswds@gsa.gov)
+- [Email Us](mailto:uswds@support.digitalgov.gov)
 - [Join our community](https://digital.gov/communities/uswds/)
 - [Follow @uswds on Twitter](https://twitter.com/uswds)
-
-_This talk is hosted by the [U.S. Web Design System](https://designsystem.digital.gov/) and Digital.gov._

--- a/content/events/2020/02/2020-02-20-uswds-monthly-call.md
+++ b/content/events/2020/02/2020-02-20-uswds-monthly-call.md
@@ -39,17 +39,18 @@ youtube_id:
 
 ---
 
+{{< img-right src="uswds-logo" >}}
+
 For this month's U.S. Web Design System (USWDS) monthly call Dan Williams, product lead, will discuss the design system in greater detail. Time will be set aside for a live Q&A session between attendees and Dan.
 
 This event is part of a monthly series that takes place on the third Thursday of each month. We post the video on Digital.gov shortly after each event.
 
-USWDS is a library of principles, guidance, and code to help government teams design and build fast, accessible, mobile-friendly government websites backed by user research and modern best practices.
+## About the USWDS
+[**The U.S. Web Design System**](https://designsystem.digital.gov/) is a library of principles, guidance, and code to help government teams design and build fast, accessible, mobile-friendly government websites backed by user research and modern best practices.
 
-Follow @uswds on Twitter
 - [The U.S. Web Design System](https://designsystem.digital.gov/)
+- [The USWDS Maturity Model](https://designsystem.digital.gov/maturity-model/)
 - [Contribute GitHub](https://github.com/uswds/uswds/issues)
 - [Email Us](mailto:uswds@support.digitalgov.gov)
 - [Join our community](https://digital.gov/communities/uswds/)
 - [Follow @uswds on Twitter](https://twitter.com/uswds)
-
-_This talk is hosted by the [U.S. Web Design System](https://designsystem.digital.gov/) and Digital.gov._


### PR DESCRIPTION
Added a more consistent set os related links to the USWDS events for JAN + FEB.
Also added the USWDS image to the Fed event.

---

**Preview:** 
https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/digitalgov.gov/uswds-edits/event/2020/02/20/uswds-monthly-call/