### PR TITLE
Update 2020-05-12-federal-crowdsourcing-webinar-series-episode-10.md

### DIFF
--- a/content/events/2020/05/2020-05-12-federal-crowdsourcing-webinar-series-episode-10.md
+++ b/content/events/2020/05/2020-05-12-federal-crowdsourcing-webinar-series-episode-10.md
@@ -29,7 +29,6 @@ topics:
   - open
   - innovation
   - challenges
-  - data-science
   - medicine
   - health
 

--- a/content/events/2020/05/2020-05-12-federal-crowdsourcing-webinar-series-episode-10.md
+++ b/content/events/2020/05/2020-05-12-federal-crowdsourcing-webinar-series-episode-10.md
@@ -29,7 +29,7 @@ topics:
   - open
   - innovation
   - challenges
-  - data science
+  - data-science
   - medicine
   - health
 


### PR DESCRIPTION
Fix the data science topic tag. Should use data-science


**Summary**

<!-- Summary of the PR -->

This PR implements the following **changes:**

* [ ] remove the `data science` topic tag. The incorrect topic tag was breaking the API.


**URL / Link to page**
https://digital.gov/event/2020/05/12/federal-crowdsourcing-webinar-series-episode-10/
<!-- Link to the page that will be changed -->
<!-- Delete this section if not needed -->

