### PR TITLE
Create action to close stale issues

### DIFF
--- a/.github/workflows/close-stale-issue.yml
+++ b/.github/workflows/close-stale-issue.yml
@@ -3,7 +3,7 @@ name: "Mark stale issues and pull requests"
 # Run every Friday at midnight
 on:
   schedule:
-  - cron: "0 0 * * FRI"
+  - cron: "0 0 * * *"
 
 jobs:
   stale:

--- a/.github/workflows/close-stale-issue.yml
+++ b/.github/workflows/close-stale-issue.yml
@@ -1,0 +1,24 @@
+name: Mark stale issues and pull requests
+
+# Run every Friday at midnight
+on:
+  schedule:
+  - cron: "0 0 * * FRI"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'Hello! 👋 It looks like this issue is stale because it has been open 60 days with no activity. This is usually because the request was already solved or it is no longer applicable. If this issue should remain open, remove the stale label or add a comment. Otherwise, this will be closed in 7 days.'
+        stale-pr-message: 'Hello! 👋 It looks like this pull request is stale because it has been open 60 days with no activity. This is usually because the request was already solved or it is no longer applicable. If this pull request should remain open, remove the stale label or add a comment. Otherwise, this will be closed in 7 days.'
+        days-before-stale: 60
+        days-before-close: 7
+        stale-issue-label: '[status] stale'
+        exempt-issue-label: '---- HOLD ----'
+        stale-pr-label: '[status] stale'
+        exempt-pr-label: '---- HOLD ----'

--- a/.github/workflows/close-stale-issue.yml
+++ b/.github/workflows/close-stale-issue.yml
@@ -1,4 +1,4 @@
-name: Mark stale issues and pull requests
+name: "Mark stale issues and pull requests"
 
 # Run every Friday at midnight
 on:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   stale:
-
+    
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
It looks like we can use GitHub Actions now. Creating a test workflow. 

This change will set up an Action that runs each Friday at midnight to look for stale Issues and Pull Requests.   

It will:
1. Review all Issues (includes PR's) and evaluate if they are stale. A Stale Issue is one that hasn't had any activity in 60 days. 
1. If so, adds a `[status] stale` label. 
1. Ignore any issue/pr with a label of `---- HOLD ----`.
1. Issues with the `[status] stale` label that haven't had additional activity will be automatically closed after 7 days.



Additional documentation for the [Stale action](https://github.com/actions/stale)