### PR TITLE
updating event page

### DIFF
--- a/content/events/2019/09/2019-09-26-socialgov-talks-leveraging-pop-culture-with-paul-lester-doe.md
+++ b/content/events/2019/09/2019-09-26-socialgov-talks-leveraging-pop-culture-with-paul-lester-doe.md
@@ -1,21 +1,43 @@
 ---
+# View this page at https://digital.gov/event/2019/09/socialgov-talks-leveraging-pop-culture-with
+# Learn how to edit our pages at https://workflow.digital.gov
 slug: socialgov-talks-leveraging-pop-culture-with-paul-lester-doe
-title: 'SocialGov Talks&#58; Leveraging Pop Culture With Paul Lester of the DOE'
-summary: 'Learn from a social media expert at Department of Energy how to use pop culture references as a jumping off point to talk about your agency’s work&#46;  '
-featured_image:
-  uid: event-leveraging-pop-culture
-  alt: ''
-event_type:
-  - Zoom
-date: 2019-09-26 13:00:00 -0500
-end_date: 2019-09-26 14:00:00 -0500
-event_organizer: DigitalGov University
-host: Socialgov
+title: "SocialGov Talks: Leveraging Pop Culture With Paul Lester of the DOE"
+deck: ""
+summary: "Learn from a social media expert at Department of Energy how to use pop culture references as a jumping off point to talk about your agency’s work.  "
+host: "Socialgov"
+event_organizer: "DigitalGov University"
 registration_url: https://www.eventbrite.com/e/socialgov-talks-leveraging-pop-culture-with-paul-lester-of-the-doe-registration-66348428937
+captions: 
 
+# start date
+date: 2019-09-26 14:00:00 -0500
+
+# end date
+end_date: 2019-09-26 15:00:00 -0500
+
+# see all topics at https://digital.gov/topics
+topics: 
+  - social-media
+
+# see all authors at https://digital.gov/authors
+authors: 
+  - paul-lester
+
+# YouTube ID
 youtube_id: hC9OJjtMgnE
 
+# Primary Image (for social media)
+primary_image: "event-leveraging-pop-culture"
+
+# Page weight: controls how this page appears across the site
+# 0 -- hidden
+# 1 -- visible
+weight: 0
+
+# Make it better ♥
 ---
+
 
 Join Paul Lester, Digital Content Specialist for the [Department of Energy](https://www.energy.gov/) (DOE), to discuss how DOE leveraged the popular TV show, _Stranger Things_ as a conversation starter about the agency’s mission and work using digital media (social media, blog, podcast, etc.). Paul will also discuss how he got management buy-in to use a pop culture phenomenon to promote the agency’s work.
 


### PR DESCRIPTION
adding speaker and topic to event page

This PR implements the following **changes:**

* adding social media as a topic
* adding paul lester as speaker


**URL / Link to page**
https://digital.gov/event/2019/09/26/socialgov-talks-leveraging-pop-culture-with-paul-lester-doe/
