### PR TITLE
WIP - Site Scanning Guide Page

### DIFF
--- a/content/guides/site-scanning/index.md
+++ b/content/guides/site-scanning/index.md
@@ -1,0 +1,63 @@
+---
+date: 2020-06-25 09:00:00 -0500
+title: "Guide to the Site Scanning Program"
+deck: "A set of daily scans of the federal web presence."
+summary: 'The Site Scanning program automates a wide range of scans of public federal websites and generates data about website health and best practices.'
+guide: site-scanning
+aliases:
+  - /guide/site-scanning/
+  - /site-scanning/
+  - /site-scans/
+  - /sitescans/
+  - /sitescanning/
+
+
+---
+
+
+**The Site Scanning program** automates a wide range of scans of public federal websites and generates data about website health and best practices. The program is a shared service provided by the [Technology Transformation Services](http://www.gsa.gov/tts) (TTS) at the [U.S. General Services Administration](https://www.gsa.gov) (GSA).
+
+**We scan federal agencies for:**
+
+- Digital Analytics Program participation
+- Use of the US Web Design System
+- Enterprise Code Inventories
+- Enterprise Data Inventories
+- OMB-mandated pages
+- Open Data Hubs
+- API Hubs
+- Third-Party Services
+- Search Engine Optimization
+- SSL/TLS Security
+- Accessibility Issues
+
+
+## Interact with the scan results
+
+Numerous report pages have been built using data from the program's scans:
+
+- [Spotlight 2.0](https://federalist-05e4f538-b6c2-49a0-a38c-262ad093ad6d.app.cloud.gov/site/18f/spotlight-ui/) - _[details](https://github.com/18F/site-scanning-documentation/tree/master/presentation-layers#active)_
+- [Spotlight 1.0](https://site-scanning.app.cloud.gov/) - _[details](https://github.com/18F/site-scanning-documentation/tree/master/presentation-layers#active)_
+- [Code.json Dashboard](https://cg-bbe64741-a601-484f-bc3b-e8eef3c28590.app.cloud.gov/site/18f/site-scanning-dashboard/codegov/) - _[details](https://github.com/18F/site-scanning-documentation/blob/master/presentation-layers/live/codedotjson-dashboard.md)_
+- [Data.json Dashboard](https://cg-bbe64741-a601-484f-bc3b-e8eef3c28590.app.cloud.gov/site/18f/site-scanning-dashboard/datagov/) - _[details](https://github.com/18F/site-scanning-documentation/blob/master/presentation-layers/live/datadotjson-dashboard.md)_
+- [TTS Dashboard](https://cg-bbe64741-a601-484f-bc3b-e8eef3c28590.app.cloud.gov/site/18f/site-scanning-dashboard/) - _[details](https://github.com/18F/site-scanning-documentation/blob/master/presentation-layers/live/tts-dashboard.md)_
+
+If you've created a report page or other mashup that we haven't listed here, be sure to [let us know](mailto:site-scanning@gsa.gov)!  
+
+## Access the data directly
+
+All scan data can be accessed through the [Site Scanning API](https://open.gsa.gov/api/spotlight-api/).  An exhaustive gallery of data links can also be found on the [Spotlight website's data page](https://federalist-05e4f538-b6c2-49a0-a38c-262ad093ad6d.app.cloud.gov/site/18f/spotlight-ui/data).  
+
+
+## Learn more about the program, the scans, and the underlying data
+
+Each scan and report page is documented in detail in the program's [documentation hub](https://github.com/18F/site-scanning-documentation).  The major sections include: 
+
+- [About the Program](https://github.com/18F/site-scanning-documentation#about)
+- [Individual Scan Documentation](https://github.com/18F/site-scanning-documentation/tree/master/scans)
+- [Individual Report Documentation](https://github.com/18F/site-scanning-documentation/tree/master/presentation-layers)
+- [Program Management Documentation](https://github.com/18F/site-scanning-documentation/tree/master/project-management)
+
+## Contact the Site Scanning Team
+
+**Questions?** Email the [Site Scanning team](mailto:site-scanning@gsa.gov).


### PR DESCRIPTION
This PR implements the following **changes:**

* Creating a 'homepage' for the Site Scanning program, similar to (if less substantive than) the DAP program.  

There'll be more content in the future (ideally, it would spread out to 3-4 pages, more on par with what DAP has), but this PR includes everything that is needed at launch.  

