### PR TITLE
Fixing formatting on cyber vandalism toolkit

### DIFF
--- a/content/resources/readiness-recovery-response-social-media-cyber-vandalism-toolkit.md
+++ b/content/resources/readiness-recovery-response-social-media-cyber-vandalism-toolkit.md
@@ -127,12 +127,12 @@ Alerts of suspicious activity on social media can come from anywhere, including 
 
 ### 1. Contact Information to Recover Control After Cyber-Vandalism
 
-  1. **Facebook:** [Online form for Facebook](https://www.facebook.com/help/131719720300233/); Email: <gov@fb.com>; Email: <justin.herman@gsa.gov> and <betsy.steele@gsa.gov>
-  2. **Twitter:** [Online form for Twitter](https://support.twitter.com/articles/185703-my-account-has-been-hacked); Email: <Gov@Twitter.com>; Email: <justin.herman@gsa.gov> and <betsy.steele@gsa.gov>
-  3. **LinkedIn:** [Respond to and Report Various Issues](https://help.linkedin.com/app/safety/answers/detail/a_id/146); Email: <LCSHelp@linkedin.com>; Email: <mcirrito@linkedin.com>; Email: justin.herman@gsa.gov and <betsy.steele@gsa.gov>
-  4. **Instagram:** [Online form for Instagram](https://help.instagram.com/368191326593075); Email: <government@FB.com>; Email: <justin.herman@gsa.gov> and <betsy.steele@gsa.gov>
-  5. **Vine:** [Online form for Vine](https://support.twitter.com/forms/vine); Email: <Gov@Twitter.com>; Email: <justin.herman@gsa.gov> and <betsy.steele@gsa.gov>
-  6. **Hootsuite:** Email: <Support@hootsuite.com>; Email: <sajji.hussein@hootsuite.com>; Email: <justin.herman@gsa.gov> and <betsy.steele@gsa.gov>
+  1. **Facebook:** [Online form for Facebook](https://www.facebook.com/help/131719720300233/); Email: <gov@fb.com>;
+  2. **Twitter:** [Online form for Twitter](https://support.twitter.com/articles/185703-my-account-has-been-hacked); Email: <Gov@Twitter.com>;
+  3. **LinkedIn:** [Respond to and Report Various Issues](https://help.linkedin.com/app/safety/answers/detail/a_id/146); Email: <LCSHelp@linkedin.com>; Email: <mcirrito@linkedin.com>;
+  4. **Instagram:** [Online form for Instagram](https://help.instagram.com/368191326593075); Email: <government@FB.com>;
+  5. **Vine:** [Online form for Vine](https://support.twitter.com/forms/vine); Email: <Gov@Twitter.com>;
+  6. **Hootsuite:** Email: <Support@hootsuite.com>; Email: <sajji.hussein@hootsuite.com>; 
 
 ### 2. Audit your social media inventory
 

--- a/content/resources/readiness-recovery-response-social-media-cyber-vandalism-toolkit.md
+++ b/content/resources/readiness-recovery-response-social-media-cyber-vandalism-toolkit.md
@@ -1,23 +1,29 @@
 ---
 slug: readiness-recovery-response-social-media-cyber-vandalism-toolkit
 date: 2015-01-27 1:09:20 -0400
-title: 'Readiness, Recovery, Response: Social Media Cyber-Vandalism Toolkit'
-summary: Cyber-vandalism presents a serious challenge to online-based communication tools. Users need available resources to counter intrusions of social media accounts. This document provides guidance and security practices to federal, state, and local government employees. Suggestions and resources prepare users to respond to cyber-hijacking. and will empower digital users to make informed choices and enact future
+title: "Social Media Cyber-Vandalism Toolkit"
+deck: "Guidance on how to respond to cyber-hijacking."
+summary: "Cyber-vandalism presents a serious challenge to online-based communication tools. This document provides guidance and security practices to federal, state, and local government employees. Suggestions and resources prepare users to respond to cyber-hijacking."
+
 topics:
   - social-media
+  - security
+
 authors:
   - jherman
+
 ---
 
-Cyber-vandalism presents a serious challenge to online-based communication tools. Users need available resources to counter intrusions of social media accounts. This document provides guidance and security practices to federal, state, and local government employees. Suggestions and resources prepare users to respond to cyber-hijacking. and will empower digital users to make informed choices and enact future policy. This resource is a &#8220;living document&#8221; designed for continued contribution and expansion &#8212; if you have input please email [Justin Herman](mailto:justin.herman@gsa.gov).
+Cyber-vandalism presents a serious challenge to online-based communication tools. Users need available resources to counter intrusions of social media accounts.
 
-# Readiness: Phase 1
+This document provides guidance, resources, and security practices that prepare users to respond to cyber-hijacking, make informed choices, and enact future policy.
+
+
+## Readiness: Phase 1
 
 Cyber-vandalism occurs when an outside party, regardless of identity or motive, takes control of an agency communication channel and misdirects it. Incidents may contain information misleading to the public or threatening to an agent of the United States. Agencies should plan and train prior to an incident, and prepare approved processes and material for the recovery and response to cyber-vandalism.
 
-<h2 style="padding-left: 30px">
-  <b>1. Identify a social media stakeholder team to prevent and respond to cyber-vandalism</b>
-</h2>
+### 1. Identify a social media stakeholder team to prevent and respond to cyber-vandalism
 
 A direct chain of responsible managers should be aware of their roles in the potential response to any social media cyber-vandalism, including the necessity of quick, decisive action. This team should be connected by email, phone, text and any other appropriate means of communication. The team should include, but is not limited to:
 
@@ -28,90 +34,76 @@ A direct chain of responsible managers should be aware of their roles in the pot
   5. IT Security
   6. Senior leader/manager
 
-<h2 style="padding-left: 30px">
-  <b>2. Review Individual App/Platform Resources</b>
-</h2>
+### 2. Review Individual App/Platform Resources
 
 Online-based communication tools offer resources, each with unique strengths and limitations. Awareness of this support and their unique characteristics is beneficial before an incident:
 
   1. **Facebook:** [Facebook Security Tips](https://www.facebook.com/help/379220725465972); [Facebook Security Settings](https://www.facebook.com/settings?tab=security); Learn [extra security features](https://www.facebook.com/help/413023562082171) including approvals, notifications, trusted contacts and mobile security
-  2. ****LinkedIn:**** [LinkedIn Safety Center](https://help.linkedin.com/app/safety/home); [Prevention Tips](https://help.linkedin.com/app/safety/answers/detail/a_id/37027); [Password Guidelines](https://help.linkedin.com/app/safety/answers/detail/a_id/38595); [Frequently Asked Questions | Reporting Inappropriate Content, Messages, or Safety Concerns](https://help.linkedin.com/app/safety/answers/detail/a_id/146)
-  3. ****Instagram:**** [Instagram Privacy & Safety Center](https://help.instagram.com/369001149843369/)
-  4. ****Twitter:**** [Safe tweeting: the basics](https://support.twitter.com/groups/33-report-a-violation/topics/166-safety-center/articles/76036-safety-keeping-your-account-secure)
-  5. ****Google:**** [Keeping your account secure](https://support.google.com/accounts/answer/46526?hl=en)
-  6. ****Hootsuite:**** [Social Media Security](https://hootsuite.com/products/platform/social-media-security)
+  2. **LinkedIn:** [LinkedIn Safety Center](https://help.linkedin.com/app/safety/home); [Prevention Tips](https://help.linkedin.com/app/safety/answers/detail/a_id/37027); [Password Guidelines](https://help.linkedin.com/app/safety/answers/detail/a_id/38595); [Frequently Asked Questions | Reporting Inappropriate Content, Messages, or Safety Concerns](https://help.linkedin.com/app/safety/answers/detail/a_id/146)
+  3. **Instagram:** [Instagram Privacy & Safety Center](https://help.instagram.com/369001149843369/)
+  4. **Twitter:** [Safe tweeting: the basics](https://support.twitter.com/groups/33-report-a-violation/topics/166-safety-center/articles/76036-safety-keeping-your-account-secure)
+  5. **Google:** [Keeping your account secure](https://support.google.com/accounts/answer/46526?hl=en)
+  6. **Hootsuite:** [Social Media Security](https://hootsuite.com/products/platform/social-media-security)
 
-<h2 style="padding-left: 30px">
-  <b>3. Establish Stakeholder Rapid Outreach Plan</b>
-</h2>
+### 3. Establish Stakeholder Rapid Outreach Plan
 
-  1. Prepare a list of internal and external contacts and processes for a cyber-vandalism incident: 
+  1. Prepare a list of internal and external contacts and processes for a cyber-vandalism incident:
       * Who is the POC for the app or platform when an incident occurs (see Phase 2: Recovery for list)?
       * Who is the POC for cyber-vandalism of accounts in the Government (see Phase 2: Recovery for list)?
       * Who is on your social media stakeholder team?
       * Who are your key communities and audiences on social media and other channels you must alert?
-  2. Incorporate relevant contact information: 
+  2. Incorporate relevant contact information:
       * Emails; Phone Numbers; Social Media Handles; Hashtags; Listservs and more.
 
-<h2 style="padding-left: 30px">
-  <b>4. Create Communication Templates</b>
-</h2>
+### 4. Create Communication Templates
 
-  1. Pre-populate different types of messages. 
+  1. Pre-populate different types of messages.
       * Emails; Texts; Social media posts and more.
-  2. Communicate essential information to convey the nature of the compromise, for example: 
+  2. Communicate essential information to convey the nature of the compromise, for example:
       * An account is compromised; An administrator cannot access an account; A username and/or password for an account is compromised; Information on the account is unauthorized.
 
-<h2 style="padding-left: 30px">
-  <b>5. Review Secure Social Media Best Practices Checklist</b>
-</h2>
+### 5. Review Secure Social Media Best Practices Checklist
 
-  1. Institutionalize secure web standards, such as HTTPS, as a foundation for secure social media: 
+  1. Institutionalize secure web standards, such as HTTPS, as a foundation for secure social media:
       * Using an URI scheme, such as HTTPS, establishes a fast, private, and secure connection due to its strong encryption benefits
       * Read [Why We Use HTTPS in Every Gov Website We Make](https://18f.gsa.gov/2014/11/13/why-we-use-https-in-every-gov-website-we-make/)
-  2. Establish accounts with official .gov or .mil domains of full-time equivalent employees (FTE) . 
+  2. Establish accounts with official .gov or .mil domains of full-time equivalent employees (FTE) .
       * Allow for more than one FTE to administer an account.
       * Designate an alternative as auxiliary support. Limit this designation to an individual essential to the operation and management of an account.
       * Clearly define the criteria for the administrator and alternative.
       * Provide adequate resources to the FTE administrator, including a mobile device and third-party management tool whenever possible.
   3. Create a social media policy with standard operating procedures (SOP) for cyber-security.
   4. Obtain approval from appropriate agency parties, including IT Security and General Counsel
-  5. Train stakeholders and others on the procedures and policies of social media cyber-security. 
+  5. Train stakeholders and others on the procedures and policies of social media cyber-security.
       * Require training before use of an account.
   6. Use only authorized URL Shorteners, e.g. [go.USA.gov](https://go.usa.gov/).
-  7. Add all official accounts to the [U.S. Digital Registry]({{< ref "service_us-digital-registry.md" >}}), verifying authenticity of ownership. 
+  7. Add all official accounts to the [U.S. Digital Registry]({{< ref "service_us-digital-registry.md" >}}), verifying authenticity of ownership.
       * This tool, used by both Facebook and Google to verify accounts, tracks official federal social media accounts.
-      * List Department of Defense (DoD) social media accounts in the [DoD Social Media Site Registry](http://www.defense.gov/RegisteredSites/SocialMediaSites.aspx). 
+      * List Department of Defense (DoD) social media accounts in the [DoD Social Media Site Registry](http://www.defense.gov/RegisteredSites/SocialMediaSites.aspx).
           * Per [DOD Web Policy](http://www.defense.gov/webmasters/) and [DoDI 8550.01](http://www.dtic.mil/whs/directives/corres/pdf/855001p.pdf) , use [DoD Social Media Registry submission form](http://www.defense.gov/RegisteredSites/SubmitLink.aspx).
-  8. Follow best practices for secure passwords. 
+  8. Follow best practices for secure passwords.
       * [Guide to Enterprise Password Management (Draft)](http://csrc.nist.gov/publications/drafts/800-118/draft-sp800-118.pdf) by the National Institute of Standards and Technology
 
-<h2 style="padding-left: 30px">
-  <b>6. Evaluate Two-Step Verification</b>
-</h2>
+### 6. Evaluate Two-Step Verification
 
 This type of authentication verifies a user attempting to access a device or system. It requires confirmation of two consecutive, yet dependent, entries. It may not be applicable to those without mobile devices or in secure environments prohibited entry of such items. It may also require the use of third-party management tools to effectively allow multiple content coordinators.
 
-  1. ****Facebook:**** [Facebook&#8217;s Login Approvals](https://www.facebook.com/help/148233965247823); ZDnet.com supplemental [step-by-step guide](http://www.zdnet.com/article/tutorial-facebook-2-factor-authentication-step-by-step/).
-  2. ****Google and YouTube:**** [Google 2-Step Verification](https://www.google.com/landing/2step/).
-  3. ****LinkedIn:**** [LinkedIn&#8217;s Two Step Verification](http://blog.linkedin.com/2013/05/31/protecting-your-linkedin-account-with-two-step-verification/).
-  4. ****Twitter:**** [Twitter&#8217;s Two Step Verification Process](https://blog.twitter.com/2013/getting-started-with-login-verification).
+  1. **Facebook:** [Facebook&#8217;s Login Approvals](https://www.facebook.com/help/148233965247823); ZDnet.com supplemental [step-by-step guide](http://www.zdnet.com/article/tutorial-facebook-2-factor-authentication-step-by-step/).
+  2. **Google and YouTube:** [Google 2-Step Verification](https://www.google.com/landing/2step/).
+  3. **LinkedIn:** [LinkedIn&#8217;s Two Step Verification](http://blog.linkedin.com/2013/05/31/protecting-your-linkedin-account-with-two-step-verification/).
+  4. **Twitter:** [Twitter&#8217;s Two Step Verification Process](https://blog.twitter.com/2013/getting-started-with-login-verification).
 
-<h2 style="padding-left: 30px">
-  <b>7. Review Special Guidance Per Common User Responsibility</b>
-</h2>
+### 7. Review Special Guidance Per Common User Responsibility
 
-****For Supervisors and Directors:**** Confirm policy is clear, accessible, and distributed among employees. Review, approve, and document all agency accounts regularly. Identify and eliminate rogue accounts. Instruct staff administering accounts to adhere to agency criteria and undergo training where appropriate.
+**For Supervisors and Directors:** Confirm policy is clear, accessible, and distributed among employees. Review, approve, and document all agency accounts regularly. Identify and eliminate rogue accounts. Instruct staff administering accounts to adhere to agency criteria and undergo training where appropriate.
 
-****For Social Media Managers:**** Make security a part of regular social media meetings. Conduct security checks on a regular basis. Regularly update passwords. Keep the list of social media accounts updated. Keep account manager contact information accessible and updated. Remove access for users who are no longer with the agency. Develop a secure method of storing account names, owners, and passwords.
+**For Social Media Managers:** Make security a part of regular social media meetings. Conduct security checks on a regular basis. Regularly update passwords. Keep the list of social media accounts updated. Keep account manager contact information accessible and updated. Remove access for users who are no longer with the agency. Develop a secure method of storing account names, owners, and passwords.
 
-****For Social Media Coordinators:**** Use a protected, official government device. Use protected connections. Do not post from an open Wifi network. Use a work VPN, 3G or the work-connected Internet connection. Generally, use network locations with strong firewalls and on standalone equipment. Preview shortened links to see the address of where they lead. Review the URL of a website in the address bar.  Make sure the websites you visit use HTTPS encryption. If you are unsure of a link, double click the lock icon on your browser’s status bar to display the digital certificate for a site.
+**For Social Media Coordinators:** Use a protected, official government device. Use protected connections. Do not post from an open Wifi network. Use a work VPN, 3G or the work-connected Internet connection. Generally, use network locations with strong firewalls and on standalone equipment. Preview shortened links to see the address of where they lead. Review the URL of a website in the address bar.  Make sure the websites you visit use HTTPS encryption. If you are unsure of a link, double click the lock icon on your browser’s status bar to display the digital certificate for a site.
 
-<h2 style="padding-left: 30px">
-  <b>8. Conduct Training on Secure Use of Social Media</b>
-</h2>
+### 8. Conduct Training on Secure Use of Social Media
 
-****Live training:**** [Cybersecurity Online Learning (COL)](https://colcqpub1.connectsolutions.com/content/connect/c1/7/en/events/catalog.html) program supplements mandatory FISMA security role-based training by offering in-demand cybersecurity workshops. The Information Assurance Branch, United States Department of State, offers monthly social media security online courses for free for anyone with a “.mil” or “.gov” email address, regardless if the applicant is an FTE, military, or contractor.
+**Live training:** [Cybersecurity Online Learning (COL)](https://colcqpub1.connectsolutions.com/content/connect/c1/7/en/events/catalog.html) program supplements mandatory FISMA security role-based training by offering in-demand cybersecurity workshops. The Information Assurance Branch, United States Department of State, offers monthly social media security online courses for free for anyone with a “.mil” or “.gov” email address, regardless if the applicant is an FTE, military, or contractor.
 
   * [Department of Defense Social Media Security/Privacy Education & Training](http://www.defense.gov/socialmedia/education-and-training.aspx/)
   * [Consumer.ftc.gov/scam-alerts](https://consumer.ftc.gov/scam-alerts)
@@ -125,7 +117,7 @@ This type of authentication verifies a user attempting to access a device or sys
   * Post: [Twitter&#8217;s Two Step Verification Process]({{< ref "2013-05-31-twitters-two-step-verification-process.md" >}})
   * Post: [Government Must Respond Rapidly to Social Media Hacking]({{< ref "2013-04-25-government-must-respond-rapidly-to-social-media-hacking.md" >}})
 
-# Recovery: Phase 2
+## Recovery: Phase 2
 
 Alerts of suspicious activity on social media can come from anywhere, including social media itself. If the social media cyber-security stakeholder team or responsible manager determines an incident is in progress, remember that minutes and even seconds count. Within minutes you&#8217;ll need to alert internal stakeholders, alert outside stakeholders to help you regain control, and act to isolate the compromise.
 
@@ -133,9 +125,7 @@ Alerts of suspicious activity on social media can come from anywhere, including 
   2. Attempt to change passwords to isolate the incident (steps 2 and 3 ideally simultaneously with two employees)
   3. Contact the platform companies themselves and GSA to help regain control.
 
-<h2 style="padding-left: 30px">
-  <b>1. Contact Information to Recover Control After Cyber-Vandalism</b>
-</h2>
+### 1. Contact Information to Recover Control After Cyber-Vandalism
 
   1. **Facebook:** [Online form for Facebook](https://www.facebook.com/help/131719720300233/); Email: <gov@fb.com>; Email: <justin.herman@gsa.gov> and <betsy.steele@gsa.gov>
   2. **Twitter:** [Online form for Twitter](https://support.twitter.com/articles/185703-my-account-has-been-hacked); Email: <Gov@Twitter.com>; Email: <justin.herman@gsa.gov> and <betsy.steele@gsa.gov>
@@ -144,53 +134,42 @@ Alerts of suspicious activity on social media can come from anywhere, including 
   5. **Vine:** [Online form for Vine](https://support.twitter.com/forms/vine); Email: <Gov@Twitter.com>; Email: <justin.herman@gsa.gov> and <betsy.steele@gsa.gov>
   6. **Hootsuite:** Email: <Support@hootsuite.com>; Email: <sajji.hussein@hootsuite.com>; Email: <justin.herman@gsa.gov> and <betsy.steele@gsa.gov>
 
-<h2 style="padding-left: 30px">
-  <b>2. Audit your social media inventory</b>
-</h2>
+### 2. Audit your social media inventory
 
   1. Audit your list of social media accounts, password holders, agency hosted websites.
   2. Ensure no former employees, contractors or interns have access to current passwords.
   3. Review any third-party app you use to monitor or post to social media, such as IFTTT.
   4. Review your other digital services, including websites, for signs of cyber-vandalism and any vulnerabilities.
 
-<h2 style="padding-left: 30px">
-  <b>3. Confirm cyber-vandalism recovery process on different channels</b>
-</h2>
+### 3. Confirm cyber-vandalism recovery process on different channels
 
 Once securing your other accounts, release pre-approved initial messages alerting your communities that an incident is occurring and that steps are underway in order to recover cyber-vandalized accounts.
 
-<h2 style="padding-left: 30px">
-  <b>4. Initiate Restoration Activities After Regaining Account(s)</b>
-</h2>
+### 4. Initiate Restoration Activities After Regaining Account(s)
 
   1. Archive cyber-vandalism messages.
   2. Delete cyber-vandalism messages.
   3. Stop all pre-scheduled messages.
   4. Restore normal settings and features.
 
-# Response: Phase 3
+
+## Response: Phase 3
 
 Agencies must not only prepare for and recover social media accounts after a cyber-vandalism incident, they should also quickly and effectively respond to their stakeholders and audiences as soon as possible using social media in order to maintain trust in digital services. Initial responses to the cyber-security stakeholder team and the public should be within minutes of recovering control of your accounts.
 
-<h2 style="padding-left: 30px">
-  <b>1. Confirm Incident and Recovery</b>
-</h2>
+### 1. Confirm Incident and Recovery
 
   1. **Cyber-security team confirmation:** Send initial report of recovery to social media cyber-security stakeholder team.
   2. **Public confirmation:** Distribute as soon as possible social media posts confirming the cyber-vandalism incident and your recovery of affected accounts. Announce a return to regularly scheduled activities.
   3. **Community confirmation:** Deliver additional communication with pre-determined internal audiences and stakeholders to prevent the spread of rumors and misinformation.
 
-<h2 style="padding-left: 30px">
-  <b>2. Confirm and Verify Changes to Access</b>
-</h2>
+### 2. Confirm and Verify Changes to Access
 
   1. Review account holders.
   2. Confirm verification of login status.
   3. Confirm changes and updates of passwords.
 
-<h2 style="padding-left: 30px">
-  <b>3. Conduct a review of lessons learned</b>
-</h2>
+### 3. Conduct a review of lessons learned
 
   * What type of response worked well?
   * Why did this work so well?
@@ -198,10 +177,11 @@ Agencies must not only prepare for and recover social media accounts after a cyb
   * What unforeseen events occurred?
   * What changes will lead to a better response?
 
-<h2 style="padding-left: 30px">
-  <b>4. Apply data and analysis of outcomes to improving your program</b>
-</h2>
+### 4. Apply data and analysis of outcomes to improving your program
 
   * Develop after-action report.
   * Ensure future relevance with accurate information.
   * Include lessons learned and best practices.
+
+
+{{< note >}}**This resource is a &#8220;living document&#8221**; designed for continued contribution and expansion &#8212; if you have input or suggestions, please suggest an edit or email [digitalgov@gsa.gov](mailto:digitalgov@gsa.gov).{{< /note >}}


### PR DESCRIPTION
On Twitter, [someone tweeted](https://twitter.com/mikko_2015/status/1222209736155848704?s=20):
> Pretty solid advice on how to respond to hijacking of your organization's social media account: https://digitalgov.gov/resources/readiness-recovery-response-social-media-cyber-vandalism-toolkit/
/from 
@digital_gov

---

This change cleans up the formatting of the page, which has a lot of old HTML in the post body.

**Original:** https://digital.gov/resources/readiness-recovery-response-social-media-cyber-vandalism-toolkit/

### What changed?

- Cleaned up formatting
- Re-aligned the heading levels on the page
- Simplified the title
- Added a deck
- added the security topic
- removed references to Email — `Email: <justin.herman@gsa.gov> and <betsy.steele@gsa.gov>`

---

**Preview:** 
https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/digitalgov.gov/fixing-cyber-vandalism-toolkit/resources/readiness-recovery-response-social-media-cyber-vandalism-toolkit/ 