### PR TITLE
Only add Federalist preview link once to pull requests

### DIFF
--- a/.github/workflows/pr-preview-link.yml
+++ b/.github/workflows/pr-preview-link.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - main
+    types: [opened]
 
 jobs:
   comment:


### PR DESCRIPTION
This PR implements the following **changes:**

Since the Federalist preview link does not change with every commit, this tweaks the GitHub action to only add the Federalist preview link once, when the pull request is first initiated (rather than on every commit).