### PR TITLE
Fixing broken link

### DIFF
--- a/content/resources/checklist-of-requirements-for-federal-digital-services.md
+++ b/content/resources/checklist-of-requirements-for-federal-digital-services.md
@@ -46,7 +46,7 @@ Ensure access for people with disabilities, including motor, auditory, cognitive
 * [Section 508 Law](https://www.section508.gov/content/learn/laws-and-policies) and [Technical Standards](https://www.access-board.gov/guidelines-and-standards/communications-and-it/about-the-section-508-standards/section-508-standards)
 * [Web Content Accessibility Guidelines](https://www.w3.org/WAI/intro/wcag.php) (WCAG)
 * [WCAG Quick Reference](https://www.w3.org/WAI/WCAG20/quickref/) and [WCAG Web tutorials](https://www.w3.org/WAI/tutorials/)
-* [Technology Accessibility Playbook](https://section508.gov/sites/default/files/Technology%20Accessibility%20Playbook%20Version%201%20%28last%20updated%206_2_2016%29.doc)
+* [Technology Accessibility Playbook](https://section508.gov/tools/playbooks/technology-accessibility-playbook-intro)
 * [Federal CIO Council Accessibility Best Practices](https://section508.gov/best-practices)
 * [Governmentwide Section 508 Strategic Plan (2013)](https://www.section508.gov/sites/default/files/strategic-plan-508-compliance.pdf)
 


### PR DESCRIPTION
Fixing https://github.com/GSA/digitalgov.gov/issues/1967

The Technology Accessibility Playbook link on this checklist page 404's.
It should point to https://section508.gov/tools/playbooks/technology-accessibility-playbook-intro

---

**Preview:** https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/digitalgov.gov/fixing-link-508/resources/checklist-of-requirements-for-federal-digital-services/
