### PR TITLE
Use env var for go.usa.gov

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -59,8 +59,8 @@ params:
   cdnurl                : "https://s3.amazonaws.com/digitalgov"
   git_org               : "GSA"
   git_repo              : "digitalgov.gov"
-  url_shortener_login: jeremyz
-  url_shortener_api: d0ac464a2dfad044147e9537fd51503b
+  goUsaUsername         : ""
+  goUsaApiKey           : ""
   devmode               : false
 
   # Homepage settings

--- a/env.example
+++ b/env.example
@@ -1,2 +1,4 @@
 AWS_ACCESSKEY="[your key goes here]"
 AWS_SECRET="[your key goes here]"
+HUGO_PARAMS_goUsaUsername="[your username goes here]"
+HUGO_PARAMS_goUsaApiKey="[your key goes here]"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "gulpfile.js",
   "scripts": {
     "local-build": "gulp build-assets && gulp watch",
-    "hugo": "hugo serve",
+    "hugo": "export $(grep -v '^#' .env | xargs) && hugo serve",
     "federalist": "export NODE_ENV=production && gulp build-assets",
     "start": "npm-run-all --parallel local-build hugo",
     "test:pa11y": "pa11y-ci --config .pa11yci",

--- a/themes/digital.gov/layouts/partials/core/get_clicks.html
+++ b/themes/digital.gov/layouts/partials/core/get_clicks.html
@@ -9,8 +9,8 @@ See clicks.js
   {{- $encodedurl := (substr (querify "x" .Params.short_url) 2) -}}
 
   {{/* sets the go.usa.gov login and APIkey as varables */}}
-  {{- $usagov_shortener_login := .Site.Params.url_shortener_login -}}
-  {{- $usagov_shortener_apikey := .Site.Params.url_shortener_api -}}
+  {{- $usagov_shortener_login := .Site.Params.goUsaUsername -}}
+  {{- $usagov_shortener_apikey := .Site.Params.goUsaApiKey -}}
 
   {{/* builds the API URL */}}
   {{- $short_url_api := printf "https://go.usa.gov/api/clicks.json?login=%s&apiKey=%s&shortUrl=%s" $usagov_shortener_login $usagov_shortener_apikey $encodedurl -}}

--- a/themes/digital.gov/layouts/partials/core/head.html
+++ b/themes/digital.gov/layouts/partials/core/head.html
@@ -169,6 +169,8 @@
   <script type="text/javascript">
     git_org          = {{ .Site.Params.git_org }};
     git_repo         = {{ .Site.Params.git_repo }};
+    goUsaUsername    = {{ .Site.Params.goUsaUsername }};
+    goUsaApiKey      = {{ .Site.Params.goUsaApiKey }};
     branch           = {{ $.Scratch.Get "branch" }};
     short_url        = {{ if .Params.short_url -}}{{- .Params.short_url -}}{{ else }}""{{- end -}};
     filename         = {{ with .File -}}{{- .LogicalName -}}{{- end }};

--- a/themes/digital.gov/src/js/common/clicks.js
+++ b/themes/digital.gov/src/js/common/clicks.js
@@ -1,115 +1,109 @@
 jQuery(document).ready(function($) {
+  // ==============================================================
+  // Register clicks on pages that have the short_url
+  // ==============================================================
 
-	// ==============================================================
-	// Register clicks on pages that have the short_url
-	// ==============================================================
+  // The Goal:
+  // To be able to display a metric on our News cards content that indicates a measure of interest from our readers.
 
-	// The Goal:
-	// To be able to display a metric on our News cards content that indicates a measure of interest from our readers.
+  // How are we doing this?
+  // We are registering all clicks through the go.usa.gov short_url.
 
-	// How are we doing this?
-	// We are registering all clicks through the go.usa.gov short_url.
+  // We are using the short_url in:
+  // - links from our newsletter
+  // - links on twitter, facebook, etc...
+  // - links in any form of sharing outside of the website
 
-	// We are using the short_url in:
-	// - links from our newsletter
-	// - links on twitter, facebook, etc...
-	// - links in any form of sharing outside of the website
+  // What about links that originate on digital.gov (e.g. from the homepage)?
+  // - If there the referrer is digital.gov...
+  // - A script inserts an iframe into the page that then loads the short_url. This then registers a click with the go.usa.gov short_url.
+  // - The iframe does not fully load because we block digital.gov from loading within iframes
 
-	// What about links that originate on digital.gov (e.g. from the homepage)?
-	// - If there the referrer is digital.gov...
-	// - A script inserts an iframe into the page that then loads the short_url. This then registers a click with the go.usa.gov short_url.
-	// - The iframe does not fully load because we block digital.gov from loading within iframes
+  // What about direct links (e.g. liks that I copy and paste to a friend)?
+  // - These are a little more tricky. At the moment, we are not capturing these.
+  // - The best way to capture these is if we were able to capture the referrer of all the links from go.usa.gov and then be able to conditionaly register a click based on this value.
 
-	// What about direct links (e.g. liks that I copy and paste to a friend)?
-	// - These are a little more tricky. At the moment, we are not capturing these.
-	// - The best way to capture these is if we were able to capture the referrer of all the links from go.usa.gov and then be able to conditionaly register a click based on this value.
+  // How to test
+  // 1. Any link originating from digital.gov should register one click, via the iframe
+  // 2. Any link originating from a short_url should register a click via the short_url (the iframe should not load)
+  // 3. Any direct link -- not being captured
 
+  var referer = document.referrer;
+  var domains = ["localhost", "digital.gov", "demo.digital.gov"];
+  if (new RegExp(domains.join("|")).test(referer) || referer) {
+    // short_url is defined in the <head>
+    // If not, none of this runs...
+    if (short_url) {
+      // Get the ID of the short_url — https://go.usa.gov/123ID
+      var short_url_id = short_url.replace("https://go.usa.gov/", "");
 
-	// How to test
-	// 1. Any link originating from digital.gov should register one click, via the iframe
-	// 2. Any link originating from a short_url should register a click via the short_url (the iframe should not load)
-	// 3. Any direct link -- not being captured
+      // Now create the name of the cookie we're going to set
+      var cookie_id = "view_" + short_url_id;
+      // This name will be specific to the article (or short URL) we are viewing
+      // If a reader is clicking around a number of articles, they might one cookie for each article they are viewing.
+      // Cookies expire after 1hr.
 
+      // Let's set a cookie!
+      // If the cookie_id already exists, we are not going to load the iframe and increment the clicks (views) of the short URL.
+      if (getCookie(cookie_id) == "true") {
+      } else {
+        $("#clicks_iframe").prepend(
+          '<iframe src="' + short_url + '" width="1" height="1"></iframe>'
+        );
+        setCookie(cookie_id, "true");
+      }
+    }
+  }
 
-	var referer = document.referrer;
-	var domains = ["localhost","digital.gov","demo.digital.gov"];
-	if ( (new RegExp(domains.join("|")).test(referer)) || (referer)) {
-		// short_url is defined in the <head>
-		// If not, none of this runs...
-		if (short_url){
+  function setCookie(key, value) {
+    var expires = new Date();
+    // I think this means that the cookie will expire in 60mins?
+    expires.setTime(expires.getTime() + 60 * (60 * 1000));
+    document.cookie =
+      key + "=" + value + ";expires=" + expires.toUTCString() + "; path=/";
+  }
 
-			// Get the ID of the short_url — https://go.usa.gov/123ID
-			var short_url_id = short_url.replace("https://go.usa.gov/", "");
+  function getCookie(key) {
+    var keyValue = document.cookie.match("(^|;) ?" + key + "=([^;]*)(;|$)");
+    return keyValue ? keyValue[2] : null;
+  }
 
-			// Now create the name of the cookie we're going to set
-			var cookie_id = 'view_' + short_url_id;
-			// This name will be specific to the article (or short URL) we are viewing
-			// If a reader is clicking around a number of articles, they might one cookie for each article they are viewing.
-			// Cookies expire after 1hr.
+  // ==============================================================
+  // Display clicks on articles
+  // ==============================================================
 
+  // We want to display the clicks/views of any item on the page
+  // To do so, we need to merely set the data-short_url attribute in the HTML and include the short_url in
+  // e.g. <article data-short_url="https://go.usa.gov/123ID">
 
-			// Let's set a cookie!
-			// If the cookie_id already exists, we are not going to load the iframe and increment the clicks (views) of the short URL.
-	    if (getCookie(cookie_id) == 'true') {
-	    } else {
-				$('#clicks_iframe').prepend('<iframe src="'+short_url+'" width="1" height="1"></iframe>');
-	      setCookie(cookie_id,'true');
-	    }
+  // This finds all of the elements on the page that have the short_url defined
+  // - It gets the json API from https://go.usa.gov/ for that short url
+  // - identifies the current number of clicks
+  // - It adds the number of clicks to the HTML with a little number counting animation for fun
 
-		}
-	}
-
-	function setCookie(key, value) {
-		var expires = new Date();
-		// I think this means that the cookie will expire in 60mins?
-		expires.setTime(expires.getTime() + (60 * (60 * 1000)) );
-		document.cookie = key + '=' + value + ';expires=' + expires.toUTCString() + "; path=/";
-	}
-
-	function getCookie(key) {
-		var keyValue = document.cookie.match('(^|;) ?' + key + '=([^;]*)(;|$)');
-		return keyValue ? keyValue[2] : null;
-	}
-
-
-
-
-
-
-	// ==============================================================
-	// Display clicks on articles
-	// ==============================================================
-
-	// We want to display the clicks/views of any item on the page
-	// To do so, we need to merely set the data-short_url attribute in the HTML and include the short_url in
-	// e.g. <article data-short_url="https://go.usa.gov/123ID">
-
-	// This finds all of the elements on the page that have the short_url defined
-	// - It gets the json API from https://go.usa.gov/ for that short url
-	// - identifies the current number of clicks
-	// - It adds the number of clicks to the HTML with a little number counting animation for fun
-
-	$('*[data-short_url]').each(function(){
-		var short_url = $(this).data('short_url');
-		var article = $(this);
-		var api = 'https://go.usa.gov/api/clicks.json?login=' + process.env.HUGO_PARAMS_goUsaUsername + '&apiKey=' + process.env.HUGO_PARAMS_goUsaApiKey + '&shortUrl=' + encodeURI(short_url);
-		$.getJSON( api, function( data ) {
-			$.each( data.response.data.entry, function( key, value ) {
-				var element = $(article).find('.clicks');
-				var element_span = $(element).find('span');
-				var stale_clicks = $(element).data('clicks');
-				var current_clicks = value.user_clicks;
-				// Count up from the existing number to the current_num_clicks
-				var interval = setInterval(function() {
-					if (stale_clicks >= current_clicks) clearInterval(interval);
-					stale_clicks++;
-					$(element_span).html(stale_clicks);
-				}, 50);
-
-			});
-		});
-	});
-
-
-
+  $("*[data-short_url]").each(function() {
+    var short_url = $(this).data("short_url");
+    var article = $(this);
+    var api =
+      "https://go.usa.gov/api/clicks.json?login=" +
+      goUsaUsername +
+      "&apiKey=" +
+      goUsaApiKey +
+      "&shortUrl=" +
+      encodeURI(short_url);
+    $.getJSON(api, function(data) {
+      $.each(data.response.data.entry, function(key, value) {
+        var element = $(article).find(".clicks");
+        var element_span = $(element).find("span");
+        var stale_clicks = $(element).data("clicks");
+        var current_clicks = value.user_clicks;
+        // Count up from the existing number to the current_num_clicks
+        var interval = setInterval(function() {
+          if (stale_clicks >= current_clicks) clearInterval(interval);
+          stale_clicks++;
+          $(element_span).html(stale_clicks);
+        }, 50);
+      });
+    });
+  });
 });

--- a/themes/digital.gov/src/js/common/clicks.js
+++ b/themes/digital.gov/src/js/common/clicks.js
@@ -92,7 +92,7 @@ jQuery(document).ready(function($) {
 	$('*[data-short_url]').each(function(){
 		var short_url = $(this).data('short_url');
 		var article = $(this);
-		var api = 'https://go.usa.gov/api/clicks.json?login=jeremyz&apiKey=d0ac464a2dfad044147e9537fd51503b&shortUrl=' + encodeURI(short_url);
+		var api = 'https://go.usa.gov/api/clicks.json?login=' + process.env.HUGO_PARAMS_goUsaUsername + '&apiKey=' + process.env.HUGO_PARAMS_goUsaApiKey + '&shortUrl=' + encodeURI(short_url);
 		$.getJSON( api, function( data ) {
 			$.each( data.response.data.entry, function( key, value ) {
 				var element = $(article).find('.clicks');


### PR DESCRIPTION
This PR implements the following **changes:**

Use environment variables for go.usa.gov API details. These env vars have been added to CircleCI, Federalist and the sample `.env` file. Based on how the counter element is implemented, it is still necessary to expose the API key to the frontend, so these changes only remove the API key from the source code and build logs but it will still be visible in the compiled HTML code.

To hide the API key from the frontend it would require the logic to be moved to the Hugo code, the drawback being the page counts will only update when new changes are committed. The other option would be to have an intermediate backend service that fetches the API data for the frontend, allowing the API key to remain only visible to the backend.

