### PR TITLE
Implement additional collections in Netlify CMS

### DIFF
--- a/themes/digital.gov/static/workflow/config.yml
+++ b/themes/digital.gov/static/workflow/config.yml
@@ -13,17 +13,9 @@ backend:
   auth_endpoint: external/auth/github
   preview_context: federalist/build
   use_graphql: true
-
   branch: main
   open_authoring: true
   squash_merges: true
-  commit_messages:
-    create: 'New {{collection}}: "{{slug}}"'
-    update: 'Update {{collection}} "{{slug}}"'
-    delete: 'Delete {{collection}} "{{slug}}"'
-    uploadMedia: 'Upload "{{path}}"'
-    deleteMedia: 'Delete "{{path}}"'
-    openAuthoring: "{{message}}, {{author-login}}"
 
 # Publish Mode
 publish_mode: editorial_workflow
@@ -34,7 +26,6 @@ local_backend:
 
 # Media / Images
 media_folder: "/static/img/proxy"
-public_folder: ""
 
 # Misc
 slug:
@@ -52,26 +43,21 @@ collections:
     editor:
       preview: false
 
-    identifier_field: display_name # sets the field that is used to create the slug
-    path: "{{slug}}/_index" # custom file path
-    preview_path: authors/{{display_name}}
-    create: true # Allow users to create new documents in this collection
-    slug: "{{slug}}"
+    identifier_field: display_name
+    path: "{{slug}}/_index"
+    create: true
 
     fields:
       - label: "Display Name"
         name: "display_name"
         widget: "string"
         hint: "How you prefer to be referred to."
-
       - label: "First Name"
         name: "first_name"
         widget: "string"
-
       - label: "Last Name"
         name: "last_name"
         widget: "string"
-
       - label: "Pronoun"
         name: "pronoun"
         widget: "string"
@@ -82,21 +68,18 @@ collections:
           List your pronoun(s) if you want them displayed alongside your name.
            If blank, we'll use just your name. Learn more http://mypronouns.org
         required: false
-
       - label: "Email"
         name: "email"
         widget: "string"
         hint: "If you include an email address, it will be displayed on your profile page"
         comment: "If you include an email address, it will be displayed on your profile page"
         required: false
-
       - label: "Bio"
         name: "bio"
         widget: "text"
         hint: "Keep it under 50 words and only one paragraph"
         comment: "Keep it under 50 words and only one paragraph"
         required: false
-
       - label: "Bio URL"
         name: "bio_url"
         widget: "string"
@@ -107,21 +90,18 @@ collections:
           Where can people learn more about your work?
            Provide a full URL [e.g. 'https://www.example.gov/']
         required: false
-
       - label: "Agency Full Name"
         name: "agency_full_name"
         widget: "string"
         hint: "e.g. U.S. General Services Administration"
         comment: "e.g. U.S. General Services Administration"
         required: false
-
       - label: "Agency Acronym"
         name: "agency"
         widget: "string"
         hint: "e.g. GSA"
         comment: "Agency Acronym [e.g., GSA]"
         required: false
-
       - label: "Location"
         name: "location"
         widget: "string"
@@ -130,20 +110,18 @@ collections:
           Where in the country do you live in? [e.g. 'New York City' or 'Portland, OR']
         comment: "Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']"
         required: false
-
       - label: "GitHub ID"
         name: "github"
         widget: "string"
-        hint: |
+        hint: |-
           [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
           Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
           Learn more about getting a Github account at [URL]
-        comment: |
+        comment: |-
           [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
            Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
            Learn more about getting a Github account at [URL]
         required: false
-
       - label: "Profile Photo"
         name: "profile_photo"
         widget: "select"
@@ -151,33 +129,27 @@ collections:
         hint: "See [URL] for a full list of profile photo options"
         comment: "See [URL] for a full list of profile photo options"
         required: false
-
       - label: "Twitter"
         name: "twitter"
         widget: "string"
         hint: "e.g., Digital_Gov"
         required: false
-
       - label: "Facebook"
         name: "facebook"
         widget: "string"
         required: false
-
       - label: "Instagram"
         name: "instagram"
         widget: "string"
         required: false
-
       - label: "Linkedin"
         name: "linkedin"
         widget: "string"
         required: false
-
       - label: "YouTube"
         name: "youtube"
         widget: "string"
         required: false
-
       - label: "Redirects"
         label_singular: Redirect
         name: "aliases"
@@ -197,9 +169,7 @@ collections:
 
     path: "{{cms_date[yyyy]}}/{{cms_date[mm]}}/{{slug}}"
     slug: "{{cms_date[yyyy]}}-{{cms_date[mm]}}-{{cms_date[dd]}}-{{slug}}"
-    media_folder: "/static/img/proxy"
-    public_folder: ""
-    create: true # Allow users to create new documents in this collection
+    create: true
 
     fields:
       - label: "Event Title"
@@ -212,19 +182,54 @@ collections:
         hint: |-
           Think of this as the sentence you'd most like to tweet.
           Do not repeat the headline. You need to be able to read it outloud in a single breath.
+        required: false
       - label: "Kicker"
         name: "kicker"
         widget: "string"
         hint: |-
           Highlight the relevant topic. This displays above the event title on the /events/ page.
           Should always be included. Use only one or two words.
+        required: false
       - label: "Summary"
         name: "summary"
         widget: "text"
         hint: "1-sentence description that does not repeat the headline"
+      - label: "Source Url"
+        name: "source_url"
+        widget: "string"
+        hint: "e.g. https://18f.gsa.gov/2019/04/01/ ..."
+        comment: "Originally published at the following URL"
+        required: false
+      - label: "Source"
+        name: "source"
+        widget: "relation"
+        collection: "sources"
+        searchFields: ["name"]
+        valueField: "slug"
+        displayFields: ["name"]
+        required: false
+      - label: "Host"
+        name: "host"
+        widget: "string"
+        hint: "e.g. Plain Language Community of Practice"
+        required: false
+      - label: "Event Organizer"
+        name: "event_organizer"
+        widget: "string"
+        default: "Digital.gov"
+      - label: "Registration URL"
+        name: "registration_url"
+        widget: "string"
+        hint: "e.g. https://www.eventbrite.com/..."
+      - label: "Captions URL"
+        name: "captions"
+        widget: "string"
+        hint: "e.g. https://www.captionedtext.com..."
+        required: false
       - label: "Start Date/Time"
         name: "cms_date"
         widget: "object"
+        hint: "e.g. 2019-04-01 13:24"
         fields:
           - label: "Month"
             name: "mm"
@@ -249,6 +254,7 @@ collections:
       - label: "End Date/Time"
         name: "cms_end_date"
         widget: "object"
+        hint: "Usually the same date as the event"
         fields:
           - label: "Month"
             name: "mm"
@@ -270,10 +276,144 @@ collections:
             widget: "string"
             hint: "The time the event ends, in eastern time (HH:MM)"
             pattern: ["^(?:2[0-3]|[01][0-9]):[0-5][0-9]$", "Must be HH:MM"]
+      - label: "Topics"
+        name: "topics"
+        widget: "async-select"
+        url: "https://digital.gov/topics/v1/json/"
+        valueField: "slug"
+        displayField: "title"
+        dataKey: "items"
+        multiple: true
+        hint: "See all topics at https://digital.gov/topics"
+        comment: "See all topics at https://digital.gov/topics"
+        required: false
+      - label: "Presenters (authors)"
+        name: "authors"
+        widget: "relation"
+        collection: "authors"
+        searchFields: ["first_name", "last_name"]
+        valueField: "slug"
+        displayFields: ["display_name"]
+        multiple: true
+        hint: "See all authors at https://digital.gov/authors"
+        comment: "See all authors at https://digital.gov/authors"
+        required: false
+      - label: "Event platform"
+        name: "event_platform"
+        widget: "select"
+        options: ["zoom", "youtube_live", "adobe_connect", "google"]
+        comment: "zoom, youtube_live, adobe_connect, google"
+        required: false
+      - label: "YouTube ID"
+        name: "youtube_id"
+        widget: "string"
+        hint: "e.g. 3FKyVeipMss"
+        required: false
       - label: "Primary Image (for social media)"
         name: "primary_image"
         widget: "image"
         required: false
+      - label: "Page Weight"
+        name: "weight"
+        widget: "number"
+        default: 0
+        valueType: "int"
+        min: 0
+        max: 1
+        step: 1
+        hint: "Controls how this page appears across the site (0 -- hidden, 1 -- visible)"
+        comment: |-
+          Controls how this page appears across the site
+           0 -- hidden
+           1 -- visible
+      - label: "Redirects"
+        label_singular: Redirect
+        name: "aliases"
+        widget: "list"
+        hint: "Enter the path of the URL that you want redirected to this page"
+        comment: "Enter the path of the URL that you want redirected to this page"
+        field: { label: Redirect, name: redirect, widget: string }
+        required: false
+
+  # SOURCES =======================
+  - name: "sources"
+    label: "Sources"
+    label_singular: "Source"
+    description: "Sources are the sites from our community that we have pointed to or re-published from."
+    folder: "content/sources"
+    editor:
+      preview: false
+
+    identifier_field: name
+    path: "source_{{slug}}"
+    create: true
+
+    fields:
+      - label: "Source Name"
+        name: "name"
+        widget: "string"
+        hint: "e.g. 18F, HHS Idea Lab"
+      - label: "Summary"
+        name: "summary"
+        widget: "text"
+        hint: "A short, 1-sentence description that does not include the source name."
+      - label: "Primary Domain"
+        name: "domain"
+        widget: "string"
+        hint: "e.g. https://18f.gsa.gov/"
+        comment: "The link to your blog homepage or news feed. (e.g. https://18f.gsa.gov/)"
+      - label: "Logo"
+        name: "logo"
+        widget: "string"
+        hint: "Images must be uploaded in the /static/logos/ folder before they can be used here."
+        comment: "The link to your blog homepage or news feed. (e.g. https://18f.gsa.gov/)"
+      - label: "Topics"
+        name: "topics"
+        widget: "async-select"
+        url: "https://digital.gov/topics/v1/json/"
+        valueField: "slug"
+        displayField: "title"
+        dataKey: "items"
+        multiple: true
+        hint: "See all topics at https://digital.gov/topics"
+        comment: "See all topics at https://digital.gov/topics"
+        required: false
+
+  # TOPICS =======================
+  - name: "topics"
+    label: "Topics"
+    label_singular: "Topic"
+    description: "This page will help create a new topic on Digital.gov"
+    folder: "content/topics"
+    editor:
+      preview: false
+
+    path: "{{slug}}/_index"
+    create: true
+
+    fields:
+      - label: "Topic Title"
+        name: "title"
+        widget: "string"
+        hint: "Short, topical, no acronyms."
+      - label: "Description"
+        name: "summary"
+        widget: "text"
+        hint: "1-sentence description that does not repeat the headline"
+      - label: "Weight"
+        name: "weight"
+        widget: "number"
+        default: 0
+        valueType: "int"
+        min: 0
+        max: 2
+        step: 1
+        hint: "Controls how this page appears across the site (0 -- hidden, 1 -- visible, 2 -- featured on the Resource page"
+        comment: |-
+          Controls how this page appears across the site
+           0 -- hidden
+           1 -- visible
+           2 -- featured on the Resource page
 
   # IMAGE UPLOAD =======================
   - name: "image-upload"
@@ -283,10 +423,10 @@ collections:
     editor:
       preview: false
 
-    media_folder: "/content/images/_inbox"
+    media_folder: ""
     public_folder: ""
-    identifier_field: image # sets the field that is used to create the slug
-    create: true # Allow users to create new documents in this collection
+    identifier_field: image
+    create: true
 
     fields:
       - label: "Image"
@@ -301,7 +441,7 @@ collections:
     editor:
       preview: false
 
-    identifier_field: uid # sets the field that is used to create the slug
+    identifier_field: uid
     extension: yml
     format: yml
 

--- a/themes/digital.gov/static/workflow/config.yml
+++ b/themes/digital.gov/static/workflow/config.yml
@@ -5,17 +5,18 @@
 site_url: https://digital.gov
 logo_url: https://digital.gov/logos/digitalgov-logo.png
 
-# Backend and connections
 backend:
+  # Federalist
   name: github
   repo: GSA/digitalgov.gov
   base_url: https://federalistapp.18f.gov
   auth_endpoint: external/auth/github
   preview_context: federalist/build
-  branch: main
   use_graphql: true
-  open_authoring: true # accept contributions (forks) from GitHub users
-  squash_merges: true # squash all commits into a single commit when the PR is merged
+
+  branch: main
+  open_authoring: true
+  squash_merges: true
   commit_messages:
     create: 'New {{collection}}: "{{slug}}"'
     update: 'Update {{collection}} "{{slug}}"'
@@ -32,8 +33,8 @@ local_backend:
   url: http://localhost:8081/api/v1
 
 # Media / Images
-media_folder: "static/media"
-public_folder: "/img/proxy"
+media_folder: "/static/img/proxy"
+public_folder: ""
 
 # Misc
 slug:
@@ -43,18 +44,19 @@ slug:
 # Content Collections
 collections:
   # AUTHORS =======================
-  - name: "authors" # Used in routes, e.g., /workflow/collections/blog
-    label: "Authors" # Used in the UI
+  - name: "authors"
+    label: "Authors"
     label_singular: "Author"
     description: "This page will help create a new author profile on Digital.gov"
-    folder: "content/authors" # path to the folder where files are stored
+    folder: "content/authors"
+    editor:
+      preview: false
+
     identifier_field: display_name # sets the field that is used to create the slug
     path: "{{slug}}/_index" # custom file path
     preview_path: authors/{{display_name}}
     create: true # Allow users to create new documents in this collection
     slug: "{{slug}}"
-    editor:
-      preview: false
 
     fields:
       - label: "Display Name"
@@ -93,7 +95,6 @@ collections:
         widget: "text"
         hint: "Keep it under 50 words and only one paragraph"
         comment: "Keep it under 50 words and only one paragraph"
-        pattern: [".{20,}", "Must have at least 20 characters"]
         required: false
 
       - label: "Bio URL"
@@ -184,3 +185,136 @@ collections:
         hint: "Enter the path of the URL that you want redirected to this page"
         comment: "Enter the path of the URL that you want redirected to this page"
         field: { label: Redirect, name: redirect, widget: string }
+
+  # EVENTS =======================
+  - name: "events"
+    label: "Events"
+    label_singular: "Event"
+    description: "This page will help create a new event on Digital.gov"
+    folder: "content/events"
+    editor:
+      preview: false
+
+    path: "{{cms_date[yyyy]}}/{{cms_date[mm]}}/{{slug}}"
+    slug: "{{cms_date[yyyy]}}-{{cms_date[mm]}}-{{cms_date[dd]}}-{{slug}}"
+    media_folder: "/static/img/proxy"
+    public_folder: ""
+    create: true # Allow users to create new documents in this collection
+
+    fields:
+      - label: "Event Title"
+        name: "title"
+        widget: "string"
+        hint: "Short, topical, no acronyms."
+      - label: "Deck / Sub-head"
+        name: "deck"
+        widget: "text"
+        hint: |-
+          Think of this as the sentence you'd most like to tweet.
+          Do not repeat the headline. You need to be able to read it outloud in a single breath.
+      - label: "Kicker"
+        name: "kicker"
+        widget: "string"
+        hint: |-
+          Highlight the relevant topic. This displays above the event title on the /events/ page.
+          Should always be included. Use only one or two words.
+      - label: "Summary"
+        name: "summary"
+        widget: "text"
+        hint: "1-sentence description that does not repeat the headline"
+      - label: "Start Date/Time"
+        name: "cms_date"
+        widget: "object"
+        fields:
+          - label: "Month"
+            name: "mm"
+            widget: "string"
+            hint: "MM"
+            pattern: ["^(0[1-9]|1[0-2])$", "Must be 01-12"]
+          - label: "Day"
+            name: "dd"
+            widget: "string"
+            hint: "DD"
+            pattern: ["^(0[1-9]|[12]\\d|3[01])$", "Must be 01-31"]
+          - label: "Year"
+            name: "yyyy"
+            widget: "string"
+            hint: "YYYY"
+            pattern: ["^(\\d{4})$", "Must be valid year"]
+          - label: "Time"
+            name: "time"
+            widget: "string"
+            hint: "The time the event starts, in eastern time (HH:MM)"
+            pattern: ["^(?:2[0-3]|[01][0-9]):[0-5][0-9]$", "Must be HH:MM"]
+      - label: "End Date/Time"
+        name: "cms_end_date"
+        widget: "object"
+        fields:
+          - label: "Month"
+            name: "mm"
+            widget: "string"
+            hint: "MM"
+            pattern: ["^(0[1-9]|1[0-2])$", "Must be 01-12"]
+          - label: "Day"
+            name: "dd"
+            widget: "string"
+            hint: "DD"
+            pattern: ["^(0[1-9]|[12]\\d|3[01])$", "Must be 01-31"]
+          - label: "Year"
+            name: "yyyy"
+            widget: "string"
+            hint: "YYYY"
+            pattern: ["^(\\d{4})$", "Must be valid year"]
+          - label: "Time"
+            name: "time"
+            widget: "string"
+            hint: "The time the event ends, in eastern time (HH:MM)"
+            pattern: ["^(?:2[0-3]|[01][0-9]):[0-5][0-9]$", "Must be HH:MM"]
+      - label: "Primary Image (for social media)"
+        name: "primary_image"
+        widget: "image"
+        required: false
+
+  # IMAGE UPLOAD =======================
+  - name: "image-upload"
+    label: "Image upload"
+    description: "This page will help upload a new image to Digital.gov"
+    folder: "content/images/_inbox"
+    editor:
+      preview: false
+
+    media_folder: "/content/images/_inbox"
+    public_folder: ""
+    identifier_field: image # sets the field that is used to create the slug
+    create: true # Allow users to create new documents in this collection
+
+    fields:
+      - label: "Image"
+        name: "image"
+        widget: "image"
+
+  # IMAGE METADATA =======================
+  - name: "image-metadata"
+    label: "Image metadata"
+    description: "This page will help edit image metadata"
+    folder: "data/images"
+    editor:
+      preview: false
+
+    identifier_field: uid # sets the field that is used to create the slug
+    extension: yml
+    format: yml
+
+    fields:
+      - label: "uid"
+        name: "uid"
+        widget: "hidden"
+      - label: "Credit"
+        name: "credit"
+        widget: "string"
+      - label: "Caption"
+        name: "caption"
+        widget: "string"
+      - label: "Alt"
+        name: "alt"
+        widget: "string"

--- a/themes/digital.gov/static/workflow/index.html
+++ b/themes/digital.gov/static/workflow/index.html
@@ -10,6 +10,9 @@
         margin-left: 75px;
         width: 150px;
       }
+      nav li:last-child {
+        display: none;
+      }
     </style>
   </head>
   <body>
@@ -38,10 +41,37 @@
       CMS.registerEventListener({
         name: "preSave",
         handler: ({ entry }) => {
-          if (!entry.get("slug")) {
-            const slug = slugify(entry.getIn(["data", "display_name"]));
+          switch (entry.get("collection")) {
+            case "authors":
+              if (!entry.get("slug")) {
+                const slug = slugify(entry.getIn(["data", "display_name"]));
 
-            return entry.get("data").set("slug", slug);
+                return entry.get("data").set("slug", slug);
+              }
+              break;
+
+            case "events":
+              const cms_date = entry.getIn(["data", "cms_date"]);
+              const cms_end_date = entry.getIn(["data", "cms_end_date"]);
+              const primary_image =
+                entry.getIn(["data", "primary_image"]) || "";
+
+              const date = `${cms_date.getIn(["yyyy"])}-${cms_date.getIn([
+                "mm"
+              ])}-${cms_date.getIn(["dd"])} ${cms_date.getIn([
+                "time"
+              ])}:00 -0500`;
+              const end_date = `${cms_end_date.getIn([
+                "yyyy"
+              ])}-${cms_end_date.getIn(["mm"])}-${cms_end_date.getIn([
+                "dd"
+              ])} ${cms_end_date.getIn(["time"])}:00 -0500`;
+
+              return entry
+                .get("data")
+                .set("date", date)
+                .set("end_date", end_date)
+                .set("primary_image", primary_image.replace(/\.[^/.]+$/, ""));
           }
         }
       });

--- a/themes/digital.gov/static/workflow/index.html
+++ b/themes/digital.gov/static/workflow/index.html
@@ -10,14 +10,29 @@
         margin-left: 75px;
         width: 150px;
       }
-      nav li:last-child {
+
+      div[class*="LibraryTop"] button[class*="DeleteButton"] {
+        display: none;
+      }
+
+      body:not(.show-upload) label[class*="nc-fileUploadButton"] {
         display: none;
       }
     </style>
   </head>
   <body>
     <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+    <script src="https://unpkg.com/netlify-cms-widget-async-select@1.3.4"></script>
+
     <script>
+      function addSlug(field = "title") {
+        if (!entry.get("slug")) {
+          return entry
+            .get("data")
+            .set("slug", slugify(entry.getIn(["data", field])));
+        }
+      }
+
       function slugify(string) {
         const a =
           "àáâäæãåāăąçćčđďèéêëēėęěğǵḧîïíīįìłḿñńǹňôöòóœøōõőṕŕřßśšşșťțûüùúūǘůűųẃẍÿýžźż·/_,:;";
@@ -38,16 +53,14 @@
           .replace(/-+$/, ""); // Trim - from end of text
       }
 
+      CMS.registerWidget("async-select", window.AsyncSelectControl);
+
       CMS.registerEventListener({
         name: "preSave",
         handler: ({ entry }) => {
           switch (entry.get("collection")) {
             case "authors":
-              if (!entry.get("slug")) {
-                const slug = slugify(entry.getIn(["data", "display_name"]));
-
-                return entry.get("data").set("slug", slug);
-              }
+              addSlug("display_name");
               break;
 
             case "events":
@@ -56,25 +69,43 @@
               const primary_image =
                 entry.getIn(["data", "primary_image"]) || "";
 
-              const date = `${cms_date.getIn(["yyyy"])}-${cms_date.getIn([
-                "mm"
-              ])}-${cms_date.getIn(["dd"])} ${cms_date.getIn([
-                "time"
-              ])}:00 -0500`;
-              const end_date = `${cms_end_date.getIn([
-                "yyyy"
-              ])}-${cms_end_date.getIn(["mm"])}-${cms_end_date.getIn([
-                "dd"
-              ])} ${cms_end_date.getIn(["time"])}:00 -0500`;
-
-              return entry
+              entry
                 .get("data")
-                .set("date", date)
-                .set("end_date", end_date)
+                .set(
+                  "date",
+                  `${cms_date.getIn(["yyyy"])}-${cms_date.getIn([
+                    "mm"
+                  ])}-${cms_date.getIn(["dd"])} ${cms_date.getIn([
+                    "time"
+                  ])}:00 -0500`
+                )
+                .set(
+                  "end_date",
+                  `${cms_end_date.getIn(["yyyy"])}-${cms_end_date.getIn([
+                    "mm"
+                  ])}-${cms_end_date.getIn(["dd"])} ${cms_end_date.getIn([
+                    "time"
+                  ])}:00 -0500`
+                )
                 .set("primary_image", primary_image.replace(/\.[^/.]+$/, ""));
+
+              addSlug();
+              break;
+
+            case "sources":
+              addSlug("name");
+              break;
           }
         }
       });
+
+      window.addEventListener("hashchange", function(e) {
+        var body = document.querySelector("body");
+        window.location.hash.indexOf("#/collections/image-upload/new") > -1
+          ? body.classList.add("show-upload")
+          : body.classList.remove("show-upload");
+      });
+      window.dispatchEvent(new HashChangeEvent("hashchange"));
     </script>
   </body>
 </html>


### PR DESCRIPTION
This PR implements the following **changes:**

Newly added collections to Netlify CMS
- Events
- Image uploads
- Image metadata
- Sources
- Topics

Using the Image Upload collection allows images to be uploaded and processed using the CI script. In order to avoid confusion, I've also added some CSS to hide the Upload option provided by the CMS media library because using that would not place new images in the correct `_inbox` folder which would cause images not to be processed properly.

I'm also dynamically loading the topics from the Digital.gov API in order to avoid an issue with the slug value being converted into a path: https://github.com/netlify/netlify-cms/issues/4092 - because of this there will likely be CORS issues hitting that API on the Federalist preview link - so this may need to be merged to `main` in order to fully test it.