### PR TITLE
adding author to page

### DIFF
--- a/content/events/2020/03/2020-03-31-intro-cloud-foundry-on-cloudgov.md
+++ b/content/events/2020/03/2020-03-31-intro-cloud-foundry-on-cloudgov.md
@@ -1,11 +1,10 @@
 ---
 # View this page at https://digital.gov/event/2020/03/intro-cloud-foundry-on-cloudgov
 # Learn how to edit our pages at https://workflow.digital.gov
-
 slug: intro-cloud-foundry-on-cloudgov
-kicker: Cloud.gov
 title: "Intro to Cloud Foundry on Cloud.gov"
 deck: "A look at the open source cloud application platform behind Cloud.gov"
+kicker: "Cloud.gov"
 summary: "In this workshop, we demonstrate the basics of using the Cloud.gov platform as a developer."
 host: "Cloud.gov"
 event_organizer: "Digital.gov"
@@ -13,20 +12,21 @@ registration_url: https://www.eventbrite.com/e/99225922405
 captions: https://www.captionedtext.com/client/event.aspx?EventID=4375326&CustomerID=321
 
 # start date
-date: 2020-03-31 14:00:00 -0500
+date: 2020-03-31 15:00:00 -0500
 
 # end date
-end_date: 2020-03-31 15:00:00 -0500
+end_date: 2020-03-31 16:00:00 -0500
 
 # see all topics at https://digital.gov/topics
-topics:
-  - cloud
-  - cloud-gov
+topics: 
   - code
   - open-source
+  - cloud
+  - cloud-gov
 
-# Event platform (zoom, youtube_live, adobe_connect, google)
-event_platform: 
+# see all authors at https://digital.gov/authors
+authors: 
+  - steve-greenberg
 
 # YouTube ID
 youtube_id: G3fk3cJci0I
@@ -34,10 +34,13 @@ youtube_id: G3fk3cJci0I
 # Primary Image (for social media)
 primary_image: "cloudgov-intro-to-cloud-foundry"
 
+# Page weight: controls how this page appears across the site
+# 0 -- hidden
+# 1 -- visible
+weight: 0
+
 # Make it better ♥
-
 ---
-
 
 Are you a [Cloud.gov](https://cloud.gov/) customer—or potential customer—interested in how Cloud.gov can simplify and accelerate your development organizations? In this guided demonstration, we walk you through the basics of using the core Cloud.gov platform called [Cloud Foundry](https://www.cloudfoundry.org/)— an open source cloud application platform. We highlight the simplicity that Cloud Foundry brings to developer workflows through its use of high-level abstractions and APIs, and discuss the impact of using cloud.gov and Cloud Foundry on a developer's responsibilities.
 


### PR DESCRIPTION
adding author to event page

This PR implements the following **changes:**

* adding steve greenberg to event page as author


**URL / Link to page**
https://digital.gov/event/2020/03/31/intro-cloud-foundry-on-cloudgov/

