### PR TITLE
Add preview link action

### DIFF
--- a/.github/workflows/pr-preview-link.yml
+++ b/.github/workflows/pr-preview-link.yml
@@ -1,0 +1,23 @@
+name: add federalist preview link to PR
+
+on:
+  # Trigger the workflow pull request,
+  # but only for the master branch
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    name: Add Federalist Preview link
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Comment Pull Request
+        uses: thollander/actions-comment-pull-request@1.0.0
+        with:
+          message: ':mag: [__view the preview__](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/${{ github.head_ref }})'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    

--- a/.github/workflows/pr-preview-link.yml
+++ b/.github/workflows/pr-preview-link.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Comment Pull Request
         uses: thollander/actions-comment-pull-request@1.0.0
         with:
-          message: ':mag: [__view the preview__](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/${{ github.head_ref }})'
+          message: ':mag: [__Preview in Federalist__](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/${{ github.head_ref }})'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     


### PR DESCRIPTION
Changes include:
* add a github action to post the Federalist preview link to PR's

The workflow only runs on pull requests to the master branch.
It will automatically add a comment to the PR with a link to view the Federalist preview.
The link is generated based on the branch name.

The next todo would be to post the comment only after the federalist branch is done building. Right now it doesn't take that into consideration. This could cause some initial confusion with users BUT I need to see how it interacts with the current PR checks in order to add that piece.