### PR TITLE
New sources: Section508.gov

### DIFF
--- a/content/news/2020/06/2020-06-26-mapping-wcag-20-functional-performance-criteria.md
+++ b/content/news/2020/06/2020-06-26-mapping-wcag-20-functional-performance-criteria.md
@@ -12,7 +12,7 @@ slug: mapping-wcag-20-functional-performance-criteria
 
 date: 2020-06-26 14:00:00 -0500
 title: "Mapping of WCAG 2.0 to Functional Performance Criteria"
-deck: "**Mapping of WCAG 2.0 to Functional Performance Criteria** &mdash; See how specific disabilities may be impacted by by not following accessible guidelines. "
+deck: "**Mapping of WCAG 2.0 to Functional Performance Criteria** &mdash; See how specific disabilities may be impacted by not following accessible guidelines. "
 
 
 # Make it better ♥

--- a/content/news/2020/06/2020-06-26-mapping-wcag-20-functional-performance-criteria.md.md
+++ b/content/news/2020/06/2020-06-26-mapping-wcag-20-functional-performance-criteria.md.md
@@ -1,0 +1,19 @@
+---
+# View this page at https://digital.gov/2020/06/26/mapping-wcag-20-functional-performance-criteria
+# Learn how to edit our pages at https://workflow.digital.gov
+
+# originally published at the following URL
+source_url: "https://www.section508.gov/content/mapping-wcag-to-fpc"
+
+# Which team published this?
+# Learn about sources at https://workflow.digital.gov/sources
+source: section508gov
+slug: mapping-wcag-20-functional-performance-criteria
+
+date: 2020-06-26 14:00:00 -0500
+title: "Mapping of WCAG 2.0 to Functional Performance Criteria"
+deck: "**Mapping of WCAG 2.0 to Functional Performance Criteria** &mdash; See how specific disabilities may be impacted by by not following accessible guidelines. "
+
+
+# Make it better ♥
+---

--- a/content/sources/source_section508gov.md
+++ b/content/sources/source_section508gov.md
@@ -15,16 +15,13 @@ domain: "https://section508.gov/"
 # Upload new images to Github in the /static/logos/ folder
 # https://github.com/GSA/digitalgov.gov/tree/master/static/source/ 
 # The name of your organization should be clearly reflected in the filename (e.g., usds-logo.png or 18f-logo.png)
-icon: "https://section508.gov/"
+logo: gsa
 
 # see all topics at https://digital.gov/topics
 topics: 
   - accessibility
 
-# Page weight: controls how this page appears across the site
-# 0 -- hidden
-# 1 -- visible
-weight: 1
+
 
 # Make it better ♥
 ---

--- a/content/sources/source_section508gov.md
+++ b/content/sources/source_section508gov.md
@@ -1,0 +1,30 @@
+---
+# View this page at https://digital.gov/sources/section508gov
+# Learn how to edit our pages at https://workflow.digital.gov
+slug: section508gov
+
+# Source Name
+name: "Section508.gov"
+summary: "Guidance to Federal agency staff who play a role in IT accessibility."
+
+# Primary Domain — the link to your blog homepage or news feed. (e.g. https://18f.gsa.gov/)
+# Note: We'll automatically add ?dg to the end of your URL, to help you track links back to your site.
+domain: "https://section508.gov/"
+
+# Images need to be 200x200px with a transparent background
+# Upload new images to Github in the /static/logos/ folder
+# https://github.com/GSA/digitalgov.gov/tree/master/static/source/ 
+# The name of your organization should be clearly reflected in the filename (e.g., usds-logo.png or 18f-logo.png)
+icon: "https://section508.gov/"
+
+# see all topics at https://digital.gov/topics
+topics: 
+  - accessibility
+
+# Page weight: controls how this page appears across the site
+# 0 -- hidden
+# 1 -- visible
+weight: 1
+
+# Make it better ♥
+---


### PR DESCRIPTION
This PR implements the following **changes:**

* adds Section508.gov as a new source
* adds link post for a page on Section508.gov

<img width="853" alt="Screen Shot 2020-06-26 at 1 28 42 PM" src="https://user-images.githubusercontent.com/2197515/85884895-5ae0d580-b7b1-11ea-8333-043d9283d875.png">

Since this is a GSA property, I used the GSA logo we already had on the platform.