### PR TITLE
Reducing the number of paginated pages built

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -7,7 +7,7 @@ themesDir               : "./themes"
 MetaDataFormat          : "yaml"
 DefaultContentLanguage  : "en"
 SectionPagesMenu        : "main"
-Paginate                : 20
+Paginate                : 50
 googleAnalytics         : ""
 enableRobotsTXT         : true
 enableEmoji             : true


### PR DESCRIPTION
Changing the setting that determines how many items per page will be displayed on the paginated pages. Changing to 50 items per page, from 20 per page.

This will reduce the overall number of pages built (and uploaded) and hopefully speed up federalist build time.

Currently building 649 Paginator pages. Now building 186.

```
+------------------+------+
  Pages            | 9631  
  Paginator pages  |  186  
  Non-page files   |    0  
  Static files     | 1035  
  Processed images |    0  
  Aliases          | 1292  
  Sitemaps         |    1  
  Cleaned          |    0  
```

---

**Preview:** 
