### PR TITLE
Update twidea-9-mural-meetup-summary.yml

### DIFF
--- a/data/images/twidea-9-mural-meetup-summary.yml
+++ b/data/images/twidea-9-mural-meetup-summary.yml
@@ -10,4 +10,4 @@ height   : 5939
 format   : png
 credit   : ""
 caption  : "Summary from four breakout groups."
-alt      : "Screen capture of five groups of notes in light green, light blue, pink, yellow, and black, are displayed in an online whiteboard."
+alt      : "Screen capture of 325 notes that have been separated into five groups in four columns on an online whiteboard. There are 59 light green notes under Group 1 (A great experience is straightforward and makes sense, it just takes ...). There are 111 light blue cards in Group 2 (To deliver an experience that solves a problem, I need ...). There are 60 pink cards in Group 3 (To make a better digital experience, it would be helpful to have access to ...). There are 85 yellow cards in Group 4 (To make me feel capable and in control of the digital experience, I need ...). Ten black cards are in an additional group, Miscellaneous, below Group 1 in the bottom left corner. In the paragraph below this image, there is a link to the whiteboard where one can zoom in and out to read the cards."


### PR DESCRIPTION
updated alt text to:

"Screen capture of 325 notes that have been separated into five groups in four columns on an online whiteboard. There are 59 light green notes under Group 1 (A great experience is straightforward and makes sense, it just takes ...). There are 111 light blue cards in Group 2 (To deliver an experience that solves a problem, I need ...). There are 60 pink cards in Group 3 (To make a better digital experience, it would be helpful to have access to ...). There are 85 yellow cards in Group 4 (To make me feel capable and in control of the digital experience, I need ...). Ten black cards are in an additional group, Miscellaneous, below Group 1 in the bottom left corner. In the paragraph below this image, there is a link to the whiteboard where one can zoom in and out to read the cards."

---

**Preview:** 
https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/updated-alt-text/images/ 