### PR TITLE
Update 2020-01-27-searchgov-2019-in-review.md

### DIFF
--- a/content/posts/2020/01/2020-01-27-searchgov-2019-in-review.md
+++ b/content/posts/2020/01/2020-01-27-searchgov-2019-in-review.md
@@ -11,8 +11,8 @@ source: searchgov
 slug: searchgov-2019-in-review
 date: 2020-01-27 13:00:00 -0500
 title: "Search.gov: 2019 in Review"
-deck: "**In 2019, Search.gov served 295,916,305 queries across over 2,000 government websites**. Find out more in their annual report, including the common topics people search for."
-summary: "**In 2019, Search.gov served **295,916,305 queries across over 2,000 government websites**. Find out more in their annual report, including the common topics people search for."
+deck: "**In 2019, Search.gov served 295,916,305 queries across more than 2,000 government websites**. Find out more in their annual report, including the most common topics that people searched for."
+summary: "**In 2019, Search.gov served **295,916,305 queries across more than 2,000 government websites**. Find out more in their annual report, including the most common topics that people searched for."
 
 # see all topics at https://digital.gov/topics
 topics:


### PR DESCRIPTION
Changed "over" (physical) to "more than" (numerical)
added 'most' and 'that'
past tense - searched

---

**Preview:** 
https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/digitalgov.gov/copyedit-search-spotlight-item/