### PR TITLE
fixing the text in the bug button

### DIFF
--- a/themes/digital.gov/layouts/_default/baseof.html
+++ b/themes/digital.gov/layouts/_default/baseof.html
@@ -49,7 +49,7 @@
 
   <div class="edit_tools">
     <a class="edit edit-open" href="#"><i class="far fa-edit"></i></a>
-    <a class="edit edit-issue" target="_blank" href="https://github.com/GSA/digitalgov.gov/issues/new?body=%0D%0A%23%23+Issue%0D%0A%0D%0A%2A%2ATitle%2A%2A+%E2%80%94+%2A%2A{{- .Title -}}%2A%2A%0D%0A%2A%2ADemo+URL%2A%2A+%E2%80%94+https%3A%2F%2Fdemo.digital.gov%2F{{- .Permalink -}}%0D%0A%2A%2ALive+URL%2A%2A+%E2%80%94+https%3A%2F%2Fdigital.gov%2F{{- .Permalink -}}%0D%0A%0D%0A---%0D%0A%0D%0A%2A%2APlease+describe+the+issue+clearly.+Include+a+screenshot+if+needed%2A%2A%0D%0A"><i class="fas fa-bug"></i></a>
+    <a class="edit edit-issue" target="_blank" href="https://github.com/GSA/digitalgov.gov/issues/new?body=%0D%0A%23%23+Issue%0D%0A%0D%0A%2A%2A{{- .Title -}}%2A%2A%0D%0Ahttps%3A%2F%2Fdigital.gov%2F{{- .Permalink -}}%0D%0A%0D%0A---%0D%0A%0D%0A%2A%2APlease+describe+the+issue+clearly.+Include+a+screenshot+if+needed%2A%2A%0D%0A"><i class="fas fa-bug"></i></a>
   </div>
 
 

--- a/themes/digital.gov/layouts/_default/baseof.html
+++ b/themes/digital.gov/layouts/_default/baseof.html
@@ -49,7 +49,7 @@
 
   <div class="edit_tools">
     <a class="edit edit-open" href="#"><i class="far fa-edit"></i></a>
-    <a class="edit edit-issue" target="_blank" href="https://github.com/GSA/digitalgov.gov/issues/new?body=%0D%0A%23%23+Issue%0D%0A%0D%0A%2A%2A{{- .Title -}}%2A%2A%0D%0Ahttps%3A%2F%2Fdigital.gov%2F{{- .Permalink -}}%0D%0A%0D%0A---%0D%0A%0D%0A%2A%2APlease+describe+the+issue+clearly.+Include+a+screenshot+if+needed%2A%2A%0D%0A"><i class="fas fa-bug"></i></a>
+    <a class="edit edit-issue" target="_blank" href="https://github.com/GSA/digitalgov.gov/issues/new?body=%0D%0A%2A%2A{{- .Title -}}%2A%2A%0D%0Ahttps%3A%2F%2Fdigital.gov%2F{{- .Permalink -}}%0D%0A%0D%0A---%0D%0A%0D%0A%2A%2APlease+describe+the+issue+clearly.+Include+a+screenshot+if+needed%2A%2A%0D%0A"><i class="fas fa-bug"></i></a>
   </div>
 
 


### PR DESCRIPTION
We have a button on each page that makes it easier for people to submit a bug. That button opens up an "issue" with pre-formatted text. That text has links to the DEMO URL that we no longer need.

<img src="https://user-images.githubusercontent.com/395641/73032502-4321b180-3e0d-11ea-9f0f-a3fabebb2f7a.png" width="300px"/>


## What we fixed.
This fix simplifies the text that gets generated into a GitHub issue when someone files a bug with the new bug button.

---

**Preview:** https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/digitalgov.gov/fix-bug-button/resources/checklist-of-requirements-for-federal-digital-services/
