### PR TITLE
Removing Annabel as email contact

### DIFF
--- a/content/communities/customer-experience-community.md
+++ b/content/communities/customer-experience-community.md
@@ -12,8 +12,6 @@ topics:
 community_list:
   - platform: "listserv"
     type: government
-    subscribe_email: annabel.berman@gsa.gov
-    subscribe_email_subject: "Join: CX"
     subscribe_form: "https://docs.google.com/a/gsa.gov/forms/d/1hzJbZChUg2TRLi_MiC4nAbB-HKUOerBF2kL0qO38fPo/viewform"
     members: 826
     emails_per_week: 


### PR DESCRIPTION
This PR implements the following **changes:**

Removing Annabel as CX CoP contact 


**URL / Link to page**

https://digital.gov/communities/customer-experience-community/

