### PR TITLE
Removing "sticky" weight on two posts

### DIFF
--- a/content/news/2019/12/2019-12-19-a-new-digitalgov.md
+++ b/content/news/2019/12/2019-12-19-a-new-digitalgov.md
@@ -19,10 +19,7 @@ topics:
 authors:
   - jeremyzilar
 
-# Page weight: controls how this page appears across the site
-# 0 -- hidden
-# 1 -- visible
-weight: 1
+
 
 featured_image:
   uid: digitalgov-new-2019

--- a/content/news/2020/03/2020-03-17-updates-on-21st-century-idea-key.md
+++ b/content/news/2020/03/2020-03-17-updates-on-21st-century-idea-key.md
@@ -12,7 +12,7 @@ deck: ""
 summary: "We spoke to Ammie Farraj Feijoo, GSA’s 21st Century IDEA implementation lead, to get the rundown on what’s been accomplished and what’s on deck for 2020."
 
 # see all topics at https://digital.gov/topics
-topics: 
+topics:
   - 21st-century-idea
   - design
   - metrics
@@ -21,16 +21,12 @@ topics:
   - ux
 
 # see all authors at https://digital.gov/authors
-authors: 
+authors:
   - stephanie-santana
 
 # primary Image (for social media)
 primary_image: "this-weeks-idea-card"
 
-# Page weight: controls how this page appears across the site
-# 0 -- hidden
-# 1 -- visible
-weight: 1
 
 # Make it better ♥
 
@@ -38,53 +34,53 @@ weight: 1
 
 {{< img-right src="21c-idea-icon-w600sq" >}}
 
-If you’ve been following the Digital.gov site, you may be familiar with our articles focusing on the [21st Century Integrated Digital Experience Act](https://digital.gov/resources/21st-century-integrated-digital-experience-act/) (21st Century IDEA). In a nutshell, the Act is intended “to improve executive agency digital services." There are five substantive parts to the Act, which reflect efforts to enhance the user experience. We spoke to 21st Century IDEA implementation lead, Ammie Farraj Feijoo, at the General Services Administration (GSA), to get the rundown on what’s been accomplished&mdash;and what’s on deck for 2020. 
+If you’ve been following the Digital.gov site, you may be familiar with our articles focusing on the [21st Century Integrated Digital Experience Act](https://digital.gov/resources/21st-century-integrated-digital-experience-act/) (21st Century IDEA). In a nutshell, the Act is intended “to improve executive agency digital services." There are five substantive parts to the Act, which reflect efforts to enhance the user experience. We spoke to 21st Century IDEA implementation lead, Ammie Farraj Feijoo, at the General Services Administration (GSA), to get the rundown on what’s been accomplished&mdash;and what’s on deck for 2020.
 
-## Completed in 2019: Modernization Planning 
+## Completed in 2019: Modernization Planning
 
-As Farraj Feijoo explains, there’s a “two-pronged” approach to modernizing websites under 21st Century IDEA. That includes focusing efforts on: 
+As Farraj Feijoo explains, there’s a “two-pronged” approach to modernizing websites under 21st Century IDEA. That includes focusing efforts on:
 
 - Ensuring all **new**, public-facing websites adhere to the eight requirements seen in [What Does It Mean to Modernize Websites](https://digital.gov/resources/21st-century-integrated-digital-experience-act/#what-does-it-mean-to-modernize-websites) (section 3(a) of the Act)
 - Planning out how to modernize **existing** websites that are “most viewed or utilized by the public” or “otherwise important for public engagement” (section 3(b) of the Act)
 
-## What Steps Are Helping to Achieve 21st Century IDEA Goals? 
+## What Steps Are Helping to Achieve 21st Century IDEA Goals?
 
-- **Planning for the Future**: Agencies developed plans on modernization progress. These plans included cost and schedule estimates to modernize high-priority and high-impact sites. 
-- **Documenting Efforts**: Agencies submitted comprehensive reports on their plans in December 2019 to OMB and to Congress. Many agencies have published their digital strategy on an agency.gov/digitalstrategy page of their main website (e.g., [gsa.gov/digitalstrategy](https://www.gsa.gov/technology/government-it-initiatives/digital-strategy)). 
+- **Planning for the Future**: Agencies developed plans on modernization progress. These plans included cost and schedule estimates to modernize high-priority and high-impact sites.
+- **Documenting Efforts**: Agencies submitted comprehensive reports on their plans in December 2019 to OMB and to Congress. Many agencies have published their digital strategy on an agency.gov/digitalstrategy page of their main website (e.g., [gsa.gov/digitalstrategy](https://www.gsa.gov/technology/government-it-initiatives/digital-strategy)).
 
-## GSA Case Study: Key Methods and Lessons Learned 
+## GSA Case Study: Key Methods and Lessons Learned
 
 Like all executive branch agencies, GSA is working to better understand its digital footprint, prioritize its websites and digital services, and create a plan to modernize those that need it. Below are a few key methods and lessons learned from GSA’s efforts to improve their digital services.
 
-- **Establish a cross-agency team**: That method was critical in gaining buy-in on all steps in the planning process. GSA’s team included representatives from its IT office, communications office, and customer experience office. 
-- **Understand the “landscape”**: GSA’s small, but resourceful team made a strategic choice to inventory their websites, which helped determine the range of content GSA was producing online as well as GSA’s overall digital footprint.  
-- **Ensure buy-in from senior level management**: In addition to the cross-agency team, GSA also established a digital governance senior steering committee. This way senior executives across the agency had multiple opportunities to give their input and support on deliverables. 
-- **Determine points of contact before a data call**: GSA’s team worked to identify what areas of critical feedback they wanted. They also made sure they had key points of contact for each of their determined domains, such as how searchable or accessible GSA sites are. The data call ultimately resulted in four target areas GSA identified to improve their digital presence. 
+- **Establish a cross-agency team**: That method was critical in gaining buy-in on all steps in the planning process. GSA’s team included representatives from its IT office, communications office, and customer experience office.
+- **Understand the “landscape”**: GSA’s small, but resourceful team made a strategic choice to inventory their websites, which helped determine the range of content GSA was producing online as well as GSA’s overall digital footprint.
+- **Ensure buy-in from senior level management**: In addition to the cross-agency team, GSA also established a digital governance senior steering committee. This way senior executives across the agency had multiple opportunities to give their input and support on deliverables.
+- **Determine points of contact before a data call**: GSA’s team worked to identify what areas of critical feedback they wanted. They also made sure they had key points of contact for each of their determined domains, such as how searchable or accessible GSA sites are. The data call ultimately resulted in four target areas GSA identified to improve their digital presence.
 
-- **Cross reference website data with analytics**: GSA found only about a dozen of its sites accounted for 95% of the web traffic. Those stats combined with information acquired from the data call helped GSA narrow down their focus. 
-- **Form a practice network**: GSA created a Content Management Community of Practice for its employees who manage websites and digital services. This enabled staff across the agency to share news, information, and resources all in one location. 
+- **Cross reference website data with analytics**: GSA found only about a dozen of its sites accounted for 95% of the web traffic. Those stats combined with information acquired from the data call helped GSA narrow down their focus.
+- **Form a practice network**: GSA created a Content Management Community of Practice for its employees who manage websites and digital services. This enabled staff across the agency to share news, information, and resources all in one location.
 
-- **Use the Maturity Model**: GSA has issued and is using the [U.S. Web Design System (USWDS) Maturity Model](https://designsystem.digital.gov/maturity-model/) to improve its web presence. 
+- **Use the Maturity Model**: GSA has issued and is using the [U.S. Web Design System (USWDS) Maturity Model](https://designsystem.digital.gov/maturity-model/) to improve its web presence.
 
 {{< img src="uswds-maturity-model" >}}
 
 
-## Up Next for 2020: Digitization 
+## Up Next for 2020: Digitization
 
-The next 21st Century IDEA deadline is for forms to be digital by **December 2020**. Agencies will have to create additional guidance on digitizing government services and forms. Here are four things you can do to tackle that task: 
+The next 21st Century IDEA deadline is for forms to be digital by **December 2020**. Agencies will have to create additional guidance on digitizing government services and forms. Here are four things you can do to tackle that task:
 
-- **Understand your agency’s forms landscape by conducting an inventory of its forms and the data the forms collect**: How many forms does your agency have? How is the data being collected? What information is needed? 
+- **Understand your agency’s forms landscape by conducting an inventory of its forms and the data the forms collect**: How many forms does your agency have? How is the data being collected? What information is needed?
 - **Engage with your agency forms program manager**
-- **Visit [PRA.digital.gov](http://pra.digital.gov)** to learn more about the Paperwork Reduction Act. 
+- **Visit [PRA.digital.gov](http://pra.digital.gov)** to learn more about the Paperwork Reduction Act.
 
-Finally, if you’re overwhelmed by 21st Century IDEA tasks or similar huge digital undertakings, we close out with a few of the many inspiring examples of federal websites that have done work to improve their customers’ online experience: 
+Finally, if you’re overwhelmed by 21st Century IDEA tasks or similar huge digital undertakings, we close out with a few of the many inspiring examples of federal websites that have done work to improve their customers’ online experience:
 
-- General Services Administration - [CIO.gov](http://www.cio.gov), [Digital.gov](http://www.digital.gov), [GSA.gov](https://www.gsa.gov) (plus read the respective blog posts about each team’s work on [What's New on CIO.gov](https://www.cio.gov/highlights-of-the-updated-cio/), [Welcome to the NEW Digital.gov](https://digital.gov/2019/12/19/a-new-digitalgov/), and [A Look at the New GSA.gov](https://digital.gov/2020/01/08/a-look-at-new-gsagov/)) 
-- Department of Homeland Security - [Ready.gov](http://www.ready.gov) 
-- Department of Commerce - [Commerce.gov](https://www.commerce.gov/) and [NIST.gov](http://www.NIST.gov) 
+- General Services Administration - [CIO.gov](http://www.cio.gov), [Digital.gov](http://www.digital.gov), [GSA.gov](https://www.gsa.gov) (plus read the respective blog posts about each team’s work on [What's New on CIO.gov](https://www.cio.gov/highlights-of-the-updated-cio/), [Welcome to the NEW Digital.gov](https://digital.gov/2019/12/19/a-new-digitalgov/), and [A Look at the New GSA.gov](https://digital.gov/2020/01/08/a-look-at-new-gsagov/))
+- Department of Homeland Security - [Ready.gov](http://www.ready.gov)
+- Department of Commerce - [Commerce.gov](https://www.commerce.gov/) and [NIST.gov](http://www.NIST.gov)
 - Department of Justice - [AmberAlert.gov](http://www.amberalert.gov) and [NIJ.gov ](https://nij.ojp.gov/)
-- Department of Health and Human Services - [FindTreatment.gov](https://findtreatment.gov/), [StopBullying.gov](http://www.stopbullying.gov), and [FoodSafety.gov](http://www.foodsafety.gov) 
-- Small Business Administration - [certify.SBA.gov](http://certify.SBA.gov) 
-- Department of Agriculture - [Farmers.gov](http://www.farmers.gov) 
+- Department of Health and Human Services - [FindTreatment.gov](https://findtreatment.gov/), [StopBullying.gov](http://www.stopbullying.gov), and [FoodSafety.gov](http://www.foodsafety.gov)
+- Small Business Administration - [certify.SBA.gov](http://certify.SBA.gov)
+- Department of Agriculture - [Farmers.gov](http://www.farmers.gov)
 
-_If you see a federal government site that you think warrants a shout out, [send us an email](mailto:digitalgov@gsa.gov)! Maybe it can become our next UX design feature post._ 
+_If you see a federal government site that you think warrants a shout out, [send us an email](mailto:digitalgov@gsa.gov)! Maybe it can become our next UX design feature post._


### PR DESCRIPTION
This change removes the `weight: 1` from the two posts at the top of the homepage news feed.
https://digital.gov/

---

**Preview:** 
