### PR TITLE
adding topic and authors to page

### DIFF
--- a/content/events/2019/07/2019-07-25-machine-learning-how-bureau-labor-statistics-did-it.md
+++ b/content/events/2019/07/2019-07-25-machine-learning-how-bureau-labor-statistics-did-it.md
@@ -1,19 +1,39 @@
 ---
+# View this page at https://digital.gov/event/2019/07/machine-learning-how-bureau-labor-statistics
+# Learn how to edit our pages at https://workflow.digital.gov
 slug: machine-learning-how-bureau-labor-statistics-did-it
-title: 'Machine Learning&#58; How Bureau of Labor Statistics Did It'
-summary: 'The Bureau of Labor Statistics has been on a journey to improve their data reporting, using and iterating on machine learning, from algorithms to deep neural networks with lessons for everyone on this path&#46;'
-featured_image: 
-  uid: 
-  alt: ''
-event_type: 
-  - Zoom
-date: 2019-07-25 14:00:00 -0500
-end_date: 2019-07-25 15:00:00 -0500
-event_organizer: DigitalGov University
-host: AI COP
+title: "Machine Learning: How Bureau of Labor Statistics Did It"
+deck: ""
+summary: "The Bureau of Labor Statistics has been on a journey to improve their data reporting, using and iterating on machine learning, from algorithms to deep neural networks with lessons for everyone on this path."
+host: "AI COP"
+event_organizer: "DigitalGov University"
 registration_url: https://www.eventbrite.com/e/machine-learning-how-bureau-of-labor-statistics-did-it-registration-64613832713
+captions: 
+
+# start date
+date: 2019-07-25 15:00:00 -0500
+
+# end date
+end_date: 2019-07-25 16:00:00 -0500
+
+# see all topics at https://digital.gov/topics
+topics: 
+  - data
+
+# see all authors at https://digital.gov/authors
+authors: 
+  - alex-measure
+  - gwynne-kostin
+
+# YouTube ID
 youtube_id: 0j-DmzJmJFg
 
+# Page weight: controls how this page appears across the site
+# 0 -- hidden
+# 1 -- visible
+weight: 0
+
+# Make it better ♥
 ---
 
 Come and learn about the eight year journey of integrating machine learning (ML) models into the [Bureau of Labor Statistics](https://www.bls.gov/) (BLS). Discover how the organization learned to change, and how the team worked internally to make BLS more data-friendly.


### PR DESCRIPTION
adding: kostin and measure to event as authors and topic to event page

This PR implements the following **changes:**

* adding gwynne kostin and alexander measure as speakers/authors
* adding data as topic


**URL / Link to page**
https://digital.gov/event/2019/07/25/machine-learning-how-bureau-labor-statistics-did-it/

