### PR TITLE
fixing the list of related services

### DIFF
--- a/themes/digital.gov/layouts/partials/core/list_related_services.html
+++ b/themes/digital.gov/layouts/partials/core/list_related_services.html
@@ -12,51 +12,37 @@ A list of the most important services tagged with the same topic */}}
   <ul>
     {{- range sort $services "Title" "asc" -}}
 
-    {{/* If an external link  */}}
-    {{- if or .Params.source_url .Params.source -}}
-
-    <li data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
-      <a class="" href="{{- .Params.source_url -}}?=dg" title="{{- .Title | markdownify -}}">
+      {{/* If an external link  */}}
+      {{- if or .Params.source_url .Params.source -}}
 
         {{/* If there is a defined source for this page */}}
         {{- if .Params.source -}}
-          {{- $source := $.Site.GetPage "page" (print "source_" .Params.source ) -}}
+          {{/* Get the source data */}}
+          {{- $source := .Site.GetPage (print "source_" .Params.source ) -}}
+          {{/* If there is a logo defined in the source */}}
           {{- if $source.Params.logo -}}
-
-            {{/*
-            We have two folders for source icons
-            - /logos/ — this is for logos to be used in the newsfeed and the icons
-            - logos/icons/ — for overriding the icon image
-            */}}
-            {{- $icon_url := (print "/static/logos/_icons/" $source.Params.logo) -}}
-            {{- if (fileExists $icon_url) -}}
-              <img src="{{- (print "/logos/_icons/" $source.Params.logo) | relURL -}}" alt="{{- $source.Params.name -}} logo"/><span>{{- .Title | markdownify -}}</span>
-            {{- else -}}
-              <img src="{{- (print "/logos/" $source.Params.logo) | relURL -}}" alt="{{- $source.Params.name -}} logo"/><span>{{- .Title | markdownify -}}</span>
-            {{- end -}}
-
+            {{/* get the path for the icon — e.g. 18f-icon.png */}}
+            {{- $src := (printf "/logos/%s%s" $source.Params.logo "-icon.png") -}}
+            {{/* Pass these vars into the list item template (botton of page) */}}
+            {{- template "list-item-resource" dict "item" . "href" (print .Params.source_url "?dg") "src" $src -}}
 
           {{- end -}}
-
         {{/* No source? let's attempt to get the favicon for the URL */}}
         {{- else -}}
-          <img src="https://www.google.com/s2/favicons?domain={{- .Params.source_url -}}" alt="{{- .Params.source -}} logo"/><span>{{- .Title | markdownify -}}</span>
+          {{/* get the Favicon via Google Favicon service */}}
+          {{- $src := (print "https://www.google.com/s2/favicons?domain=" .Params.source_url) -}}
+          {{/* Pass these vars into the list item template (botton of page) */}}
+          {{- template "list-item-resource" dict "item" . "href" (print .Params.source_url "?dg") "src" $src -}}
         {{- end -}}
 
-      </a>
-      {{- if .Params.deck }} — {{ .Params.deck -}}{{- end -}}</li>
+      {{/* If an internal link... */}}
+      {{- else -}}
 
-    {{/* If an internal link  */}}
-    {{- else -}}
-    <li data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
-      <a href="{{- .Permalink -}}" title="{{ .Title | markdownify }}">
         {{/* Use the digital.gov logo */}}
-        {{- $source_url := (print "/img/digit-50.png") -}}
-        <img class="thumb" src="{{ $source_url | relURL }}" alt="{{ .Title }} Logo">
-        <span>{{ .Title | markdownify }}</span>
-      </a>
-      {{- if .Params.deck }} — {{ .Params.deck -}}{{- end -}}</li>
-    {{- end -}}
+        {{/* Pass these vars into the list item template (botton of page) */}}
+        {{- template "list-item-resource" dict "item" . "href" (print .Permalink "?dg") "src" (print "/img/digit-50.png") -}}
+
+      {{- end -}}
 
     {{- end -}}
   </ul>


### PR DESCRIPTION
The list collection for services on the topics pages is not working as expected. 😞 
https://digital.gov/topics/accessibility/

This fixes that 😄 



---

**Preview:** https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/fix-topics-list/topics/accessibility/
