### PR TITLE
Adding AI CoP author 

### DIFF
--- a/content/communities/artificial-intelligence.md
+++ b/content/communities/artificial-intelligence.md
@@ -12,6 +12,10 @@ summary: "Supporting and coordinating the use of artificial intelligence technol
 topics:
   - data
   - artificial-intelligence
+  
+# see all authors at https://digital.gov/authors
+authors:
+  - steven-babitch
 
 # Page weight: controls how this page appears across the site
 # 0 -- hidden


### PR DESCRIPTION
**Summary**

Adding Steve Babitch as an author to the AI CoP page. 

This PR implements the following **changes:**

* Adding Steve as AI CoP author. 
 
Page being changed: https://digital.gov/communities/artificial-intelligence/

Federalist preview: https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/AS_AICoP-Author-1/communities/artificial-intelligence/
