### PR TITLE
New news: Connecting Americans to Coronavirus Information Online

### DIFF
--- a/content/news/2020/04/2020-04-24-connecting-americans-coronavirus-information-online.md
+++ b/content/news/2020/04/2020-04-24-connecting-americans-coronavirus-information-online.md
@@ -1,0 +1,31 @@
+---
+# View this page at https://digital.gov/2020/04/24/connecting-americans-coronavirus-information-online
+# Learn how to edit our pages at https://workflow.digital.gov
+
+# originally published at the following URL
+source_url: "https://www.whitehouse.gov/articles/connecting-americans-coronavirus-information-online/"
+
+# Which team published this?
+# Learn about sources at https://workflow.digital.gov/sources
+source: whitehouse
+slug: connecting-americans-coronavirus-information-online
+
+# Short URL — https://go.usa.gov/
+short_url: http://go.usa.gov/xvRxJ
+date: 2020-04-24 10:00:00 -0500
+kicker: "Findability"
+title: "Connecting Americans to Coronavirus Information Online"
+deck: "**The American people need access to the most up-to-date public health guidance and information on coronavirus testing facilities.** To help Americans find coronavirus information online, incorporate Schema.org’s new standard tags into all web pages related to COVID-19. "
+summary: "**The American people need access to the most up-to-date public health guidance and information on coronavirus testing facilities.** To help Americans find coronavirus information online, incorporate Schema.org’s new standard tags into all web pages related to COVID-19. "
+
+# see all topics at https://digital.gov/topics
+topics: 
+  - content-strategy
+  - cx
+  - metadata
+  - search-engine-optimization
+
+authors:
+  - matt-harmon
+# Make it better ♥
+---


### PR DESCRIPTION
New link post provided by DHS:

**The American people need access to the most up-to-date public health guidance and information on coronavirus testing facilities.** To help Americans find coronavirus information online, incorporate Schema.org’s new standard tags into all web pages related to COVID-19.


