### PR TITLE
updating event information

### DIFF
--- a/content/events/2019/11/2019-11-19-intro-ab-testing-cop.md
+++ b/content/events/2019/11/2019-11-19-intro-ab-testing-cop.md
@@ -1,18 +1,40 @@
 ---
+# View this page at https://digital.gov/event/2019/11/an-introduction-ab-testing-community-practice
+# Learn how to edit our pages at https://workflow.digital.gov
 slug: intro-ab-testing-cop
-title: "An Introduction to the A&#x2F;B Testing Community of Practice"
-summary: 'We know there are many ways to use A&#x2F;B testing to inform decision making at your agency – this is a quick introduction on the many ways CFPB has used it to improve UX across their website&#46; '
-featured_image: 
-  uid: 
-  alt: ''
-event_type: 
-  - zoom
+title: "An Introduction to the A/B Testing Community of Practice"
+deck: ""
+summary: "We know there are many ways to use A/B testing to inform decision making at your agency – this is a quick introduction on the many ways CFPB has used it to improve UX across their website. "
+host: "TTS Research Guild & Digital.gov"
+event_organizer: "DigitalGov University"
+registration_url: 
+captions: 
+
+# start date
 date: 2019-11-19 11:00:00 -0500
+
+# end date
 end_date: 2019-11-19 11:30:00 -0500
-event_organizer: DigitalGov University
-host: TTS Research Guild & Digital.gov
+
+# see all topics at https://digital.gov/topics
+topics: 
+  - a-b-testing
+  - dap
+  - seo
+
+# see all authors at https://digital.gov/authors
+authors: 
+  - kelley-holden
+
+# YouTube ID
 youtube_id: fXHqrdOEbnI
 
+# Page weight: controls how this page appears across the site
+# 0 -- hidden
+# 1 -- visible
+weight: 0
+
+# Make it better ♥
 ---
 
 The Consumer Financial Protection Bureau (CFPB) has been running A/B tests for over four years, and we have learned a lot about when testing makes sense, how to work cross-team for the best results, how to run a successful test, and what it means when your test doesn’t get the results you expected. In this session, we would like to share knowledge with our new community of practice, as well as discuss what we as a group hope to get out of this community.  


### PR DESCRIPTION
adding holden and three topics to event information

This PR implements the following **changes:**

* adding kelley holden as event speaker
* adding DAP, A/B testing and SEO as event tags


**URL / Link to page**
https://digital.gov/event/2019/11/19/intro-ab-testing-cop/

