### PR TITLE
Update 2020-04-15-accessibility-intersection-between-plain-language-5…

### DIFF
--- a/content/events/2020/04/2020-04-15-accessibility-intersection-between-plain-language-508.md
+++ b/content/events/2020/04/2020-04-15-accessibility-intersection-between-plain-language-508.md
@@ -62,7 +62,7 @@ At its core, plain language is about making documents accessible to readers. In 
  - [Section 508 training](https://www.section508.gov/training)
  - [Accessibility for Teams](https://accessibility.digital.gov/)
  - [18F's Guide to Accessibility](https://accessibility.18f.gov/)
- - [Join the Accessibility Community]({{< ref "/communities/accessibility.md" >}})
+ - [Join the Accessibility Community]({{< ref "/communities/it-accessibility-section-508.md" >}})
  - [An Introduction to Accessibility]({{< ref "/resources/intro-accessibility.md" >}})
  - [Plain language training](https://plainlanguage.gov/)
  - [Join the Plain Community]({{< ref "/communities/plain-language-community-of-practice.md" >}})


### PR DESCRIPTION

This PR implements the following **changes:**

* updates the reference to `Join the Accessibility Community` to point to `/communities/it-accessibility-section-508/`

This was weirdly breaking a build.

**URL / Link to page**
https://digital.gov/event/2020/04/15/accessibility-intersection-between-plain-language-508/
<!-- Link to the page that will be changed -->
<!-- Delete this section if not needed -->

