### PR TITLE
Clarify the full link

### DIFF
--- a/themes/digital.gov/layouts/shortcodes/card-policy.html
+++ b/themes/digital.gov/layouts/shortcodes/card-policy.html
@@ -19,7 +19,7 @@
   <div id="card-policy-{{- .Page.Scratch.Get "count" -}}" class="card-policy-body usa-accordion__content usa-prose">
     {{- .Inner | markdownify -}}
 
-    <a class="src" href="{{- .Get "src" }}" title="View {{ .Get "name" | plainify -}}">View the full document <i class="fas fa-arrow-right"></i></a>
+    <a class="src" href="{{- .Get "src" }}" title="View {{ .Get "name" | plainify -}}">View the full legislation <i class="fas fa-arrow-right"></i></a>
   </div>
   {{- end -}}
 


### PR DESCRIPTION
Clarify that the `view full` link prompts visitors to view the full `legislation` on Congress.gov