### PR TITLE
updating event page

### DIFF
--- a/content/events/2019/09/2019-09-24-devops-community-monthly-meeting-decennial-census.md
+++ b/content/events/2019/09/2019-09-24-devops-community-monthly-meeting-decennial-census.md
@@ -1,27 +1,46 @@
 ---
+# View this page at https://digital.gov/event/2019/09/devops-community-monthly-meeting-devops-for
+# Learn how to edit our pages at https://workflow.digital.gov
 slug: devops-community-monthly-meeting-decennial-census
-title: 'DevOps Community Monthly Meeting&#58; DevOps for the Decennial Census'
-summary: 'In this month’s Community meeting, we will hear from a Census team that is brand new to DevOps—failing fast and often, but learning lessons as they undergo a cultural transformation&#46;'
-featured_image: 
-  uid: 
-  alt: ''
-event_type: 
-  - Zoom
-date: 2019-09-24 14:00:00 -0500
-end_date: 2019-09-24 14:30:00 -0500
-event_organizer: DigitalGov University
-host: DevOps CoP 
-youtube_id: mBF73XzaU0c
+title: "DevOps Community Monthly Meeting: DevOps for the Decennial Census"
+deck: ""
+summary: "In this month’s Community meeting, we will hear from a Census team that is brand new to DevOps—failing fast and often, but learning lessons as they undergo a cultural transformation."
+host: "DevOps CoP"
+event_organizer: "DigitalGov University"
+registration_url: 
+captions: 
+
+# start date
+date: 2019-09-24 15:00:00 -0500
+
+# end date
+end_date: 2019-09-24 15:30:00 -0500
+
+# see all topics at https://digital.gov/topics
 topics: 
   - devops
 
+# see all authors at https://digital.gov/authors
+authors: 
+  - brian-fox
+  - graham-bagget
+
+# YouTube ID
+youtube_id: mBF73XzaU0c
+
+# Page weight: controls how this page appears across the site
+# 0 -- hidden
+# 1 -- visible
+weight: 0
+
+# Make it better ♥
 ---
 
 In this month’s community meeting, we will hear from a [Census] (https://www.census.gov) team that is brand new to DevOps&mdash;failing fast and often, but learning lessons as they undergo a cultural transformation. 
 
 Hear a brief overview of a previous Census Agile IT project called BARCA, as well as a current IT project called JAGUAR. In JAGUAR, the hope is for relevant stakeholders to gradually have and use a more DevOps-centric culture.  
  
-Graham Bagget has worked at the Census Bureau for the past 15 years, first as a GIS software developer, and currently as an IT Manager. He began his career helping Census transition from a legacy GIS topological database into the Master Address File/Toplogically Integrated Geographic Encoding and Referencing (MAF/TIGER) database. He participated in the design, development, and maintenance of several MAF/TIGER-based applications, including the Geographic Acquis-based Topological Real-time Editing System (GATRES) and the Block Assessment, Research, and Classification Application (BARCA), which was demonstrated at this year's [ESRI User Conference](https://www.esri.com/videos/watch?&channelid=UC_yE3TatdZKAXvt_TzGJ6mw&playlistid=PLaPDDLTCmy4bC2dGacC3ZH8YnCl4x7kuB). 
+**Graham Bagget** has worked at the Census Bureau for the past 15 years, first as a GIS software developer, and currently as an IT Manager. He began his career helping Census transition from a legacy GIS topological database into the Master Address File/Toplogically Integrated Geographic Encoding and Referencing (MAF/TIGER) database. He participated in the design, development, and maintenance of several MAF/TIGER-based applications, including the Geographic Acquis-based Topological Real-time Editing System (GATRES) and the Block Assessment, Research, and Classification Application (BARCA), which was demonstrated at this year's [ESRI User Conference](https://www.esri.com/videos/watch?&channelid=UC_yE3TatdZKAXvt_TzGJ6mw&playlistid=PLaPDDLTCmy4bC2dGacC3ZH8YnCl4x7kuB). 
 
 **DevOps** is a set of software development practices that combine software development (Dev) and information-technology operations (Ops) to 1) shorten the systems-development life cycle, while 2) delivering features, fixes, and updates that align with an organization’s goals and objectives. 
 


### PR DESCRIPTION
adding author and updating copy formatting

This PR implements the following **changes:**

* boldening "graham bagget" in event copy
* adding brian fox and graham bagget as event speakers


**URL / Link to page**
https://digital.gov/event/2019/09/24/devops-community-monthly-meeting-decennial-census/
