### PR TITLE
Remove len function

### DIFF
--- a/themes/digital.gov/layouts/topics/terms.html
+++ b/themes/digital.gov/layouts/topics/terms.html
@@ -124,7 +124,6 @@
         <div class="grid-col-6">
           <table>
             {{- $topics := (where .Site.Pages "Section" "topics") -}}
-            {{- len $topics -}}
             {{- range $name, $taxonomy := $topics.ByTitle -}}
               <tr>
                 <td class="padding-1 border-bottom-1px border-base-lighter"><a href="{{- .Permalink -}}" title="{{- $name -}}"><span>{{- .Title -}}</span></a></td>
@@ -137,7 +136,6 @@
         <div class="grid-col-6">
           <table>
             {{- $topics_tax := $.Site.Taxonomies.topics -}}
-            {{- len $topics_tax -}}
             {{- range $name, $taxonomy := $topics_tax -}}
               {{- with $.Site.GetPage (printf "/topics/%s" $name) -}}
               <tr>


### PR DESCRIPTION
This PR implements the following **changes:**

Some leftover `len` tags that are printing out the topic count within the `<table>` where it shouldn't be.