### PR TITLE
Fix bio

### DIFF
--- a/content/authors/dr-emily-shen/_index.md
+++ b/content/authors/dr-emily-shen/_index.md
@@ -15,10 +15,7 @@ pronoun: ""
 email: 
 
 # Bio — keep it under 50 words
-bio: "A technical staff member in the Secure Resilient Systems and Technology Group at MIT Lincoln Laboratory. Her primary research interests lie in cryptography. She currently leads projects designing and developing secure multi-party computation technology for privacy-preserving collaboration. She has also worked on cryptographically secure database search and access control.  
-
-Dr. Shen is a recipient of the 2019 MIT Lincoln Laboratory Early Career Technical Achievement Award. Prior to joining the Laboratory in 2013, she received a BS degree, with distinction and honors, in computer science from Stanford University in 2006, and SM and PhD degrees in electrical engineering and computer science from MIT in 2008 and 2013, respectively.
-"
+bio: "A technical staff member in the Secure Resilient Systems and Technology Group at MIT Lincoln Laboratory. Her primary research interests lie in cryptography. She currently leads projects designing and developing secure multi-party computation technology for privacy-preserving collaboration. She has also worked on cryptographically secure database search and access control."
 
 # bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
 bio_url: 


### PR DESCRIPTION
Weirdly, when someone has more than one paragraph in their bio, it breaks the authors API. 

Updating author bio for Dr. Emily Shen here to fix the API.


```
"dr-emily-shen": {
			"display_name": "Dr. Emily Shen",
			"first_name": "Emily ",
			"last_name": "Shen",
			"slug": "dr-emily-shen",
			**"bio": "A technical staff member in the Secure Resilient Systems and Technology Group at MIT Lincoln Laboratory. Her primary research interests lie in cryptography. She currently leads projects designing and developing secure multi-party computation technology for privacy-preserving collaboration. She has also worked on cryptographically secure database search and access control.
			Dr.Shen is a recipient of the 2019 MIT Lincoln Laboratory Early Career Technical Achievement Award.Prior to joining the Laboratory in 2013,
			she received a BS degree,
			with distinction and honors,
			in computer science from Stanford University in 2006,
			and SM and PhD degrees in electrical engineering and computer science from MIT in 2008 and 2013,
			respectively.
			","**
			branch " :"
			master ","
			filename " :"
			_index.md ","
			filepath " : "
			authors / dr - emily - shen / _index.md ",
			"filepathURL": "https://github.com/GSA/digitalgov.gov/blob/master/content/author
```