### PR TITLE
removes XML pages for single pages

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -43,7 +43,7 @@ taxonomies:
 outputs:
   home: ["HTML","RSS", "SiteImages", "JSON"]
   section: ["HTML","RSS", "JSON"]
-  page: ["HTML","RSS", "JSON"]
+  page: ["HTML", "JSON"]
   taxonomy: ["HTML","RSS", "json"]
 
 # Goldmark is from Hugo 0.60 the default library used for Markdown.


### PR DESCRIPTION
This change removes the setting to build an XML page for every single page on the site. XML files are still being built out for sections.

This significantly reduces the number of pages built out:

```
+------------------+------+
  Pages            | 9673  
  Paginator pages  |  628  
  Non-page files   |    0  
  Static files     | 1036  
  Processed images |    0  
  Aliases          | 1295  
  Sitemaps         |    1  
  Cleaned          |    0  
```

```
+------------------+------+
  Pages            | 7630  
  Paginator pages  |  630  
  Non-page files   |    0  
  Static files     | 1036  
  Processed images |    0  
  Aliases          | 1296  
  Sitemaps         |    1  
  Cleaned          |    0 
```


---

**Preview:** 
