### PR TITLE
tagging presenters

### DIFF
--- a/content/events/2018/01/2018-01-26-us-web-design-standards-monthly-users-call.md
+++ b/content/events/2018/01/2018-01-26-us-web-design-standards-monthly-users-call.md
@@ -20,6 +20,7 @@ end_date: 2018-01-26 12:30:00 -0500
 topics: 
   - design
   - uswds
+  - draft-web-design-standards
 
 # see all authors at https://digital.gov/authors
 authors: 

--- a/content/events/2018/01/2018-01-26-us-web-design-standards-monthly-users-call.md
+++ b/content/events/2018/01/2018-01-26-us-web-design-standards-monthly-users-call.md
@@ -1,23 +1,44 @@
 ---
+# View this page at https://digital.gov/event/2018/01/us-web-design-standards-monthly-users
+# Learn how to edit our pages at https://workflow.digital.gov
 slug: us-web-design-standards-monthly-users-call
-title: 'U.S. Web Design Standards Monthly Users Call'
-summary: 'In our next monthly users call, the U&#46;S&#46; Web Design Standards core team will share what they’re working on in 2018&#46;'
-featured_image:
-  uid:
-  alt: ''
-event_type:
-  - online
-date: 2018-01-26 13:00:00 -0400
-end_date: 2018-01-26 13:30:00 -0400
-event_organizer: DigitalGov University
-host: USWDS
+title: "U.S. Web Design Standards Monthly Users Call"
+deck: ""
+summary: "In our next monthly users call, the U.S. Web Design Standards core team will share what they’re working on in 2018."
+host: "USWDS"
+event_organizer: "DigitalGov University"
 registration_url: https://www.eventbrite.com/e/january-us-web-design-standards-users-call-tickets-42250600684
-aliases:
-  - /event/us-web-design-standards-monthly-users-call/
-topics:
+captions: 
+
+# start date
+date: 2018-01-26 12:00:00 -0500
+
+# end date
+end_date: 2018-01-26 12:30:00 -0500
+
+# see all topics at https://digital.gov/topics
+topics: 
   - design
   - uswds
   - draft-web-design-standards
+
+# see all authors at https://digital.gov/authors
+authors: 
+  - dan-williams
+  - maya-benari
+  - john-donmoyer
+
+# Event platform (zoom, youtube_live, adobe_connect)
+event_platform: zoom
+
+# YouTube ID
+youtube_id: 
+
+# Redirects: enter the path of the URL that you want redirected to this page
+aliases: 
+  - /event/us-web-design-standards-monthly-users-call/
+
+# Make it better ♥
 
 ---
 

--- a/content/events/2018/01/2018-01-26-us-web-design-standards-monthly-users-call.md
+++ b/content/events/2018/01/2018-01-26-us-web-design-standards-monthly-users-call.md
@@ -20,7 +20,6 @@ end_date: 2018-01-26 12:30:00 -0500
 topics: 
   - design
   - uswds
-  - draft-web-design-standards
 
 # see all authors at https://digital.gov/authors
 authors: 
@@ -58,6 +57,5 @@ Join us to hear from the team and ask questions.
 - John Donmoyer
 - Dan Williams
 
-This call will be help over Zoom. Link will be provided upon registration.
 
 _This talk is open to federal employees who work on digital projects that could use the Web Design Standards._


### PR DESCRIPTION
adding presenters in tag section -- currently they are listed in body of copy not as meta-tag


A one-line description of the changes you're making and how they'll affect users.

---

**Preview:** 
https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/digitalgov.gov/DanielJPino-ux-patch-2/event/2018/01/26/us-web-design-standards-monthly-users-call/ 