### PR TITLE
Update email address on Communities page

### DIFF
--- a/themes/digital.gov/layouts/communities/list.html
+++ b/themes/digital.gov/layouts/communities/list.html
@@ -66,7 +66,7 @@
 
         </div>
         <div class="grid-col-12 tablet:grid-col-4">
-          <p><strong>For more information on Communities</strong>, or to propose a new inter-agency group, please send an email to <a href="mailto:digitalgov@gsa.gov?subject=Communities">digitalgov@gsa.gov</a>.</p>
+          <p><strong>For more information on Communities</strong>, or to propose a new inter-agency group, please send an email to <a href="mailto:digitalgovu@gsa.gov?subject=Communities">digitalgovu@gsa.gov</a>.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Changes:
- Update the Communities page to list the digitalgovu@gsa.gov to direct those messages to the right reviewers. 

https://digital.gov/communities/

_Before:_
<img width="1168" alt="Screen Shot 2020-04-17 at 5 27 44 PM" src="https://user-images.githubusercontent.com/2197515/79615477-e7478b80-80d0-11ea-80a8-ab6a8270036b.png">


_After:_
<img width="1050" alt="Screen Shot 2020-04-17 at 5 32 56 PM" src="https://user-images.githubusercontent.com/2197515/79615774-810f3880-80d1-11ea-970e-909d6f9ce263.png">
