### PR TITLE
Update 2020-07-28-2020-government-ux-summit.md

### DIFF
--- a/content/events/2020/07/2020-07-28-2020-government-ux-summit.md
+++ b/content/events/2020/07/2020-07-28-2020-government-ux-summit.md
@@ -39,6 +39,8 @@ authors:
   - john-pull
   - katherine-b-nammacher
   - margo-kabel
+  - maya-rhodan
+  - sarah-rigdon
 
 # Event platform (zoom, youtube_live, adobe_connect, google)
 event_platform: zoom


### PR DESCRIPTION
This PR implements the following **changes:**

* Adding 2 more authors to the event page.


**URL / Link to page**

https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/adding-more-authors-to-ux-summit/event/2020/07/28/2020-government-ux-summit/

