### PR TITLE
Update gov banner

### DIFF
--- a/themes/digital.gov/layouts/partials/core/usa-banner.html
+++ b/themes/digital.gov/layouts/partials/core/usa-banner.html
@@ -29,9 +29,9 @@
           <img class="usa-banner__icon usa-media-block__img" src="{{- $path -}}" alt="Dot gov">
           <div class="usa-media-block__body">
             <p>
-              <strong>The .gov means it’s official.</strong>
+              <strong>Official websites use .gov</strong>
               <br>
-              Federal government websites often end in .gov or .mil. Before sharing sensitive information, make sure you’re on a federal government site.
+              A <strong>.gov</strong> website belongs to an official government organization in the United States.
             </p>
           </div>
         </div>
@@ -42,9 +42,12 @@
           <img class="usa-banner__icon usa-media-block__img" src="{{- $path -}}" alt="Https">
           <div class="usa-media-block__body">
             <p>
-              <strong>The site is secure.</strong>
+              <strong>Secure .gov websites use HTTPS</strong>
               <br>
-              The <strong>https://</strong> ensures that you are connecting to the official website and that any information you provide is encrypted and transmitted securely.
+              A <strong>lock</strong> (
+                <span class="icon-lock"><svg xmlns="http://www.w3.org/2000/svg" width="52" height="64" viewBox="0 0 52 64" class="usa-banner__lock-image" role="img" aria-labelledby="banner-lock-title banner-lock-description"><title id="banner-lock-title">Lock</title><desc id="banner-lock-description">A locked padlock</desc><path fill="#ffffff" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"/></svg></span>
+                ) or <strong>https://</strong> means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.
+                
             </p>
           </div>
         </div>


### PR DESCRIPTION
This PR implements the following **changes:**

* Update the text of the gov banner based on the latest USWDS release (2.8)


**URL / Link to page**

<!-- Link to the page that will be changed -->
<!-- Delete this section if not needed -->
**_AFTER_**
<img width="1227" alt="Screen Shot 2020-07-10 at 7 41 05 AM" src="https://user-images.githubusercontent.com/2197515/87150972-09d8e300-c281-11ea-9613-60d1045f0e2b.png">


**_BEFORE_**
<img width="1106" alt="Screen Shot 2020-07-10 at 7 44 13 AM" src="https://user-images.githubusercontent.com/2197515/87151067-31c84680-c281-11ea-8d33-35ea190889f0.png">
