### PR TITLE
Cleaning up section index files

### DIFF
--- a/content/404/_index.md
+++ b/content/404/_index.md
@@ -1,12 +1,8 @@
 ---
-date: 2019-01-07 12:00:00 -0500
 title: "404 Error ... Page Not Found"
 deck: "I'm sorry, but the page you're looking for does not exist."
 summary: "We're sorry, but the page you're seeking does not exist. Please verify that you've entered the correct URL in your browser's address bar."
 headless: true
-authors:
-  - toni-bonitto
-  - jeremyzilar
 
 ---
 

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -1,6 +1,5 @@
 ---
-date: 2017-11-14 12:05:00 -0400
-title: 'Welcome to Digital.gov'
+title: "Welcome to Digital.gov"
 deck: 'We help the government community deliver better digital services.'
 summary: 'Welcome to DigitalGov. Learn more about what we&#39;re working on'
 aliases:

--- a/content/authors/_index.md
+++ b/content/authors/_index.md
@@ -1,7 +1,6 @@
 ---
-url: /authors/
-date: 2019-04-30 22:30:00 -0400
-title: "Contributing Authors"
+title: "Authors"
 deck: "The people who have contributed their stories and guidance over the years."
-summary: ""
+summary: "The people who have contributed their stories and guidance over the years."
+
 ---

--- a/content/communities/_index.md
+++ b/content/communities/_index.md
@@ -1,9 +1,7 @@
 ---
-slug: communities
-title: 'Communities of Practice'
-summary: 'Collaborate and share resources with others across government.'
+title: "Communities of Practice"
+summary: "Collaborate and share resources with others across government."
 deck: "Collaborate and share resources with others across government."
-
 aliases:
   - /communities/community-solutions/
   - /communities/data-cabinet/

--- a/content/events/_index.md
+++ b/content/events/_index.md
@@ -1,6 +1,4 @@
 ---
-url: /events/
-date: 2018-03-27 10:04:09 -0400
 title: Events and Training
 deck: "**Digital.gov University** provides free training and events that highlight the innovations, case studies, tools, and resources people in government need most."
 summary: 'Register for Digital.gov University training sessions, interviews, community of practice meetings, and other events with digital leaders from across the public and private sectors.'

--- a/content/guides/_index.md
+++ b/content/guides/_index.md
@@ -1,5 +1,4 @@
 ---
-date: 2019-12-31 12:00:00 -0500
 title: 'Guides'
 deck: "TKTK"
 summary: 'TKTK'

--- a/content/resources/_index.md
+++ b/content/resources/_index.md
@@ -1,6 +1,4 @@
 ---
-slug:
-date: 2013-11-17 11:13:13 -0400
 title: "Guides and Resources"
 summary: 'Common resources for people working in Digital government.'
 aliases:
@@ -18,7 +16,7 @@ aliases:
 
 ## Accessibility
 
-* [Intro to Accessibility](https://digital.gov/resources/intro-accessibility/) 
+* [Intro to Accessibility](https://digital.gov/resources/intro-accessibility/)
 * [Find Your Agency's 508 Program Manager](https://section508.gov/tools/coordinator-listing)
 * [How to Use Assistive Technology to Comply with Section 508](https://www.youtube.com/watch?v=4XJcswWmmAw)
 * [Introducing Accessibility for Teams](https://digital.gov/2018/07/10/introducing-accessibility-for-teams/)

--- a/content/services/_index.md
+++ b/content/services/_index.md
@@ -1,9 +1,5 @@
 ---
-url: /services/
-title: 'Tools and Services'
+title: "Tools and Services"
 deck: "Explore free and low-cost services for improving your users‘ digital experience"
-summary: 'Explore services that are user-centered, open-source, and built by government for government.'
-
-weight: 0
-
+summary: "Explore services that are user-centered, open-source, and built by government for government."
 ---

--- a/content/sources/_index.md
+++ b/content/sources/_index.md
@@ -1,6 +1,4 @@
 ---
-head: 'Source'
+title: "Sources"
 summary: ''
-path: 'https://digital.gov/'
-icon: 'icon-url'
 ---

--- a/content/topics/_index.md
+++ b/content/topics/_index.md
@@ -1,4 +1,4 @@
 ---
-url: /topics/
-title: 'Topics'
+title: "Topics"
+summary: ""
 ---


### PR DESCRIPTION
In HUGO, each folder and sub-folder within the `/content/` folder is considered a "section".

**Example:** 
```
content/
- about/
- communities/
- resources/
```

So as we build out better resource page organization, we are going to need a better way to build menus (navigation) that is accurate and also editable.

_See [Hugo Menu Templates](https://gohugo.io/templates/menu-templates/)_

So if we were to make something like:
```
content/
- about/
- communities/
- resources/
   - accessibility/
       - _index.md
       - automated-testing.md
       - testing-program.md
       - videos.md
   - getting started/
       - _index.md
       - tools-you-need.md
   - mobile/
       - _index.md
       - mobile-testing.md
   - performance/
       - _index.md
       - optimize-js.md
       - optimize-css.md
   - web-standards/
       - _index.md
       - uswds.md
```


This first step is just to clean up the current section index files to make sure they have the minimum amount of front matter needed to make them work. 

This will ensure that we can pull a better site navigation through the HUGO menus.

## What was changed

- Removed dates from the section indexes
- Added quotes around titles
- Removed authors on some of these

---

**Preview:** 
