### PR TITLE
Fix typo on RPA guide

### DIFF
--- a/content/guides/rpa/_index.md
+++ b/content/guides/rpa/_index.md
@@ -8,7 +8,7 @@ aliases:
 
 ---
 {{< box >}}
-**Interested in joining the RPA communtity?** Click here to [learn more](https://digital.gov/communities/rpa/).
+**Interested in joining the RPA community?** Click here to [learn more](https://digital.gov/communities/rpa/).
 {{< /box >}}
 {{< guide-toc >}}
 ## What is RPA


### PR DESCRIPTION
This PR implements the following **changes:**

* fixes misspelling of the word `community` in the RPA guide


**URL / Link to page**
https://digital.gov/guides/rpa/
<!-- Link to the page that will be changed -->
<!-- Delete this section if not needed -->

