### PR TITLE
Update 2020-10-08-federal-source-code-summit-building-coding.md

### DIFF
--- a/content/events/2020/10/2020-10-08-federal-source-code-summit-building-coding.md
+++ b/content/events/2020/10/2020-10-08-federal-source-code-summit-building-coding.md
@@ -63,7 +63,7 @@ This summit includes success stories in the U.S. and abroad with source code and
 
 **9:00 - 9:15am** Welcome kick-off
 
-**9:15 - 9:35am** Summit Keynote by *Ron Bewtra*, Chief Technology Officer, Department of Justice
+**9:15 - 9:35am** Summit Keynote
 
 **9:45 - 10:15am** Fireside Chat with International Governments  
 


### PR DESCRIPTION
This PR implements the following **changes:**

*Removed the keynote speaker name.

**URL / Link to page**

https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/removing-keynote-speaker-name/event/2020/10/08/federal-source-code-summit-building-coding/

