### PR TITLE
adding author to event page

### DIFF
--- a/content/events/2019/07/2019-07-24-dap-learning-series-misunderstood-metrics.md
+++ b/content/events/2019/07/2019-07-24-dap-learning-series-misunderstood-metrics.md
@@ -1,25 +1,42 @@
 ---
+# View this page at https://digital.gov/event/2019/07/dap-learning-series-misunderstood-metrics
+# Learn how to edit our pages at https://workflow.digital.gov
 slug: dap-learning-series-misunderstood-metrics
-kicker: Learning Series
-title: 'DAP Learning Series&#58; Misunderstood Metrics'
-summary: 'What are some examples of misunderstood metrics, and how and when should you use them&#63; We’ll talk about these metrics and their potential misinterpretations and pitfalls&#46;'
-featured_image:
-  uid:
-  alt: ''
-event_type:
-  - youtube-live
-date: 2019-07-24 14:00:00 -0500
-end_date: 2019-07-24 15:00:00 -0500
-event_organizer: DigitalGov University
-host: DAP
+title: "DAP Learning Series: Misunderstood Metrics"
+deck: ""
+kicker: "Learning Series"
+summary: "What are some examples of misunderstood metrics, and how and when should you use them? We’ll talk about these metrics and their potential misinterpretations and pitfalls."
+host: "DAP"
+event_organizer: "DigitalGov University"
 registration_url: https://www.eventbrite.com/e/dap-learning-series-misunderstood-metrics-registration-59346956344
-youtube_id: nvNwmFEroWA
-topics:
+captions: 
+
+# start date
+date: 2019-07-24 15:00:00 -0500
+
+# end date
+end_date: 2019-07-24 16:00:00 -0500
+
+# see all topics at https://digital.gov/topics
+topics: 
   - metrics
   - analytics
   - dap
   - digital-analytics-program
 
+# see all authors at https://digital.gov/authors
+authors: 
+  - freddie-blicher
+
+# YouTube ID
+youtube_id: nvNwmFEroWA
+
+# Page weight: controls how this page appears across the site
+# 0 -- hidden
+# 1 -- visible
+weight: 0
+
+# Make it better ♥
 ---
 
 _[View live captioning for this event.](https://www.captionedtext.com/client/event.aspx?EventID=3993566&CustomerID=321)_


### PR DESCRIPTION
adding blicher to event page

This PR implements the following **changes:**

* adding freddie blicher to event page as author


**URL / Link to page**
https://digital.gov/event/2019/07/24/dap-learning-series-misunderstood-metrics/
