### PR TITLE
Author Addition

### DIFF
--- a/content/events/2019/04/2019-04-10-principles-speaking-plainly.md
+++ b/content/events/2019/04/2019-04-10-principles-speaking-plainly.md
@@ -1,22 +1,44 @@
 ---
+# View this page at https://digital.gov/event/2019/04/principles-speaking-plainly
+# Learn how to edit our pages at https://workflow.digital.gov
 slug: principles-speaking-plainly
-title: 'Principles of Speaking Plainly'
-summary: 'This seminar adapts principles of plain language to the context of speaking, covering not only wording but also structure and integration with visual aids&#46;'
-featured_image:
-  uid: plain-language
-  alt: ''
-event_type:
-  - zoom
-date: 2019-04-10 14:00:00 -0500
-end_date: 2019-04-10 15:00:00 -0500
-event_organizer: DigitalGov University
-host: Plain language
+title: "Principles of Speaking Plainly"
+deck: ""
+summary: "This seminar adapts principles of plain language to the context of speaking, covering not only wording but also structure and integration with visual aids."
+host: "Plain language"
+event_organizer: "DigitalGov University"
 registration_url: https://www.eventbrite.com/e/principles-of-speaking-plainly-registration-59398898705
-youtube_id: VTXJoHara-4
-topics:
+captions: 
+
+# start date
+date: 2019-04-10 15:00:00 -0500
+
+# end date
+end_date: 2019-04-10 16:00:00 -0500
+
+# see all topics at https://digital.gov/topics
+topics: 
   - plain-language
-  - plain-language-community-of-practice
   - writing
+  - plain-language-community-of-practice
+
+# see all authors at https://digital.gov/authors
+authors: 
+  - christopher-chip-crane
+  - katherine-spivey
+
+# YouTube ID
+youtube_id: VTXJoHara-4
+
+# Primary Image (for social media)
+primary_image: "plain-language"
+
+# Page weight: controls how this page appears across the site
+# 0 -- hidden
+# 1 -- visible
+weight: 0
+
+# Make it better ♥
 
 ---
 


### PR DESCRIPTION
adding two authors to event page

* adding Christopher "Chip" Crane and Katherine Spivey to event page as authors

**https://digital.gov/event/2019/04/10/principles-speaking-plainly/**


