### PR TITLE
fixing encoding in author names

### DIFF
--- a/themes/digital.gov/layouts/authors/list.html
+++ b/themes/digital.gov/layouts/authors/list.html
@@ -15,7 +15,7 @@
 
             <div>
               {{/* Name */}}
-              <h1>{{ .Params.display_name }}</h1>
+              <h1>{{- .Params.display_name | markdownify -}}</h1>
               {{/* Bio */}}
               <div class="bio">
 

--- a/themes/digital.gov/layouts/authors/terms.html
+++ b/themes/digital.gov/layouts/authors/terms.html
@@ -41,7 +41,7 @@
                       <div class="details">
                         <h5>
                           <a href="{{- $link | absURL -}} " title="Posts by {{- $author.Params.display_name | default $i -}} " rel="author">
-                            {{- $author.Params.display_name | default $i -}}
+                            {{- $author.Params.display_name | default $i | markdownify -}}
                           </a>
                         </h5>
 


### PR DESCRIPTION
### Fixes
https://github.com/GSA/digitalgov.gov/pull/2156
https://github.com/GSA/digitalgov.gov/issues/2077

The template tag for the author name needed `markdownify`
```
{{- .Params.display_name | markdownify -}}
```

**When live, these should be fixed**
- https://digital.gov/authors/russell-oneill/
- https://digital.gov/authors/kristen-onell/

Thanks to @afeijoo @monkeywithacupcake and @saracope for surfacing! 🎉 

---

🔎[**Preview**]( 
https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/author-name-encoding/authors/)