### PR TITLE
Create author bio partial

### DIFF
--- a/themes/digital.gov/layouts/authors/list.json.json
+++ b/themes/digital.gov/layouts/authors/list.json.json
@@ -32,9 +32,7 @@
     {{- if .Params.location -}}
     "location" : "{{- .Params.location -}}",
     {{- end -}}
-    {{- if .Params.bio -}}
-    "bio" : "{{- .Params.bio -}}",
-    {{- end -}}
+    {{- partial "api/bio" . -}}
     {{- if .Params.bio_url -}}
     "bio_url" : "{{- .Params.bio_url -}}",
     {{- end -}}

--- a/themes/digital.gov/layouts/partials/api/bio.html
+++ b/themes/digital.gov/layouts/partials/api/bio.html
@@ -1,0 +1,3 @@
+{{- with .Params.bio -}}
+"bio" : "{{- . -}}",
+{{- end -}}

--- a/themes/digital.gov/layouts/shortcodes/api-authors.html
+++ b/themes/digital.gov/layouts/shortcodes/api-authors.html
@@ -41,9 +41,9 @@
         {{- if .Params.location -}}
         "location" : "{{- .Params.location -}}",
         {{- end -}}
-        {{- if .Params.bio -}}
-        "bio" : "{{- .Params.bio -}}",
-        {{- end -}}
+
+        {{- partial "api/bio" . -}}
+        
         {{- if .Params.bio_url -}}
         "bio_url" : "{{- .Params.bio_url -}}",
         {{- end -}}


### PR DESCRIPTION
A one-line description of the changes you're making and how they'll affect users.

Updates the author API to extract the code for creating the `bio` key/value pair into a partial for better reuse.
---

**🔎Preview:**  https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/sc_bio-partial/authors/v1/json/
