### PR TITLE
adding information to event

### DIFF
--- a/content/events/2019/11/2019-11-13-ginny-redish-how-collaborate-on-strategies.md
+++ b/content/events/2019/11/2019-11-13-ginny-redish-how-collaborate-on-strategies.md
@@ -1,16 +1,43 @@
 ---
+# View this page at https://digital.gov/event/2019/11/ginny-redish-how-collaborate-on-strategies
+# Learn how to edit our pages at https://workflow.digital.gov
 slug: ginny-redish-how-collaborate-on-strategies
-title: "Ginny Redish&#58; How to Collaborate on Strategies"
-summary: "How does content strategy mesh with business, user experience &#40;UX&#41;, and a marketing strategy&#63;"
-featured_image:
-  uid: plainlanguage-ginny-redish-card
-  alt: ''
+title: "Ginny Redish: How to Collaborate on Strategies"
+deck: ""
+summary: "How does content strategy mesh with business, user experience (UX), and a marketing strategy?"
+host: "PLAIN and Digital.gov"
+event_organizer: "DigitalGov University"
+registration_url: 
+captions: 
+
+# start date
 date: 2019-11-13 14:00:00 -0500
+
+# end date
 end_date: 2019-11-13 15:30:00 -0500
-event_organizer: DigitalGov University
-host: PLAIN and Digital.gov
+
+# see all topics at https://digital.gov/topics
+topics: 
+  - content-strategy
+  - plain-language
+  - user-experience
+
+# see all authors at https://digital.gov/authors
+authors: 
+  - ginny-redish
+
+# YouTube ID
 youtube_id: 3jY7z9gYG5Y
 
+# Primary Image (for social media)
+primary_image: "plainlanguage-ginny-redish-card"
+
+# Page weight: controls how this page appears across the site
+# 0 -- hidden
+# 1 -- visible
+weight: 0
+
+# Make it better ♥
 ---
 
 Join us for a session with noted user experience (UX) and plain language expert, Ginny Redish. She'll explain strategies, how they work together, the good that happens when they do, the mess that happens when they don't, and the worst scenario of all: no strategy at all.

--- a/content/events/2019/11/2019-11-13-ginny-redish-how-collaborate-on-strategies.md
+++ b/content/events/2019/11/2019-11-13-ginny-redish-how-collaborate-on-strategies.md
@@ -38,10 +38,10 @@ primary_image: "plainlanguage-ginny-redish-card"
 weight: 0
 
 # Make it better ♥
+
 ---
 
 Join us for a session with noted user experience (UX) and plain language expert, Ginny Redish. She'll explain strategies, how they work together, the good that happens when they do, the mess that happens when they don't, and the worst scenario of all: no strategy at all.
-
 
 ## About the speaker
 
@@ -62,4 +62,3 @@ _All references to specific brands, products, and/or companies are used only for
 Questions about this event or future events? Send them to [digitalgovu@gsa.gov](mailto:digitalgovu@gsa.gov).
 
 This talk is hosted by the [Plain Language Action and Information Network](https://digital.gov/communities/plain-language/) (PLAIN) and Digital.gov.
-


### PR DESCRIPTION
adding redish as event speaker and three topics to event

This PR implements the following **changes:**

* adding ginny redish as event speaker
* adding content strategy, plain language and user experience as event tags


**URL / Link to page**
https://digital.gov/event/2019/11/13/ginny-redish-how-collaborate-on-strategies/

