### PR TITLE
Update 2020-04-16-federal-source-code-summit-building-coding.md

### DIFF
--- a/content/events/2020/04/2020-04-16-federal-source-code-summit-building-coding.md
+++ b/content/events/2020/04/2020-04-16-federal-source-code-summit-building-coding.md
@@ -1,6 +1,9 @@
 ---
 # View this page at https://digital.gov/event/2020/04/federal-source-code-summit-building-coding
-# Learn how to edit our pages at https://workflow.digital.gov
+# Learn how to edit our pages at https://workflow.digital.gov 
+
+draft: true
+
 slug: federal-source-code-summit-building-coding
 title: "Federal Source Code Summit: Building a Source Code Community"
 deck: ""


### PR DESCRIPTION
From Alex Y in DG's slack, 3/18: 
The Federal Code Summit is officially postponing... can you please hide the event page until they confirm a date with me? TY! https://digital.gov/event/2020/04/16/federal-source-code-summit-building-coding/

---

**Preview:** 
https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/postponed-draft-true/events/ 