### PR TITLE
Fix button contrast

### DIFF
--- a/content/news/2019/11/2019-11-18-building-elements-that-earn-trust.md
+++ b/content/news/2019/11/2019-11-18-building-elements-that-earn-trust.md
@@ -33,11 +33,12 @@ The more we do this work, it becomes clear that trust is a key value that overla
 
 We’d like to get your help in defining the elements that we all need to have in place to start earning trust, and what actions federal digital teams need to take to get there.
 
-{{< card-prompt intro="**In your words, help us complete these two sentences.** There are no right or wrong answers, and you’re welcome to submit as many times as you’d like." button="Submit your answers" url="https://github.com/GSA/digitalgov.gov/issues/1517">}}
+{{< card-prompt intro="**In your words, help us complete these two sentences.** There are no right or wrong answers, and you’re welcome to submit as many times as you’d like.">}}
 
 1. To deliver an experience that is trustworthy, we need to _____________.
 2. To perform this action, we need _______________.
 {{< /card-prompt >}}
+{{< button href="https://github.com/GSA/digitalgov.gov/issues/1517" text="Submit your answers" >}}  
 
 **An example might be**:
 


### PR DESCRIPTION
For https://digital.gov/2019/11/18/building-elements-that-earn-trust/

Use the button shortcode to fix the color contrast.

The previous code (card-prompt) generated a <button> html tag around the Submit link which isn’t appropriate to use here as this is not an actual form.
I updated it to use the button shortcode which gives is some styling to look like a button without the misleading/inappropriate tag.

**_before:_**
<img width="638" alt="Screen Shot 2020-04-13 at 12 35 50 PM" src="https://user-images.githubusercontent.com/2197515/79138921-5c3e5c80-7d83-11ea-82f3-e9aa65ba7532.png">

**_after:_**
<img width="657" alt="Screen Shot 2020-04-13 at 12 35 56 PM" src="https://user-images.githubusercontent.com/2197515/79138930-606a7a00-7d83-11ea-9c77-ed957dc5f1b8.png">


closes #2354 
