### PR TITLE
New link post: Making .gov More Secure by Default

### DIFF
--- a/content/news/2020/06/2020-06-22-making-gov-more-secure-by-default.md
+++ b/content/news/2020/06/2020-06-22-making-gov-more-secure-by-default.md
@@ -1,6 +1,13 @@
 ---
 # View this page at https://digital.gov/2020/06/22/making-gov-more-secure-by-default
 # Learn how to edit our pages at https://workflow.digital.gov
+
+# originally published at the following URL
+source_url: "https://home.dotgov.gov/management/preloading/dotgovhttps/"
+
+# Which team published this?
+# Learn about sources at https://workflow.digital.gov/sources
+source: dotgov
 slug: making-gov-more-secure-by-default
 
 # Short URL — https://go.usa.gov/
@@ -16,10 +23,6 @@ topics:
   - code
   - security
 
-# Page weight: controls how this page appears across the site
-# 0 -- hidden
-# 1 -- visible
-weight: 1
 
 # Make it better ♥
 ---

--- a/content/news/2020/06/2020-06-22-making-gov-more-secure-by-default.md
+++ b/content/news/2020/06/2020-06-22-making-gov-more-secure-by-default.md
@@ -1,0 +1,25 @@
+---
+# View this page at https://digital.gov/2020/06/22/making-gov-more-secure-by-default
+# Learn how to edit our pages at https://workflow.digital.gov
+slug: making-gov-more-secure-by-default
+
+# Short URL — https://go.usa.gov/
+short_url: https://home.dotgov.gov/management/preloading/dotgovhttps/
+date: 2020-06-22 15:00:00 -0500
+kicker: "Building trust"
+title: "Making .gov More Secure by Default"
+deck: "The DotGov Program announces its intent to preload the .gov top-level domain in order to protect .gov site visitors."
+summary: "The DotGov Program announces its intent to preload the .gov top-level domain in order to protect .gov site visitors."
+
+# see all topics at https://digital.gov/topics
+topics: 
+  - code
+  - security
+
+# Page weight: controls how this page appears across the site
+# 0 -- hidden
+# 1 -- visible
+weight: 1
+
+# Make it better ♥
+---


### PR DESCRIPTION
The DotGov Program announces its intent to preload the .gov top-level domain in order to protect .gov site visitors.

This PR implements the following **changes:**

* adds a new link post to 'Making .gov More Secure by Default' from DotGov


**URL / Link to page**
https://home.dotgov.gov/management/preloading/dotgovhttps/
<!-- Link to the page that will be changed -->
<!-- Delete this section if not needed -->

