### PR TITLE
adding topics and speaker

### DIFF
--- a/content/events/2020/07/2020-07-16-uswds-monthly-call-july-2020.md
+++ b/content/events/2020/07/2020-07-16-uswds-monthly-call-july-2020.md
@@ -11,10 +11,20 @@ registration_url: https://www.eventbrite.com/e/uswds-monthly-call-form-component
 captions: https://www.captionedtext.com/client/event.aspx?EventID=4506109&CustomerID=321
 
 # start date
-date: 2020-07-16 14:30:00 -0500
+date: 2020-07-16 15:30:00 -0500
 
 # end date
-end_date: 2020-07-16 15:30:00 -0500
+end_date: 2020-07-16 16:30:00 -0500
+
+# see all topics at https://digital.gov/topics
+topics: 
+  - code
+  - design
+  - uswds
+
+# see all authors at https://digital.gov/authors
+authors: 
+  - dan-williams
 
 # YouTube ID
 youtube_id: 

--- a/content/events/2020/07/2020-07-16-uswds-monthly-call-july-2020.md
+++ b/content/events/2020/07/2020-07-16-uswds-monthly-call-july-2020.md
@@ -11,10 +11,10 @@ registration_url: https://www.eventbrite.com/e/uswds-monthly-call-form-component
 captions: https://www.captionedtext.com/client/event.aspx?EventID=4506109&CustomerID=321
 
 # start date
-date: 2020-07-16 15:30:00 -0500
+date: 2020-07-16 14:30:00 -0500
 
 # end date
-end_date: 2020-07-16 16:30:00 -0500
+end_date: 2020-07-16 15:30:00 -0500
 
 # see all topics at https://digital.gov/topics
 topics: 


### PR DESCRIPTION
adding topics to event

This PR implements the following **changes:**

* adding: code, design and USWDS as event topics
* adding Dan Williams as event speaker

**URL / Link to page**
https://digital.gov/event/2020/07/16/uswds-monthly-call-july-2020/
