### PR TITLE
Update stale issue action

### DIFF
--- a/.github/workflows/close-stale-issue.yml
+++ b/.github/workflows/close-stale-issue.yml
@@ -1,9 +1,9 @@
 name: "Mark stale issues and pull requests"
 
-# Run every Friday at midnight
+# Run at 07:00 on every Monday
 on:
   schedule:
-  - cron: "0 0 * * *"
+  - cron: "0 7 * * mon"
 
 jobs:
   stale:


### PR DESCRIPTION
Changes include:

- Updates the Stale GitHub Action to only run once a week on Mondays
- Updates the schedule comment

Reasoning:
- Gives us more time to review the Issues that are marked as stale before they get closed out
- Uses less Action "minutes" so we can apply those to creating additional Actions.  


_**AFTER:**_
```
# Run at 07:00 on every Monday
on:
  schedule:
  - cron: "0 7 * * mon"
```