### PR TITLE
New events: A Technical Overview of cloud.gov

### DIFF
--- a/content/events/2020/07/2020-07-15-a-technical-overview-cloudgov.md
+++ b/content/events/2020/07/2020-07-15-a-technical-overview-cloudgov.md
@@ -26,6 +26,7 @@ topics:
 # see all authors at https://digital.gov/authors
 authors: 
   - kara-reinsel
+  - steve-greenberg
 
 # Event platform (zoom, youtube_live, adobe_connect, google)
 event_platform: zoom

--- a/content/events/2020/07/2020-07-15-a-technical-overview-cloudgov.md
+++ b/content/events/2020/07/2020-07-15-a-technical-overview-cloudgov.md
@@ -47,7 +47,7 @@ cloud.gov is a sophisticated and complex platform. Using visual diagrams, we wil
 
 ## Presenter:
 
-Steve Greenberg is an industry veteran with more than 20 years of experience in the architecture, operations, and development of custom applications. He is a proud Cloud Foundry Ambassador, an active member of the Cloud Foundry community, a technical advisor to the Cloud Foundry Foundation, and the recipient of the Cloud Advocate community award. A frequent open source contributor, he is the original author of the Spring Cloud Service Broker. He is currently working on the cloud.gov team as a platform operator (contractor).
+**Steve Greenberg** is an industry veteran with more than 20 years of experience in the architecture, operations, and development of custom applications. He is a proud Cloud Foundry Ambassador, an active member of the Cloud Foundry community, a technical advisor to the Cloud Foundry Foundation, and the recipient of the Cloud Advocate community award. A frequent open source contributor, he is the original author of the Spring Cloud Service Broker. He is currently working on the cloud.gov team as a platform operator (contractor).
 
 A regular speaker at conferences, unconferences, and meetups, Steve was invited to be a keynote speaker at the Cloud Foundry Summit in Basel in 2018.
 

--- a/content/events/2020/07/2020-07-15-a-technical-overview-cloudgov.md
+++ b/content/events/2020/07/2020-07-15-a-technical-overview-cloudgov.md
@@ -1,0 +1,55 @@
+---
+# View this page at https://digital.gov/event/2020/07/a-technical-overview-cloudgov
+# Learn how to edit our pages at https://workflow.digital.gov
+slug: a-technical-overview-cloudgov
+title: "A Technical Overview of cloud.gov"
+deck: ""
+kicker: "cloud.gov"
+summary: "In this webinar, we will provide a technical overview of cloud.gov including a visual representation of its architecture, marketplace services, content delivery networks, and how to engage with cloud.gov."
+host: "cloud.gov"
+event_organizer: "Digital.gov"
+registration_url: https://www.eventbrite.com/e/a-technical-overview-of-cloudgov-tickets-111824664582
+captions: https://www.captionedtext.com/client/event.aspx?EventID=4375344&CustomerID=321
+
+# start date
+date: 2020-07-15 14:00:00 -0500
+
+# end date
+end_date: 2020-07-15 15:00:00 -0500
+
+# see all topics at https://digital.gov/topics
+topics: 
+  - devops
+  - cloud
+  - cloud-gov
+
+# see all authors at https://digital.gov/authors
+authors: 
+  - kara-reinsel
+
+# Event platform (zoom, youtube_live, adobe_connect, google)
+event_platform: zoom
+
+# YouTube ID
+youtube_id: 
+
+# Page weight: controls how this page appears across the site
+# 0 -- hidden
+# 1 -- visible
+weight: 0
+
+# Make it better ♥
+
+---
+
+cloud.gov is a sophisticated and complex platform. Using visual diagrams, we will walk through the architecture of major system components including AWS GovCloud, AWS Commercial, and Cloud Foundry. In addition, this webinar will review marketplace services and the availability of on-demand provisioning, understanding how traffic gets to an app via CDN and non-CDN apps, and finally how to engage with cloud.gov about feature requests.
+
+## Presenter:
+
+Steve Greenberg is an industry veteran with more than 20 years of experience in the architecture, operations, and development of custom applications. He is a proud Cloud Foundry Ambassador, an active member of the Cloud Foundry community, a technical advisor to the Cloud Foundry Foundation, and the recipient of the Cloud Advocate community award. A frequent open source contributor, he is the original author of the Spring Cloud Service Broker. He is currently working on the cloud.gov team as a platform operator (contractor).
+
+A regular speaker at conferences, unconferences, and meetups, Steve was invited to be a keynote speaker at the Cloud Foundry Summit in Basel in 2018.
+
+---
+
+*[cloud.gov](https://cloud.gov/) is a product of the U.S. General Services Administration that helps government teams build, run, and authorize government cloud systems quickly and cost-effectively. [Get in touch »](https://cloud.gov/docs/help/)*


### PR DESCRIPTION
This PR implements the following **changes:**

Creating the event page for the 5th cloud.gov event. 


**URL / Link to page**

https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/ay-july-cloud-event/event/2020/07/15/a-technical-overview-cloudgov/

