### PR TITLE
Removing 2019 meetings

### DIFF
--- a/content/communities/devops.md
+++ b/content/communities/devops.md
@@ -57,12 +57,6 @@ Government agencies are investing in cloud capabilities and are seeking to work 
 - [**March Meeting: Why I Love My Agile Team!**](https://digital.gov/event/2020/03/24/why-i-love-my-agile-team/)
 - [**February Meeting: Moving From Agile Towards DevOps With a Small Team**](https://digital.gov/event/2020/02/25/moving-from-agile-towards-devops-with/)
 - [**January Meeting: Panel Discussion on How Agencies Are Spreading Best Practices**](https://digital.gov/event/2020/01/28/panel-discussion-how-agencies-spreading-best/)
-- [**December Special Event: Nicolas Chaillan**](https://digital.gov/event/2019/12/03/devops-holiday-special-event-nicolas-chaillan/)
-- [**November Special Event: Jez Humble: Building and Scaling High Performing Technology Organizations**](https://digital.gov/event/2019/11/19/jez-humble-building-scaling-high-performing-technology-organizations/)
-- [**October Meeting**](https://digital.gov/event/2019/10/22/october-devops-cop-meeting/)
-- [**September Meeting**](https://digital.gov/event/2019/09/24/devops-community-monthly-meeting-decennial-census/)
-- [**August Meeting**](https://digital.gov/event/2019/08/27/devops-community-practice-monthly-meeting/)
-- [**July Meeting**](https://digital.gov/event/2019/07/23/devops-cop-monthly-meeting/)
 
 ## Join
 We have two listservs available, one for Federal Employees, and one for all individuals:


### PR DESCRIPTION
This PR implements the following **changes:**

Removing 2019 meetings from page. 


**URL / Link to page**

https://digital.gov/communities/devops/

