### PR TITLE
Removing GitHub from profile

### DIFF
--- a/content/authors/alan-atlas/_index.md
+++ b/content/authors/alan-atlas/_index.md
@@ -31,11 +31,11 @@ agency: "GSA"
 location: ""
 
 # A GitHub account will allow you to edit pages on DigitalGov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
-github: "AlanAtlas"
+github: ""
 
 # Profile Photo
 # See [URL] for a full list of profile photo options
-profile_photo: "github"
+profile_photo: ""
 
 # [e.g., Digital_Gov]
 twitter: ""


### PR DESCRIPTION
Dr. Atlas removed his Github profile after leaving 18F. He is fully retired and enjoying life.
I am removing it from his profile.

Note, this creates a white circle on the author image https://digital.gov/event/2019/11/14/intro-kanban-ii/

---

**Preview:** 
