### PR TITLE
Lowercase linkedin in Netlify CMS

### DIFF
--- a/themes/digital.gov/static/workflow/config.yml
+++ b/themes/digital.gov/static/workflow/config.yml
@@ -168,7 +168,7 @@ collections:
         required: false
 
       - label: "Linkedin"
-        name: "linkedIn"
+        name: "linkedin"
         widget: "string"
         required: false
 


### PR DESCRIPTION
This PR implements the following **changes:**

Use all lowercase for field name `linkedin`.
