### PR TITLE
Event: removing draft, making public

### DIFF
--- a/content/events/2019/10/2019-10-30-federal-crowdsourcing-webinar-series-episode-6-fedramp-ideation.md
+++ b/content/events/2019/10/2019-10-30-federal-crowdsourcing-webinar-series-episode-6-fedramp-ideation.md
@@ -11,7 +11,6 @@ date: 2019-10-30 14:00:00 -0500
 end_date: 2019-10-30 15:00:00 -0500
 event_organizer: DigitalGov University
 host: Challenge.gov
-draft: true
 registration_url: https://www.eventbrite.com/e/federal-crowdsourcing-webinar-series-6-registration-66229112057
 
 aliases:


### PR DESCRIPTION
this event had `draft: true` set. Probably as a result of it being taken down on the live site, moved to DEMO, then moved back when we made the new site live and the `draft: true` was accidentally left in.

---

**Preview:** 
