### PR TITLE
Update 2020-06-16-building-for-21st-century-web-with.md

### DIFF
--- a/content/events/2020/06/2020-06-16-building-for-21st-century-web-with.md
+++ b/content/events/2020/06/2020-06-16-building-for-21st-century-web-with.md
@@ -53,9 +53,9 @@ David Corwin is a polyglot software engineer with 15 years of experience in vari
  - [https://designsystem.digital.gov/](https://designsystem.digital.gov/)
  - [https://search.gov/](https://search.gov/)
  - https://digital.gov/guides/dap/
- - [https://jamstack.org/](https://jamstack.org/
- - [https://www.netlifycms.org/](https://www.netlifycms.org/
- - [https://jekyllrb.com/](https://jekyllrb.com/
+ - [https://jamstack.org/](https://jamstack.org/)
+ - [https://www.netlifycms.org/](https://www.netlifycms.org/)
+ - [https://jekyllrb.com/](https://jekyllrb.com/)
  - [https://github.com/gohugoio/hugo](https://github.com/gohugoio/hugo)
  - https://www.gatsbyjs.org/
  


### PR DESCRIPTION
This PR implements the following **changes:**

Three links at end (under Related Links) were missing closing parenthesis, and so did not render correctly.

https://digital.gov/event/2020/06/16/building-for-21st-century-web-with/
