### PR TITLE
Add space between attributes

### DIFF
--- a/themes/digital.gov/layouts/events/card-event-past.html
+++ b/themes/digital.gov/layouts/events/card-event-past.html
@@ -1,4 +1,4 @@
-<div class="card card-event card-event-past card-linked" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}" {{- if .Params.short_url -}}data-short_url="{{- .Params.short_url -}}"{{- end -}}>
+<div class="card card-event card-event-past card-linked" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
   <div class="grid-row tablet:grid-gap-4">
 
     {{- if .Params.youtube_id -}}

--- a/themes/digital.gov/layouts/events/card-event.html
+++ b/themes/digital.gov/layouts/events/card-event.html
@@ -1,4 +1,4 @@
-<div class="card card-event-promo card-linked" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}" {{- if .Params.short_url -}}data-short_url="{{- .Params.short_url -}}"{{- end -}}>
+<div class="card card-event-promo card-linked" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
 
   <div class="grid-row tablet:grid-gap-4">
 

--- a/themes/digital.gov/layouts/news/card-article.html
+++ b/themes/digital.gov/layouts/news/card-article.html
@@ -1,4 +1,4 @@
-<div class="card card-article card-linked" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}" {{- if .Params.short_url -}}data-short_url="{{- .Params.short_url -}}"{{- end -}}>
+<div class="card card-article card-linked" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
   <div class="grid-row tablet:grid-gap-4">
     <div class="grid-col-12 tablet:grid-col-4 tablet:order-2">
       {{- partial "core/img-featured" . -}}

--- a/themes/digital.gov/layouts/news/card-elsewhere.html
+++ b/themes/digital.gov/layouts/news/card-elsewhere.html
@@ -1,4 +1,4 @@
-<div class="card card-elsewhere card-linked" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}" {{- if .Params.short_url -}}data-short_url="{{- .Params.short_url -}}"{{- end -}}>
+<div class="card card-elsewhere card-linked" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
   <div>
     <div class="icon">
       {{/* Favicon

--- a/themes/digital.gov/layouts/news/single.html
+++ b/themes/digital.gov/layouts/news/single.html
@@ -1,7 +1,7 @@
 {{- define "content" -}}
 
 <main role="main">
-  <article {{ if .Params.short_url -}}data-short_url="{{- .Params.short_url -}}"{{- end -}}>
+  <article {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
     <header>
       <div class="grid-container grid-container-desktop" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
         <div class="grid-row">

--- a/themes/digital.gov/layouts/shortcodes/img-right.html
+++ b/themes/digital.gov/layouts/shortcodes/img-right.html
@@ -12,9 +12,9 @@
 <div class="image image-right">
   <img
     src='{{- $imgBaseCDN -}}_w200.{{- $imgExt -}}'
-    {{- if or (.Get "alt") $thisimg.alt -}}
+    {{ if or (.Get "alt") $thisimg.alt }}
     alt='{{- with .Get "alt" -}}{{- . -}}{{- else -}}{{- $thisimg.alt -}}{{- end -}}'
-    {{- end -}}
+    {{ end }}
     srcset="
     {{- if ge $imgWidth 200 -}}{{- $imgBaseCDN -}}_bu.jpg 48w,
       {{- if ge $imgWidth 400 -}}

--- a/themes/digital.gov/layouts/shortcodes/img.html
+++ b/themes/digital.gov/layouts/shortcodes/img.html
@@ -14,7 +14,7 @@
 
 <div class="image{{- if (.Get "align") -}} image-{{- .Get "align" -}}{{- else}}{{- if lt $imgWidth 600 -}} image-right{{- end -}}{{- end -}}">
   <img src="{{- if ne $prefix $thisuid -}}{{- $thisuid -}}{{- else -}}{{- $imgBaseCDN -}}_w800.{{- $imgExt -}}{{- end -}}"
-  {{- if or (.Get "alt" ) $thisimg.alt }} alt="{{- with .Get "alt" -}}{{- . -}}{{- else -}}{{- $thisimg.alt -}}{{- end -}}"
+  {{ if or (.Get "alt" ) $thisimg.alt }} alt="{{- with .Get "alt" -}}{{- . -}}{{- else -}}{{- $thisimg.alt -}}{{ end }}"
   {{- end -}}
   {{- if eq $prefix $thisuid }} srcset="
     {{- if ge $imgWidth 200 -}}{{- $imgBaseCDN -}}_bu.jpg 48w,


### PR DESCRIPTION
This PR implements the following **changes:**

Due to a conditional statement with whitespace being stripped, two HTML attributes are displaying without a space in-between causing a validation error:
```
<div class="card card-article card-linked" data-edit-this="/edit/news/?page=https://digital.gov/2020/06/30/bringing-our-humanity-work-5-ingredients/"data-short_url="https://go.usa.gov/xwtku">
```

 This updates the attributes to have a space in-between them.
