### PR TITLE
Update resource

### DIFF
--- a/content/resources/coronavirus-covid19-guidance-for-us-government.md
+++ b/content/resources/coronavirus-covid19-guidance-for-us-government.md
@@ -61,13 +61,30 @@ Link to authoritative information from other government agencies related to your
 
 The White House, in collaboration with DHS and HHS, encourages agencies to feature the following content on both their agency homepages and coronavirus pages as appropriate.
 
-### Last updated April 1, 2020
+### Last updated April 16, 2020
+-   **Schema.org 7.0 Tags for Coronavirus Pages**: The [White House and key federal agencies](https://www.whitehouse.gov/articles/connecting-americans-coronavirus-information-online/) are working alongside Schema.org to help ensure coronavirus resources are prioritized with online search engines. [Schema.org has released new standard tags](http://blog.schema.org/2020/03/schema-for-coronavirus-special.html) for webpages; [view the implementation instructions](https://developers.google.com/search/docs/data-types/special-announcements).
+    
+-   **Coronavirus Aid, Relief, and Economic Security (CARES) Act**: The Treasury Department is hard at work implementing the [CARES Act](https://treasury.gov/coronavirus) to provide relief for hard working American families, small businesses, and various industries impacted by coronavirus (COVID-19). This site includes valuable resources for these groups.
+    
 
-- [**Updated: Coronavirus Guidelines for America**](https://www.whitehouse.gov/briefings-statements/coronavirus-guidelines-america/) — The White House Coronavirus Task Force has issued an updated version of this document.
-- [**Frequently Asked Questions**](https://faq.coronavirus.gov) — An interagency website, organized by the White House Coronavirus Task Force, for definitive information on the public’s most frequently asked questions. The site currently features content from the Department of Health and Human Services, Department of Homeland Security, Federal Emergency Management Agency (FEMA), Department of the Treasury, and Small Business Administration.
-- [**Small Business Resources**](https://www.coronavirus.gov/smallbusiness/) — The White House Coronavirus Task Force has provided this information on various assistance programs available to small businesses.
-- [**FEMA Rumor Control**](https://www.fema.gov/Coronavirus-Rumor-Control) — Helping the public distinguish between rumors and facts regarding the coronavirus (COVID-19) pandemic. A great resource for social media – if you see a rumor, reply back with the correct answer and link to the FEMA Rumor Control page.
-- [**FEMA How You Can Help**](https://www.fema.gov/coronavirus/how-to-help) — Learn the best way to donate, volunteer, or provide critical supplies to fight the COVID-19 pandemic.
+-   **Coronavirus Tax Relief**: The Internal Revenue Service (IRS) is offering [Coronavirus Tax Relief](http://www.irs.gov/coronavirus) for individuals, businesses, tax-exempt organizations and others affected by coronavirus (COVID-19). This includes information on Economic Impact Payments going to millions of people.
+    
+
+-   **OPM Open Opportunities**: The OPM COVID-19 Response Program is using [Open Opportunities](https://openopps.usajobs.gov/) as a central location for federal agencies to post details and temporary assignments related to coronavirus (COVID-19). Open Opportunities is a governmentwide platform offering professional development opportunities to current federal employees. If your agency is interested in participating:
+    -   Email [workforce@opm.gov](mailto:workforce@opm.gov) so OPM can invite you to a virtual information session.
+    -  Post details and temporary assignments to [Open Opportunities](https://openopps.usajobs.gov/).
+
+{{< accordion kicker="Previous update" title="**April 1, 2020**:" >}}
+
+- [**Updated: Coronavirus Guidelines for America**](https://www.whitehouse.gov/briefings-statements/coronavirus-guidelines-america/) — The White House Coronavirus Task Force has issued an updated version of this document.  
+- [**Frequently Asked Questions**](https://faq.coronavirus.gov) — An interagency website, organized by the White House Coronavirus Task Force, for definitive information on the public’s most frequently asked questions. The site currently features content from the Department of Health and Human Services, Department of Homeland Security, Federal Emergency Management Agency (FEMA), Department of the Treasury, and Small Business Administration.  
+- [**Small Business Resources**](https://www.coronavirus.gov/smallbusiness/) — The White House Coronavirus Task Force has provided this information on various assistance programs available to small businesses.  
+- [**FEMA Rumor Control**](https://www.fema.gov/Coronavirus-Rumor-Control) — Helping the public distinguish between rumors and facts regarding the coronavirus (COVID-19) pandemic. A great resource for social media – if you see a rumor, reply back with the correct answer and link to the FEMA Rumor Control page.  
+- [**FEMA How You Can Help**](https://www.fema.gov/coronavirus/how-to-help) — Learn the best way to donate, volunteer, or provide critical supplies to fight the COVID-19 pandemic.  
+
+{{< /accordion >}}
+
+
 
 ## Web Guidance
 

--- a/themes/digital.gov/layouts/shortcodes/accordion.html
+++ b/themes/digital.gov/layouts/shortcodes/accordion.html
@@ -1,0 +1,32 @@
+<div class="usa-accordion accordion">
+
+  {{- .Page.Scratch.Add "count" 1 -}}
+
+  <h3 class="usa-accordion__heading">
+    <button class="usa-accordion__button"
+      title="View {{ .Get "name" | plainify -}}"
+      aria-expanded="false"
+      aria-controls="accordion-{{- .Page.Scratch.Get "count" -}}">
+        {{ if (.Get "icon") -}}
+          <span class="icon">
+            <i class="{{- .Get "icon" -}}"></i>
+          </span>
+        {{- else -}}
+          <span class="icon">
+            <i class="fas fa-layer-group"></i>
+          </span>
+        {{- end -}}
+      <span class="src">
+        {{ if (.Get "kicker") -}}<strong class="kicker">{{- .Get "kicker" -}}</strong>{{- end -}}
+        {{- .Get "title" | markdownify }}
+        {{ if (.Get "pdf") -}}<em>{{- .Get "pdf" -}}</em>{{- end -}}</span>
+    </button>
+  </h3>
+
+  {{- if .Inner -}}
+  <div id="accordion-{{- .Page.Scratch.Get "count" -}}" class="accordion-body usa-accordion__content usa-prose">
+    {{- .Inner | markdownify -}}
+  </div>
+  {{- end -}}
+
+</div>

--- a/themes/digital.gov/src/scss/new/shortcodes/_accordion.scss
+++ b/themes/digital.gov/src/scss/new/shortcodes/_accordion.scss
@@ -1,0 +1,83 @@
+.accordion{
+	@include u-margin-y(2);
+	@include u-maxw('tablet');
+	button{
+		@include u-padding-y('105');
+		@include u-padding-left(7);
+		@include u-padding-right(5);
+		@include at-media('tablet') {
+			@include u-padding-right(7);
+		}
+		@include u-text('medium');
+		@include u-text('violet-80');
+		@include u-line-height('serif', 3);
+		@include u-position('relative');
+		@include u-bg('violet-10');
+		@include u-font('sans', 'xs');
+		@include u-radius('sm');
+		.icon{
+			@include u-padding-x('105');
+			@include u-position('absolute');
+			@include u-top(0);
+			@include u-left(0);
+			@include u-height('full');
+			@include u-display('flex');
+			@include u-flex('align-center');
+			@include u-text('white');
+			@include u-bg('violet-50');
+			@include u-radius-left('sm');
+		}
+
+		.src{
+			@include u-text('medium');
+			em{
+				@include u-margin-left('2px');
+				@include u-text('base-dark');
+				@include u-text('italic');
+				@include u-text('normal');
+			}
+			strong{
+				@include u-text('heavy');
+			}
+			.kicker{
+				@include u-margin-bottom('05');
+				@include u-display('block');
+				@include u-text('uppercase');
+				@include u-text('light');
+				@include u-font('sans', '3xs');
+			}
+		}
+		&:hover{
+			@include u-bg('violet-20');
+			.icon{
+				@include u-bg('violet-60');
+			}
+		}
+	}
+	.accordion-body{
+		@include u-padding-y(4);
+		@include u-padding-x(4);
+		@include u-padding-left(7);
+		@include at-media('tablet') {
+			@include u-padding-left(7);
+		}
+		@include u-bg('gray-3');
+		@include u-text('violet-80');
+		@include u-radius-bottom('sm');
+		@include u-line-height('serif', 5);
+		blockquote{
+			@include u-margin-x(0);
+			@include u-padding(0);
+			@include u-padding-left(2);
+			@include u-border-left('2px', 'base', 'solid');
+			@include u-text('base');
+		}
+		.src{
+			@include u-margin-top(3);
+			@include u-font('sans', 'xs');
+			@include u-text('violet-80');
+			@include u-text('medium');
+			@include u-display('block');
+		}
+	}
+}

--- a/themes/digital.gov/src/scss/new/styles.scss
+++ b/themes/digital.gov/src/scss/new/styles.scss
@@ -118,6 +118,7 @@
 // Edit Tools
 @import 'edit-this';
 
+@import 'shortcodes/accordion';
 @import 'shortcodes/box';
 @import 'shortcodes/note';
 @import 'shortcodes/highlight';


### PR DESCRIPTION
Changes include:
- Add an accordion shortcode that takes the following parameters
  
  - kicker: text to display above the title; will be capitalized
  - title: heading for the content you're collapsing
  - icon: use this to change the icon shown in the accordion. It defaults to "fas fa-layer-group" [shown here](https://fontawesome.com/icons/layer-group?style=solid)

- Update `/resources/coronavirus-covid19-guidance-for-us-government/` to:
  - Add the April 16 update
  - Move the April 1 update to the new accordion section


<img width="821" alt="Screen Shot 2020-04-16 at 3 12 03 PM" src="https://user-images.githubusercontent.com/2197515/79498085-c14db880-7ff6-11ea-8285-01be7b93ecdd.png">

_Expanded:_
<img width="766" alt="Screen Shot 2020-04-16 at 3 12 15 PM" src="https://user-images.githubusercontent.com/2197515/79498084-c14db880-7ff6-11ea-8be2-c591867c18a0.png">

Added documentation for the `accordion` shortcode to [our wiki](https://github.com/GSA/digitalgov.gov/wiki/Hugo-shortcodes)