### PR TITLE
New events: Building for the 21st century web with Federalist

### DIFF
--- a/content/events/2020/06/2020-06-16-building-for-21st-century-web-with.md
+++ b/content/events/2020/06/2020-06-16-building-for-21st-century-web-with.md
@@ -1,0 +1,63 @@
+---
+# View this page at https://digital.gov/event/2020/06/building-for-21st-century-web-with
+# Learn how to edit our pages at https://workflow.digital.gov
+slug: building-for-21st-century-web-with
+title: "Building for the 21st century web with Federalist"
+deck: ""
+kicker: "Cloud.gov"
+summary: "Building, deploying, and hosting fast, secure, and compliant federal web sites and applications with Federalist."
+host: "Cloud.gov"
+event_organizer: "Digital.gov"
+registration_url: https://www.eventbrite.com/e/108465669738
+captions: https://www.captionedtext.com/client/event.aspx?EventID=4375338&CustomerID=321
+
+# start date
+date: 2020-06-16 14:00:00 -0500
+
+# end date
+end_date: 2020-06-16 15:00:00 -0500
+
+# see all topics at https://digital.gov/topics
+topics: 
+  - security
+  - cloud
+  - cloud-gov
+
+# Event platform (zoom, youtube_live, adobe_connect, google)
+event_platform: zoom
+
+# YouTube ID
+youtube_id: 
+
+# Page weight: controls how this page appears across the site
+# 0 -- hidden
+# 1 -- visible
+weight: 0
+
+# Make it better ♥
+
+---
+
+Publishing federal web sites doesn’t have to be hard. We’ll explore how Federalist helps federal agencies leap over compliance and technical hurdles to get their message to the public quickly and securely.
+
+## Speaker:
+
+David Corwin is a polyglot software engineer with 15 years of experience in various roles including web application consulting, front and backend engineering, and scientific computing. He is currently the lead engineer of Federalist and was formerly a consulting engineer with 18F.
+
+---
+
+**Related Links:**
+
+ - [https://federalist.18f.gov/](https://federalist.18f.gov/)
+ - [https://designsystem.digital.gov/](https://designsystem.digital.gov/)
+ - [https://search.gov/](https://search.gov/)
+ - https://digital.gov/guides/dap/
+ - [https://jamstack.org/](https://jamstack.org/
+ - [https://www.netlifycms.org/](https://www.netlifycms.org/
+ - [https://jekyllrb.com/](https://jekyllrb.com/
+ - [https://github.com/gohugoio/hugo](https://github.com/gohugoio/hugo)
+ - https://www.gatsbyjs.org/
+ 
+ ---
+ 
+ *This talk is hosted by the cloud.gov and Digital.gov.*


### PR DESCRIPTION
This PR implements the following **changes:**

* Creating the event page for the cloud.gov 4 webinar. @ToniBonittoGSA & @saracope there is a logo and author photo in the event copy template - https://docs.google.com/document/d/1QoPQKfgfIw3RPu5PfMULmQAJWH9X96P0Q6RPkWBeGyA/edit#

Also asking @DanielJPino-ux to add the author page but wanted to get it up since the event is soon.


**URL / Link to page**

<!-- Link to the page that will be changed -->
<!-- Delete this section if not needed -->

