### PR TITLE
Add 10x submit button to event

### DIFF
--- a/content/events/2020/06/2020-06-30-10x-project-lightning-talks-2020.md
+++ b/content/events/2020/06/2020-06-30-10x-project-lightning-talks-2020.md
@@ -77,7 +77,7 @@ Through a series of quick presentations, we’ll learn more about the following 
  - Mike Stern, Government Notification Services  
  
  <br/>
- {{< button href="https://feedback.gsa.gov/jfe/form/SV_1Im8dTPnjnV3HpP?utm_source=dg-event&utm_medium=referral&utm_campaign=10x-talk-2020-06-30" text="Submit an idea to 10x!" >}}
+ {{< button href="https://go.usa.gov/xw53z" text="Submit an idea to 10x!" >}}
  <br/>
  <br/>
 
@@ -92,4 +92,4 @@ Through a series of quick presentations, we’ll learn more about the following 
  
  ---
  
- *10x is an incremental investment fund inside the United States federal government. We fund internal projects that can scale across the federal government or significantly improve how our government builds technology for the public good. Our next round of funding closes July 28, 2020 so please [submit your ideas here](https://feedback.gsa.gov/jfe/form/SV_1Im8dTPnjnV3HpP)!*
+ *10x is an incremental investment fund inside the United States federal government. We fund internal projects that can scale across the federal government or significantly improve how our government builds technology for the public good. Our next round of funding closes July 28, 2020 so please [submit your ideas here](https://go.usa.gov/xw53z)!*

--- a/content/events/2020/06/2020-06-30-10x-project-lightning-talks-2020.md
+++ b/content/events/2020/06/2020-06-30-10x-project-lightning-talks-2020.md
@@ -49,10 +49,6 @@ weight: 0
 # Make it better ♥
 
 ---
- <br/>
- {{< button href="https://feedback.gsa.gov/jfe/form/SV_1Im8dTPnjnV3HpP" text="Submit an idea to 10x!" >}}
- <br/>
- <br/>
  
 Join us for a live showcase of some of the most innovative projects in government. In this event, several 10x-funded project teams will give an overview of their work, an update on the current status, and discuss other ways in which the 10x approach is unique.
 
@@ -80,7 +76,10 @@ Through a series of quick presentations, we’ll learn more about the following 
  - Improving Access to Government Housing Assistance
  - Mike Stern, Government Notification Services  
  
-
+ <br/>
+ {{< button href="https://feedback.gsa.gov/jfe/form/SV_1Im8dTPnjnV3HpP?utm_source=dg-event&utm_medium=referral&utm_campaign=10x-talk-2020-06-30" text="Submit an idea to 10x!" >}}
+ <br/>
+ <br/>
 
  ---
  

--- a/content/events/2020/06/2020-06-30-10x-project-lightning-talks-2020.md
+++ b/content/events/2020/06/2020-06-30-10x-project-lightning-talks-2020.md
@@ -49,7 +49,11 @@ weight: 0
 # Make it better ♥
 
 ---
-
+ <br/>
+ {{< button href="https://feedback.gsa.gov/jfe/form/SV_1Im8dTPnjnV3HpP" text="Submit an idea to 10x!" >}}
+ <br/>
+ <br/>
+ 
 Join us for a live showcase of some of the most innovative projects in government. In this event, several 10x-funded project teams will give an overview of their work, an update on the current status, and discuss other ways in which the 10x approach is unique.
 
 Through a series of quick presentations, we’ll learn more about the following projects:
@@ -61,8 +65,10 @@ Through a series of quick presentations, we’ll learn more about the following 
  - Agile Budgeting and Oversight Handbook
  - Combating Bias in Artificial Intelligence and Machine Learning Implementations
  - Improving Access to Government Housing Assistance
- - Government Notification Services
- 
+ - Government Notification Services  
+
+
+
 ## Presenters:
 
  - Mike Gintz, Eligibility APIs
@@ -72,15 +78,17 @@ Through a series of quick presentations, we’ll learn more about the following 
  - Alicia Rouault, Agile Budgeting and Oversight Handbook
  - Shaudi Hosseini, Combating Bias in AI/ML Implementations
  - Improving Access to Government Housing Assistance
- - Mike Stern, Government Notification Services
+ - Mike Stern, Government Notification Services  
  
+
+
  ---
  
 **Related Links**
 
+
  - [The 10x website](https://10x.gsa.gov/)
  - [Tips for 10x submissions](https://10x.gsa.gov/send-us-an-idea/)
- - [Submit an idea to 10x](https://feedback.gsa.gov/jfe/form/SV_1Im8dTPnjnV3HpP)
  - [Learn more about 10x projects](https://10x.gsa.gov/projects/)
  
  ---


### PR DESCRIPTION
This PR implements the following **changes:**

* adds a button to submit a 10x idea
* takes that link out of the Related Links section

**URL / Link to page**
https://digital.gov/event/2020/06/30/10x-project-lightning-talks-2020/
<!-- Link to the page that will be changed -->
<!-- Delete this section if not needed -->
Preview: https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/sc_add-button/event/2020/06/30/10x-project-lightning-talks-2020/

<img width="698" alt="Screen Shot 2020-06-10 at 2 30 45 PM" src="https://user-images.githubusercontent.com/2197515/84304830-1efa0f00-ab27-11ea-9670-b45c4a6f1c5a.png">

