### PR TITLE
Update 2020-07-23-dap-learning-series-lessons-from-canadaca.md

### DIFF
--- a/content/events/2020/07/2020-07-23-dap-learning-series-lessons-from-canadaca.md
+++ b/content/events/2020/07/2020-07-23-dap-learning-series-lessons-from-canadaca.md
@@ -35,7 +35,7 @@ authors:
 event_platform:
 
 # YouTube ID
-youtube_id:
+youtube_id: 3tdj8SktL1Y
 
 # Make it better ♥
 
@@ -45,7 +45,7 @@ It’s always nice to hear from friends in the government analytics world. Join 
 
 ## About the speakers
 
-:canada: **Nicolas Pjontek** is the Manager of the [Canada.ca](https://www.canada.ca/) Analytics team at Service Canada (Government of Canada).  
+:canada: **Nicolas Pjontek** is the Manager of the [Canada.ca](https://www.canada.ca/) Analytics team at Service Canada (Government of Canada).
 
 :us: **Tim Lowden** manages the federal government's aggregated web analytics initiative, the [Digital Analytics Program]({{< ref "/guides/dap/_index.md" >}}) (DAP), at the General Services Administration (GSA).
 


### PR DESCRIPTION
add yt id

This PR implements the following **changes:**

* youtube id added

Preview: 
https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/dap-canada-gov/event/2020/07/23/dap-learning-series-lessons-from-canadaca/ 