### PR TITLE
adding speakers and topic

### DIFF
--- a/content/events/2019/07/2019-07-10-federal-plain-language-report-card-planning.md
+++ b/content/events/2019/07/2019-07-10-federal-plain-language-report-card-planning.md
@@ -1,20 +1,43 @@
 ---
+# View this page at https://digital.gov/event/2019/07/federal-plain-language-report-card-planning
+# Learn how to edit our pages at https://workflow.digital.gov
 slug: federal-plain-language-report-card-planning
+title: "Federal Plain Language Report Card Planning"
+deck: ""
 kicker: "Plain Language"
-title: 'Federal Plain Language Report Card Planning'
-summary: 'Come and help us plan for this year&#39;s federal report card review&#46;'
-featured_image:
-  uid: plain-language
-  alt: ''
-event_type:
-  - Zoom
-date: 2019-07-10 14:00:00 -0500
-end_date: 2019-07-10 15:00:00 -0500
-event_organizer: DigitalGov University
-host: Plain Language
+summary: "Come and help us plan for this year's federal report card review."
+host: "Plain Language"
+event_organizer: "DigitalGov University"
 registration_url: https://www.eventbrite.com/e/federal-plain-language-report-card-planning-registration-63583460843
+captions: 
+
+# start date
+date: 2019-07-10 15:00:00 -0500
+
+# end date
+end_date: 2019-07-10 16:00:00 -0500
+
+# see all topics at https://digital.gov/topics
+topics: 
+  - plain-language
+
+# see all authors at https://digital.gov/authors
+authors: 
+  - david-lipscomb
+  - katherine-spivey
+
+# YouTube ID
 youtube_id: T_zTZGDE7Gg
 
+# Primary Image (for social media)
+primary_image: "plain-language"
+
+# Page weight: controls how this page appears across the site
+# 0 -- hidden
+# 1 -- visible
+weight: 0
+
+# Make it better ♥
 ---
 
 David Lipscomb from the Center for Plain Language will discuss the documents they'll review and the criteria they'll use for grading in the upcoming Federal Plain Language Report Card. This meeting is also a chance for interested feds to ask questions and offer feedback on how to make the annual report card process more helpful in the coming years.


### PR DESCRIPTION
adding speakers and topic to event page

This PR implements the following **changes:**

* Adding speakers: Katherine Spivey and David Lipscomb to page
* Adding topic: Plain Language to page


**URL / Link to page**
https://digital.gov/event/2019/07/10/federal-plain-language-report-card-planning/

