### PR TITLE
Fix caption link title

### DIFF
--- a/themes/digital.gov/layouts/events/stage-adobe_connect.html
+++ b/themes/digital.gov/layouts/events/stage-adobe_connect.html
@@ -8,7 +8,7 @@
     <p><strong>This event will be held over Adobe Connect.</strong> A link to join this event will be sent via email to those who register. Before the meeting, <a href="https://helpx.adobe.com/adobe-connect/connect-downloads-updates.html" title="Download and install Adobe Connect">download and install Adobe Connect</a> and ensure that your computer and network connections are configured by <a href="https://helpx.adobe.com/adobe-connect/using/connection-test-connect-meeting.html">running a test</a>.</p>
 
     {{- if .Params.captions -}}
-    <p><a class="captions" href="{{- .Params.captions -}}" title="Captions for the {{- .Title -}}"><strong><i class="far fa-closed-captioning"></i> <span>View captions</span></strong></a></p>
+    <p><a class="captions" href="{{- .Params.captions -}}" title="Captions for the {{ .Title -}}"><strong><i class="far fa-closed-captioning"></i> <span>View captions</span></strong></a></p>
     {{- end -}}
 
   </div>

--- a/themes/digital.gov/layouts/events/stage-google.html
+++ b/themes/digital.gov/layouts/events/stage-google.html
@@ -8,7 +8,7 @@
     <p><strong>This event will be held over Google Meet.</strong> A link to join this event will be sent via email to those who register. <a href="https://support.google.com/meet/answer/9303069" title="Learn more about joining a video meeting over Google Meet">Learn more about joining a video meeting over Google Meet</a>.</p>
 
     {{- if .Params.captions -}}
-    <p><a class="captions" href="{{- .Params.captions -}}" title="Captions for the {{- .Title -}}"><strong><i class="far fa-closed-captioning"></i> <span>View captions</span></strong></a></p>
+    <p><a class="captions" href="{{- .Params.captions -}}" title="Captions for the {{ .Title -}}"><strong><i class="far fa-closed-captioning"></i> <span>View captions</span></strong></a></p>
     {{- end -}}
 
   </div>

--- a/themes/digital.gov/layouts/events/stage-zoom.html
+++ b/themes/digital.gov/layouts/events/stage-zoom.html
@@ -9,7 +9,7 @@
     </p>
 
     {{- if .Params.captions -}}
-    <p><a class="captions" href="{{- .Params.captions -}}" title="Captions for the {{- .Title -}}"><strong><i class="far fa-closed-captioning"></i> <span>View captions</span></strong></a></p>
+    <p><a class="captions" href="{{- .Params.captions -}}" title="Captions for the {{ .Title -}}"><strong><i class="far fa-closed-captioning"></i> <span>View captions</span></strong></a></p>
     {{- end -}}
 
   </div>


### PR DESCRIPTION
This PR implements the following **changes:**

* Fix issue with title text on Event caption links

After:
<img width="853" alt="Screen Shot 2020-09-01 at 2 16 03 PM" src="https://user-images.githubusercontent.com/2197515/91890947-36482480-ec5e-11ea-8353-690065d6bca6.png">

Note:
In this code:`title="Captions for the {{- .Title -}}"`, the`-` will remove white space preceding or following the element. Which is why the space between the templated text and the event title was being stripped out.

Closes: #3194 
