### PR TITLE
Add seconds to Netlify CMS date field so it can be parsed properly

### DIFF
--- a/themes/digital.gov/static/workflow/index.html
+++ b/themes/digital.gov/static/workflow/index.html
@@ -28,7 +28,7 @@
       function formatDate(date) {
         return `${date.getIn(["yyyy"])}-${date.getIn(["mm"])}-${date.getIn([
           "dd"
-        ])} ${date.getIn(["time"]) ? date.getIn(["time"]) : "12"}:00 -0500`;
+        ])} ${date.getIn(["time"]) ? date.getIn(["time"]) : "12"}:00:00 -0500`;
       }
 
       function slugify(string) {


### PR DESCRIPTION
This PR implements the following **changes:**

Fixes issue with Hugo not being able to parse date and therefore not showing new blog posts.
