### PR TITLE
Update close-stale-issue.yml

### DIFF
--- a/.github/workflows/close-stale-issue.yml
+++ b/.github/workflows/close-stale-issue.yml
@@ -16,8 +16,8 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Hello! 👋 It looks like this issue is stale because it has been open 60 days with no activity. This is usually because the request was already solved or it is no longer applicable. If this issue should remain open, remove the stale label or add a comment. Otherwise, this will be closed in 7 days.'
         stale-pr-message: 'Hello! 👋 It looks like this pull request is stale because it has been open 60 days with no activity. This is usually because the request was already solved or it is no longer applicable. If this pull request should remain open, remove the stale label or add a comment. Otherwise, this will be closed in 7 days.'
-        days-before-stale: 60
-        days-before-close: 7
+        days-before-stale: 120
+        days-before-close: 14
         stale-issue-label: '[status] stale'
         exempt-issue-label: '---- HOLD ----'
         stale-pr-label: '[status] stale'


### PR DESCRIPTION
This PR implements the following **changes:**

* change the Stale bot to run for Issues that are more than 120 days old
* change Stale bot to close items after a 14 day review

```
        days-before-stale: 120
        days-before-close: 14
```



