### PR TITLE
Update on how to join language

### DIFF
--- a/content/communities/federal-leadership-professional-development.md
+++ b/content/communities/federal-leadership-professional-development.md
@@ -24,10 +24,8 @@ community_list:
   - platform: listserv
     type: government
     subscribe_email: FedLeadershipSeminar-subscribe-request@listserv.gsa.gov.
-    subscribe_email_subject: "Subscribe FedLeadership CoP "
-    subscribe_email_body: "Please subscribe me to the FedLeadership CoP "
     terms: "Anyone with a .gov or .mil email address is eligible to join"
-    members: 4463
+    members: 4660
 
 ---
 


### PR DESCRIPTION
This PR implements the following **changes:**

* The Join by email box should translate to: “To join the listserv, send a blank email from your government email address to FedLeadershipSeminar-subscribe-request@listserv.gsa.gov.”


**URL / Link to page**

https://digital.gov/communities/federal-leadership-professional-development/


