### PR TITLE
updating the 2020 UX Summit page

### DIFF
--- a/content/events/2020/07/2020-07-28-2020-government-ux-summit.md
+++ b/content/events/2020/07/2020-07-28-2020-government-ux-summit.md
@@ -59,43 +59,55 @@ weight: 0
 
 ---
 
-{{< img src="2020-ux-summit" >}}
-
-***When registering, please select the individual sessions that you'd like to attend. You will need to register individually to receive the proper Zoom links.***
-
-Join our three-day virtual summit, **July 28 to July 30**, and gain insights on UX Methods, Service Design, and Managing UX. It’s a great opportunity to learn about UX from our federal, state, and local government UX colleagues. 
-
 {{< accordion kicker="Day 1" title="UX Methods - July 28" icon="fas fa-copy" >}}
 
- **First Session – 10-minute presentations 11:30 AM – 12:30 PM ET**
+- [Read the transcript](https://digital.gov/pdf/2020-07-28-UX-Summit-Captioning-Tues-AM.pdf ) (PDF, 125 KB, 13 pages)
 
- - **Becoming a UX Houdini: Finding Opportunities in the Face of Constrictions** - *John Pull, Library of Congress*
+## First Session – 10-minute presentations 11:30 AM – 12:30 PM ET
+
+ **Becoming a UX Houdini: Finding Opportunities in the Face of Constrictions** - John Pull, Library of Congress
 
 The Library of Congress’s Harry Houdini Collection provides insights and inspiration for UX professionals who feel chained down by the regulations, legacy systems, and PR challenges of government projects.
 
- - **UX Research via Dot-Voting** - *Angela Smithers and Maya Rhodan, National Museum of African American History and Culture*
+- [Watch the video](https://www.youtube.com/watch?v=JJbCQCYsLGU&t=182s)
+
+ **UX Research via Dot-Voting** - Angela Smithers, National Museum of African American History and Culture
 
 A presentation on adapting the [discover method](https://methods.18f.gov/discover/dot-voting/) from 18F to perform quick user testing and get quantifiable results that stakeholders can comprehend.
 
- - **Development of a Standardized Formula to Calculate Severity Scores in Multitask Usability Testing** - *Anthony J. Schulzetenberg, U.S. Census Bureau*
+- [Watch the video](https://www.youtube.com/watch?v=JJbCQCYsLGU&t=1083s)
+
+ **Development of a Standardized Formula to Calculate Severity Scores in Multitask Usability Testing** - Anthony J. Schulzetenberg, U.S. Census Bureau
 
 Severity scores are often used in usability research to provide stakeholders a measure of urgency for the usability problems that were identified during testing. However, the methods used to develop these scores often lack rigor or applicability to multitask usability research. Because government UX research often involves testing multiple tasks, we propose an intuitive method to calculate severity scores for each usability problem that takes into account both the effectiveness and efficiency of the user, weighting effectiveness-related problems more heavily. We then can calculate an overall severity score and see each problem’s relative strain on the system’s total usability.
+   
+- [Watch the video](https://www.youtube.com/watch?v=JJbCQCYsLGU&t=2021s)
 
- - **Solving the Lost Sock Problem: A Useful Method to Track Standards and UX Requirements in an Agile Software Development Process** - *Margo Kabel, Veterans Health Administration*
+ **Solving the Lost Sock Problem: A Useful Method to Track Standards and UX Requirements in an Agile Software Development Process** - Margo Kabel, Veterans Health Administration
 
 This presentation proposes a useful method to track standards and UX requirements in an agile software development process. This presentation is also a case study of medication information standards implementation at the Veterans Health Administration.
+    
+- [Watch the video](https://www.youtube.com/watch?v=JJbCQCYsLGU&t=2752s) 
 
-**Second Session 1:30 – 2:30 PM ET**
+## Second Session 1:30 – 2:30 PM ET
 
- - **Ohana for Digital Service Design (or Baking Accessibility into your Digital Product Lifecycle)** - *Jennifer Strickland and Kendra Skeene, Ad Hoc (VA Modernization)*
+ **Ohana for Digital Service Design (or Baking Accessibility into your Digital Product Lifecycle)** - Jennifer Strickland and Kendra Skeene, Ad Hoc (VA Modernization)
 
-Designing and developing digital products that are accessible to all doesn’t just make good business sense — it’s also the law. Yet it’s often an overlooked part of the product development lifecycle. The best and most cost-effective way to ensure your product is accessible is to start with accessibility. In this session, participants will learn how to incorporate accessibility and inclusive design at each stage of the product lifecycle. From product requirements through user research, content strategy and copywriting, design, front-end development, and QA, consider accessibility using these effective guidelines. {{< /accordion >}}
+Designing and developing digital products that are accessible to all doesn’t just make good business sense — it’s also the law. Yet it’s often an overlooked part of the product development lifecycle. The best and most cost-effective way to ensure your product is accessible is to start with accessibility. In this session, participants will learn how to incorporate accessibility and inclusive design at each stage of the product lifecycle. From product requirements through user research, content strategy and copywriting, design, front-end development, and QA, consider accessibility using these effective guidelines. 
+   
+- [Watch the video](https://www.youtube.com/watch?v=ZFdLZlAD5q0)
+- [Read the transcript](https://digital.gov/pdf/2020-07-28-UX-Summit-Captioning-Tues-PM.pdf) (PDF, 119 KB, 13 pages) 
+
+{{< /accordion >}}
+
+
+---
 
 {{< accordion kicker="Day 2" title="Service Design - July 29" icon="fas fa-copy" >}}
 
- **First Session –  11:30 AM – 12:30 PM ET**
+## First Session –  11:30 AM – 12:30 PM ET
 
- - **Service Design Versus Product Design – What is it and when do we use it?** - *Caroline Kyungae Smith and Katherine Nammacher, US Digital Service*
+ **Service Design Versus Product Design – What is it and when do we use it?** - Caroline Kyungae Smith and Katherine Nammacher, US Digital Service*
 
 It’s common to think of design in terms of tangible objects, like a chair, or in terms of digital products, like an app. This design discipline, known as Product Design, focuses on identifying customer requirements in order to achieve manufacturability.
 
@@ -105,33 +117,48 @@ That’s where Service Design comes in.
 
 Learn about the similarities and differences between Product Design and Service Design, how they co-exist, and more importantly, when to use them!
 
-**Second Session 1:30 – 2:30 PM ET**
+- [Watch the video](https://www.youtube.com/watch?v=Ff8VCuKxNd0&t=186s)
+- [Read the transcript](https://digital.gov/pdf/2020-07-29-UX-Summit-Captioning-Wed-AM.pdf) (PDF, 130 KB, 13 pages)
 
- - **More, Better, Faster: How Service Design Helps the Austin.gov Team Transition Content at Scale** - *Sarah Rigdon, Jo Dwyer, Andrew Do, and Kristin Taylor, Office of Design and Delivery at the City of Austin*
+## Second Session 1:30 – 2:30 PM ET
 
-For residents, forms are often front doors to access city services. They are also critical entry points not just to redesign content, but to transform the end-to-end experience of city services that better serve residents. This talk will discuss lessons learned from the City of Austin’s experiments in how service designers collaborate with content strategists to achieve this goal. We will focus on two case studies that offer different insights on how service designers and content strategists can collaborate. {{< /accordion >}}
+**More, Better, Faster: How Service Design Helps the Austin.gov Team Transition Content at Scale** - Sarah Rigdon, Jo Dwyer, Andrew Do, and Kristin Taylor, Office of Design and Delivery at the City of Austin
 
-{{< accordion kicker="Day 3" title="Managing UX - July 30" icon="fas fa-copy" >}}
+For residents, forms are often front doors to access city services. They are also critical entry points not just to redesign content, but to transform the end-to-end experience of city services that better serve residents. This talk will discuss lessons learned from the City of Austin’s experiments in how service designers collaborate with content strategists to achieve this goal. We will focus on two case studies that offer different insights on how service designers and content strategists can collaborate. 
 
- **First Session –  11:30 AM – 12:30 PM ET**
+- [Watch the video](https://www.youtube.com/watch?v=Afb4fIaCN48&t=223s)
+- [Read the transcript](https://digital.gov/pdf/2020-07-29-UX-Summit-Captioning-Wed-PM.pdf) (PDF, 137 KB, 13 pages) 
 
- - **Softening the Landing: Leading Your Customers through Change** - *Christy Hermansen, U.S. General Services Administration (GSA)*
+{{< /accordion >}}
 
-Modernization means change—and change can sometimes be hard. When creating new user experiences, it’s also important to understand and design how people will transition to an experience that is different from what they know. This case study features lessons learned from an on-going, multi-phase federal modernization impacting millions of federal and non-federal users. You will see our dramatically different old and new users’ experiences, and walk step-by-step through different approaches we are using to soften the landing for our customers.
-
-**Second Session 1:30 – 2:30 PM ET**
-
- - **Discovering #PartofSomethingBigger for HHS Careers Website** - *Brooke Dine HHS/Assistant Secretary for Public Affairs (ASPA), and Katie Kline*
-
-A comprehensive, empirical discovery process sets the stage for a streamlined roadmap and agile project approach. Drawing on discovery insights for a new Careers site for HHS.gov, the speakers will recount quantifiable tactics that led to an evidence-based decision matrix which guided the design, development, content and communications efforts for the project. Participants will hear use cases for activities that can be used to ensure any pivoting supports the overarching digital strategy. Additionally, regular check-ins with stakeholders will run smoothly when the vision for the site is captured in the beginning with benchmarks for success clearly identified. {{< /accordion >}}
 
 ---
 
-**Related Links:**
+{{< accordion kicker="Day 3" title="Managing UX - July 30" icon="fas fa-copy" >}}
 
- - [Government UX Summit 2019](https://digital.gov/event/2019/05/15/2019-government-ux-summit/)
- 
- ---
+## First Session –  11:30 AM – 12:30 PM ET
+
+**Softening the Landing: Leading Your Customers through Change** - Christy Hermansen, U.S. General Services Administration (GSA)
+
+Modernization means change—and change can sometimes be hard. When creating new user experiences, it’s also important to understand and design how people will transition to an experience that is different from what they know. This case study features lessons learned from an on-going, multi-phase federal modernization impacting millions of federal and non-federal users. You will see our dramatically different old and new users’ experiences, and walk step-by-step through different approaches we are using to soften the landing for our customers.
+
+- [Watch the video](https://www.youtube.com/watch?v=UVWKQHs0YqA&t=193s)
+- [Read the transcript](https://digital.gov/pdf/2020-07-30-UX-Summit-Captioning-Thurs-AM.pdf) (PDF, 139 KB, 10 pages) 
+
+## Second Session 1:30 – 2:30 PM ET
+
+**Discovering #PartofSomethingBigger for HHS Careers Website** - Brooke Dine HHS/Assistant Secretary for Public Affairs (ASPA), and Katie Kline
+
+A comprehensive, empirical discovery process sets the stage for a streamlined roadmap and agile project approach. Drawing on discovery insights for a new Careers site for HHS.gov, the speakers will recount quantifiable tactics that led to an evidence-based decision matrix which guided the design, development, content and communications efforts for the project. Participants will hear use cases for activities that can be used to ensure any pivoting supports the overarching digital strategy. Additionally, regular check-ins with stakeholders will run smoothly when the vision for the site is captured in the beginning with benchmarks for success clearly identified. 
+
+- [Watch the video](https://www.youtube.com/watch?v=oFu2AeThfx4&t=200s)
+- [Read the transcript](https://digital.gov/pdf/2020-07-30-UX-Summit-Captioning-Thurs-PM.pdf) (PDF, 163 KB, 12 pages) 
+
+{{< /accordion >}}
+
+
+---
+
 
 *The 2020 Government UX Summit is sponsored by the [User Experience Community of Practice](https://digital.gov/communities/user-experience/) (UX CoP) and DigitalGov.*
 


### PR DESCRIPTION
adding ux summit transcripts and youtube links to page

This PR implements the following **changes:**

* adding transcripts for all 2020 UX summit sessions
* adding video links for all 2020 UX Summit sessions


**URL / Link to page**

see issue for page content: https://github.com/GSA/digitalgov.gov/issues/3137

