### PR TITLE
Use npm install instead of npm ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,9 @@ jobs:
     <<: *default-executor
     steps:
       - checkout
-      - node/install-packages
+      - node/install-packages:
+          cache-path: ~/project/node_modules
+          override-ci-command: npm install
       - attach_workspace:
           at: .
       - run:
@@ -24,7 +26,9 @@ jobs:
     <<: *default-executor
     steps:
       - checkout
-      - node/install-packages
+      - node/install-packages:
+          cache-path: ~/project/node_modules
+          override-ci-command: npm install
       - run:
           name: Install Gulp
           command: sudo npm install gulp-cli -g


### PR DESCRIPTION
This PR implements the following **changes:**

I've been seeing some random failures with CircleCI such as: https://app.circleci.com/pipelines/github/GSA/digitalgov.gov/4935/workflows/f34e6ff8-7bc4-4a83-8854-c5c391737927/jobs/5263/steps

After researching, this appears to be an unresolved bug related to using `npm ci` to install npm packages, so this updates the command to use the more traditional `npm install`. Will keep an eye out on the builds after this is merged to see if it resolves the random failures.
