### PR TITLE
author addition

### DIFF
--- a/content/events/2019/07/2019-07-23-devops-cop-monthly-meeting.md
+++ b/content/events/2019/07/2019-07-23-devops-cop-monthly-meeting.md
@@ -1,21 +1,39 @@
 ---
+# View this page at https://digital.gov/event/2019/07/devops-community-practice-monthly-meeting
+# Learn how to edit our pages at https://workflow.digital.gov
 slug: devops-cop-monthly-meeting
-title: 'DevOps Community of Practice Monthly Meeting'
-summary: 'Overview of the HUD Real Estate Assessment Center &#40;REAC&#41; IT team, program, structure, and their shift to DevOps&#46;'
-featured_image: 
-  uid: 
-  alt: ''
-event_type: 
-  - Zoom
-date: 2019-07-23 14:00:00 -0500
-end_date: 2019-07-23 14:30:00 -0500
-event_organizer: DigitalGov University
-host: DevOps CoP
+title: "DevOps Community of Practice Monthly Meeting"
+deck: ""
+summary: "Overview of the HUD Real Estate Assessment Center (REAC) IT team, program, structure, and their shift to DevOps."
+host: "DevOps CoP"
+event_organizer: "DigitalGov University"
 registration_url: https://www.eventbrite.com/e/devops-cop-monthly-meeting-registration-64672677720
-youtube_id: LOxxXmCYU_A
+captions: 
+
+# start date
+date: 2019-07-23 15:00:00 -0500
+
+# end date
+end_date: 2019-07-23 15:30:00 -0500
+
+# see all topics at https://digital.gov/topics
 topics: 
   - devops
 
+# see all authors at https://digital.gov/authors
+authors: 
+  - brian-fox
+  - kevin-portanova
+
+# YouTube ID
+youtube_id: LOxxXmCYU_A
+
+# Page weight: controls how this page appears across the site
+# 0 -- hidden
+# 1 -- visible
+weight: 0
+
+# Make it better ♥
 ---
 
 Kevin Portanova, of the Real Estate Assessment Center (REAC) at the U.S. Department of Housing and Urban Development (HUD), will be presenting on their transition to DevOps methods&mdash;as well as the changes to the program and resulting organizational transformation&mdash;to improve services to the public. 


### PR DESCRIPTION
adding authors: fox, portanova to event page

This PR implements the following **changes:**

* adding authors: Brian Fox, Kevin Portanova to event page

**URL / Link to page**

https://digital.gov/event/2019/07/23/devops-cop-monthly-meeting/
