### PR TITLE
show all topics on pages with topics list

### DIFF
--- a/themes/digital.gov/layouts/partials/core/get_topics.html
+++ b/themes/digital.gov/layouts/partials/core/get_topics.html
@@ -29,8 +29,11 @@
 
       {{/* Show only topics with weight 2 or 3 */}}
       {{- if or (eq .Params.weight 2) (eq .Params.weight 3) -}}
-        <a href="{{- .Permalink -}}" data-topic="{{- $slug -}}">{{- .Title -}}</a>
+        {{/* <a href="{{- .Permalink -}}" data-topic="{{- $slug -}}">{{- .Title -}}</a> */}}
       {{- end -}}
+
+      {{/* Show all topics, regardless of weight */}}
+      <a href="{{- .Permalink -}}" data-topic="{{- $slug -}}">{{- .Title -}}</a>
 
     {{- end -}}
   {{- end -}}


### PR DESCRIPTION
This change makes it so that we are displaying ALL topics on pages where there is a topics list
It was previously only displaying topics with weight 2 or 3.

This will significantly reduce confusion around which topics appear where on the site.

---

🔍[**Preview** ](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/topics-list-weight/)
