### PR TITLE
adding in a redirect

### DIFF
--- a/content/posts/2020/01/2020-01-30-adopting-uswds-one-step-at-time.md
+++ b/content/posts/2020/01/2020-01-30-adopting-uswds-one-step-at-time.md
@@ -5,7 +5,7 @@ slug: adopting-uswds-one-step-at-time
 
 # Short URL — https://go.usa.gov/
 short_url: https://go.usa.gov/xdjTe
-date: 2020-01-29 19:00:00 -0500
+date: 2020-01-30 19:00:00 -0500
 kicker: "This Week's IDEA"
 title: "Adopting the USWDS, One Step at a Time"
 deck: "The U.S. Web Design System is key to new website standards"
@@ -26,6 +26,10 @@ authors:
 
 # primary Image (for social media)
 primary_image: "this-weeks-idea-card-wk6"
+
+# Redirects: enter the path of the URL that you want redirected to this page
+aliases:
+  - /2020/01/29/adopting-uswds-one-step-at-time/
 
 
 # Make it better ♥


### PR DESCRIPTION
This was published with the wrong date:
https://digital.gov/2020/01/29/adopting-uswds-one-step-at-time/

Moving to:
https://digital.gov/2020/01/30/adopting-uswds-one-step-at-time/

---

**Preview:** _(this will redirect)_  
https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/digitalgov.gov/redirect-uswds-blog-post/2020/01/29/adopting-uswds-one-step-at-time/