### PR TITLE
Fixing services directory listing

### DIFF
--- a/content/services/electronic-capital-planning-and-investment-control-ecpic.md
+++ b/content/services/electronic-capital-planning-and-investment-control-ecpic.md
@@ -4,7 +4,7 @@ summary: "An application helps automate capital planning and portfolio managemen
 contact: ecpic.pmo@gsa.gov
 source: "digitalgov"
 logo: 'digitalgov'
-
+weight: 1
 ---
 
 <div class="deck"><p>The eCPIC application helps automate capital planning and portfolio management processes for enabling government agencies to effectively mature their investment management strategies and achieve agency mission goals and objectives.</p></div>

--- a/content/services/service_18f.md
+++ b/content/services/service_18f.md
@@ -20,7 +20,7 @@ contact: inquiries18F@gsa.gov
 # 2 == will appear as related service (ADs) on blog posts and event pages
 # 1 == will appear on the tools and services page, and all related topic pages
 # 0 == hides this service from all pages, but URL is still public
-weight: 0
+weight: 1
 
 # Topics that best describe this product or service
 topics:

--- a/content/services/service_challengegov.md
+++ b/content/services/service_challengegov.md
@@ -22,7 +22,7 @@ contact: team@challenge.gov
 # 2 == will appear as related service (ADs) on blog posts and event pages
 # 1 == will appear on the tools and services page, and all related topic pages
 # 0 == hides this service from all pages, but URL is still public
-weight: 1
+weight: 2
 
 # Topics that best describe this product or service
 topics:

--- a/content/services/service_citizen-science.md
+++ b/content/services/service_citizen-science.md
@@ -21,7 +21,7 @@ contact: citizenscience@gsa.gov
 # 2 == will appear as related service (ADs) on blog posts and event pages
 # 1 == will appear on the tools and services page, and all related topic pages
 # 0 == hides this service from all pages, but URL is still public
-weight: 1
+weight: 2
 
 # see all authors at https://digital.gov/authors
 authors:

--- a/content/services/service_data-gov.md
+++ b/content/services/service_data-gov.md
@@ -23,7 +23,7 @@ contact: datagovhelp@gsa.gov
 # 2 == will appear as related service (ADs) on blog posts and event pages
 # 1 == will appear on the tools and services page, and all related topic pages
 # 0 == hides this service from all pages, but URL is still public
-weight: 1
+weight: 2
 
 # see all authors at https://digital.gov/authors
 authors:

--- a/content/services/service_dotgov.md
+++ b/content/services/service_dotgov.md
@@ -23,7 +23,7 @@ authors:
 # 2 == will appear as related service (ADs) on blog posts and event pages
 # 1 == will appear on the tools and services page, and all related topic pages
 # 0 == hides this service from all pages, but URL is still public
-weight: 1
+weight: 2
 
 # Topics that best describe this product or service
 topics:

--- a/content/services/service_fedramp.md
+++ b/content/services/service_fedramp.md
@@ -21,7 +21,7 @@ contact: info@FedRAMP.gov
 # 2 == will appear as related service (ADs) on blog posts and event pages
 # 1 == will appear on the tools and services page, and all related topic pages
 # 0 == hides this service from all pages, but URL is still public
-weight: 1
+weight: 2
 
 # see all authors at https://digital.gov/authors
 authors:

--- a/content/services/service_opm_labs.md
+++ b/content/services/service_opm_labs.md
@@ -21,7 +21,7 @@ contact: "lab@opm.gov"
 # 2 == will appear as related service (ADs) on blog posts and event pages
 # 1 == will appear on the tools and services page, and all related topic pages
 # 0 == hides this service from all pages, but URL is still public
-weight: 0
+weight: 2
 
 # Topics that best describe this product or service
 topics:

--- a/content/services/service_pif.md
+++ b/content/services/service_pif.md
@@ -19,7 +19,7 @@ contact: 'pif-team@pif.gov'
 # 2 == will appear as related service (ADs) on blog posts and event pages
 # 1 == will appear on the tools and services page, and all related topic pages
 # 0 == hides this service from all pages, but URL is still public
-weight: 0
+weight: 1
 
 # Topics that best describe this product or service
 topics:

--- a/content/services/service_plainlanguage.md
+++ b/content/services/service_plainlanguage.md
@@ -21,7 +21,7 @@ contact: info@plainlanguage.gov
 # 2 == will appear as related service (ADs) on blog posts and event pages
 # 1 == will appear on the tools and services page, and all related topic pages
 # 0 == hides this service from all pages, but URL is still public
-weight: 0
+weight: 1
 
 # see all authors at https://digital.gov/authors
 authors:

--- a/content/services/service_pra.md
+++ b/content/services/service_pra.md
@@ -20,7 +20,7 @@ contact: pra@omb.eop.gov
 # 2 == will appear as related service (ADs) on blog posts and event pages
 # 1 == will appear on the tools and services page, and all related topic pages
 # 0 == hides this service from all pages, but URL is still public
-weight: 0
+weight: 1
 
 # see all authors at https://digital.gov/authors
 authors:

--- a/content/services/service_resources-data-gov.md
+++ b/content/services/service_resources-data-gov.md
@@ -23,7 +23,7 @@ contact: datagovhelp@gsa.gov
 # 2 == will appear as related service (ADs) on blog posts and event pages
 # 1 == will appear on the tools and services page, and all related topic pages
 # 0 == hides this service from all pages, but URL is still public
-weight: 0
+weight: 1
 
 # see all authors at https://digital.gov/authors
 authors:

--- a/content/services/service_section508-gov.md
+++ b/content/services/service_section508-gov.md
@@ -19,7 +19,7 @@ contact: section.508@gsa.gov
 # 2 == will appear as related service (ADs) on blog posts and event pages
 # 1 == will appear on the tools and services page, and all related topic pages
 # 0 == hides this service from all pages, but URL is still public
-weight: 0
+weight: 1
 
 # see all authors at https://digital.gov/authors
 authors:

--- a/content/services/service_usagov.md
+++ b/content/services/service_usagov.md
@@ -21,7 +21,7 @@ source_url: "https://www.usa.gov/"
 # 2 == will appear as related service (ADs) on blog posts and event pages
 # 1 == will appear on the tools and services page, and all related topic pages
 # 0 == hides this service from all pages, but URL is still public
-weight: 0
+weight: 1
 
 # see all authors at https://digital.gov/authors
 topics:

--- a/content/services/service_usds.md
+++ b/content/services/service_usds.md
@@ -19,7 +19,7 @@ contact: 'USDS@omb.eop.gov'
 # 2 == will appear as related service (ADs) on blog posts and event pages
 # 1 == will appear on the tools and services page, and all related topic pages
 # 0 == hides this service from all pages, but URL is still public
-weight: 0
+weight: 1
 
 # Topics that best describe this product or service
 topics:

--- a/themes/digital.gov/layouts/services/directory.html
+++ b/themes/digital.gov/layouts/services/directory.html
@@ -25,6 +25,9 @@
   {{/* Gets all service pages */}}
   {{- $services := (where .Site.RegularPages "Section" "services") -}}
 
+  {{/* Gather only the pages with a weight greater than or equal to 1 */}}
+  {{- $services := (where $services ".Params.weight" "ge" 1) -}}
+
   <div class="grid-container grid-container-desktop-lg">
     <div class="grid-row">
       <div class="grid-col-12">

--- a/themes/digital.gov/layouts/services/list.html
+++ b/themes/digital.gov/layouts/services/list.html
@@ -29,7 +29,7 @@
         {{- $services := (where .Site.Pages "Section" "services") -}}
 
         {{/* Gather only the pages with a weight greater than or equal to 1 */}}
-        {{- $services_featured := (where $services ".Params.weight" "ge" 1) -}}
+        {{- $services_featured := (where $services ".Params.weight" "ge" 2) -}}
 
         {{- with $services_featured -}}
 
@@ -38,7 +38,9 @@
             {{- .Render "card-service" -}}
 
           {{- end -}}
+
         {{- end -}}
+        
         </div>
       </div>
 


### PR DESCRIPTION
This fixes https://github.com/GSA/digitalgov.gov/issues/2318 from @afeijoo 

## what was fixed

- updated the [featured Services](https://digital.gov/services/) template to look for pages with a weight of 2 or greater
- updated the [Services directory](https://digital.gov/services/directory/) template to look for pages with a weight of 1 or greater
- updated the featured services to have a `weight: 2`
- updated the non-featured services to have a `weight: 1`
- made the services directory page a `weight: 0` to hide it from the listings

---

**Preview:** 
