### PR TITLE
Update page weights

### DIFF
--- a/content/news/2020/05/2020-05-11-whats-new-in-uswds-270.md
+++ b/content/news/2020/05/2020-05-11-whats-new-in-uswds-270.md
@@ -26,10 +26,6 @@ topics:
 authors: 
   - dan-williams
 
-# Page weight: controls how this page appears across the site
-# 0 -- hidden
-# 1 -- visible
-weight: 1
 
 # Make it better ♥
 ---

--- a/content/news/2020/05/2020-05-12-promote-continuity-better-support-customer-journeys.md
+++ b/content/news/2020/05/2020-05-12-promote-continuity-better-support-customer-journeys.md
@@ -29,10 +29,6 @@ authors:
 # primary Image (for social media)
 primary_image: "twidea-9-breakout-group-brainstorm"
 
-# Page weight: controls how this page appears across the site
-# 0 -- hidden
-# 1 -- visible
-weight: 1
 
 # Make it better ♥
 

--- a/content/news/2020/05/2020-05-20-tapping-into-seo-how-government-websites.md
+++ b/content/news/2020/05/2020-05-20-tapping-into-seo-how-government-websites.md
@@ -25,10 +25,6 @@ authors:
 # primary Image (for social media)
 primary_image: "seo-colorful-website-illustration-under-magnifying-glass-aleksandr-durnov-istock-gettyimagesplus-954640444"
 
-# Page weight: controls how this page appears across the site
-# 0 -- hidden
-# 1 -- visible
-weight: 1
 
 # Make it better ♥
 

--- a/content/news/2020/05/2020-05-27-federal-source-code-study-series.md
+++ b/content/news/2020/05/2020-05-27-federal-source-code-study-series.md
@@ -27,10 +27,6 @@ topics:
 authors: 
   - joseph-castle
 
-# Page weight: controls how this page appears across the site
-# 0 -- hidden
-# 1 -- visible
-weight: 1
 
 # Make it better ♥
 ---

--- a/content/news/2020/05/2020-05-27-whos-on-your-digital-dream-team.md
+++ b/content/news/2020/05/2020-05-27-whos-on-your-digital-dream-team.md
@@ -27,10 +27,7 @@ authors:
 # primary Image (for social media)
 primary_image: "this-weeks-idea-card-wk6"
 
-# Page weight: controls how this page appears across the site
-# 0 -- hidden
-# 1 -- visible
-weight: 1
+
 
 # Make it better ♥
 ---


### PR DESCRIPTION
This PR implements the following **changes:**

* remove the page weight for these news posts

After some investigating, it looks like a page weight of 1 will make a news post sticky on the home page. News posts do not need a page weight otherwise.
I will also update the workflow tool based on this info.


