### PR TITLE
Replace workflow link with GitHub

### DIFF
--- a/themes/digital.gov/layouts/404.html
+++ b/themes/digital.gov/layouts/404.html
@@ -3,7 +3,7 @@
 <main role="main" id="main-content">
   <article>
     <header>
-      <div class="grid-container grid-container-desktop" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+      <div class="grid-container grid-container-desktop" data-edit-this="{{- .Path -}}">
         <div class="grid-row">
           <div class="grid-col-12">
 
@@ -20,7 +20,7 @@
     </header>
 
     <section>
-      <div class="grid-container grid-container-desktop" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+      <div class="grid-container grid-container-desktop" data-edit-this="{{- .Path -}}">
         <div class="grid-row tablet-lg:grid-gap-6">
 
           <div class="grid-col-12 tablet:grid-col-9">

--- a/themes/digital.gov/layouts/_default/images.html
+++ b/themes/digital.gov/layouts/_default/images.html
@@ -5,7 +5,7 @@
     <header>
       <div class="grid-container grid-container-desktop">
         <div class="grid-row">
-          <div class="grid-col-12" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+          <div class="grid-col-12" data-edit-this="{{- .Path -}}">
             <p class="breadcrumb"><a href="{{- "/" | absURL -}}"> <i class="fas fa-arrow-left"></i> <span>Home</span> </a></p>
             {{- if .Params.kicker -}}
             <p class="kicker">{{- .Params.kicker -}}</p>
@@ -26,7 +26,7 @@
       <div class="grid-container grid-container-desktop">
         <div class="grid-row">
 
-          <div class="grid-col-12" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+          <div class="grid-col-12" data-edit-this="{{- .Path -}}">
 
             {{/* Content */}}
             <div class="content">

--- a/themes/digital.gov/layouts/_default/single.html
+++ b/themes/digital.gov/layouts/_default/single.html
@@ -3,7 +3,7 @@
 <main role="main" id="main-content">
   <article>
     <header>
-      <div class="grid-container grid-container-desktop" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+      <div class="grid-container grid-container-desktop" data-edit-this="{{- .Path -}}">
         <div class="grid-row">
           <div class="grid-col-12">
 
@@ -29,7 +29,7 @@
     </header>
 
     <section>
-      <div class="grid-container grid-container-desktop" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+      <div class="grid-container grid-container-desktop" data-edit-this="{{- .Path -}}">
         <div class="grid-row tablet-lg:grid-gap-6">
 
           <div class="grid-col-12 tablet:grid-col-9">

--- a/themes/digital.gov/layouts/authors/list.html
+++ b/themes/digital.gov/layouts/authors/list.html
@@ -4,7 +4,7 @@
   <section class="author-profile">
     <div class="grid-container grid-container-desktop">
       <div class="grid-row tablet-lg:grid-gap-6">
-        <div class="grid-col-12" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+        <div class="grid-col-12" data-edit-this="{{- .Path -}}">
           <header>
 
             {{- if .Params.github -}}

--- a/themes/digital.gov/layouts/authors/terms.html
+++ b/themes/digital.gov/layouts/authors/terms.html
@@ -26,7 +26,7 @@
               {{- range $i, $author := $authors -}}
                 {{ if .Params.slug }}
                   {{ $link := printf "authors/%s/" .Params.slug }}
-                  <div class="author grid-row" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+                  <div class="author grid-row" data-edit-this="{{- .Path -}}">
                     <div class="grid-col-auto">
                       <div class="photo">
                         {{- if $author.Params.github -}}

--- a/themes/digital.gov/layouts/communities/list.html
+++ b/themes/digital.gov/layouts/communities/list.html
@@ -36,7 +36,7 @@
         {{ range $i, $e := $communities }}
           <div class="grid-col-12 tablet:grid-col-6">
 
-            <article class="promo promo-card" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+            <article class="promo promo-card" data-edit-this="{{- .Path -}}">
               <div class="grid-row tablet-lg:grid-gap-4">
                 <div class="grid-col-12">
                   <h4><a href="{{- $e.Permalink -}}" title="{{- $e.Title | markdownify -}}">{{- $e.Title | markdownify -}}</a></h4>

--- a/themes/digital.gov/layouts/communities/single.html
+++ b/themes/digital.gov/layouts/communities/single.html
@@ -6,7 +6,7 @@
     <header>
       <div class="grid-container grid-container-desktop">
         <div class="grid-row">
-          <div class="grid-col-12" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+          <div class="grid-col-12" data-edit-this="{{- .Path -}}">
 
             <p class="breadcrumb"><a href="{{ .Parent.Permalink }}" title="{{ .Parent.Title }}"><i class="fas fa-arrow-left"></i> <span>{{ .Parent.Title }}</span></a></p>
             {{/* Page Title */}}

--- a/themes/digital.gov/layouts/events/card-event-past.html
+++ b/themes/digital.gov/layouts/events/card-event-past.html
@@ -1,4 +1,4 @@
-<div class="card card-event card-event-past card-linked" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
+<div class="card card-event card-event-past card-linked" data-edit-this="{{- .Path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
   <div class="grid-row tablet:grid-gap-4">
 
     {{- if .Params.youtube_id -}}

--- a/themes/digital.gov/layouts/events/card-event.html
+++ b/themes/digital.gov/layouts/events/card-event.html
@@ -1,4 +1,4 @@
-<div class="card card-event-promo card-linked" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
+<div class="card card-event-promo card-linked" data-edit-this="{{- .Path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
 
   <div class="grid-row tablet:grid-gap-4">
 

--- a/themes/digital.gov/layouts/events/list.html
+++ b/themes/digital.gov/layouts/events/list.html
@@ -4,7 +4,7 @@
   <header class="page-head page-head-{{- .Type -}}">
     <div class="grid-container grid-container-desktop">
       <div class="grid-row">
-        <div class="grid-col-12" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+        <div class="grid-col-12" data-edit-this="{{- .Path -}}">
 
           {{/* Page Title */}}
           <h1>{{- .Title | markdownify -}} </h1>

--- a/themes/digital.gov/layouts/events/single.html
+++ b/themes/digital.gov/layouts/events/single.html
@@ -16,7 +16,7 @@
     <header>
       <div class="grid-container grid-container-desktop">
         <div class="grid-row">
-          <div class="grid-col-12" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+          <div class="grid-col-12" data-edit-this="{{- .Path -}}">
             <p class="breadcrumb"><a href="{{- "events/" | absURL -}}"> <i class="fas fa-arrow-left"></i> <span>All Events</span> </a></p>
             {{- if .Params.kicker -}}
             <p class="kicker">{{- .Params.kicker -}}</p>
@@ -107,7 +107,7 @@
 
 
     <section>
-      <div class="grid-container grid-container-desktop" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+      <div class="grid-container grid-container-desktop" data-edit-this="{{- .Path -}}">
         <div class="grid-row tablet-lg:grid-gap-4">
           <div class="grid-col-12 tablet:grid-col-9">
 

--- a/themes/digital.gov/layouts/events/training-card.html
+++ b/themes/digital.gov/layouts/events/training-card.html
@@ -1,4 +1,4 @@
-<article class="event card promo" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+<article class="event card promo" data-edit-this="{{- .Path -}}">
   <div class="grid-row tablet-lg:grid-gap-2">
     <div class="grid-col-12 tablet:grid-col-4">
       <div class="youtube-card" data-id="{{ .Params.youtube_id }}" data-link="{{ .Permalink }}"></div>

--- a/themes/digital.gov/layouts/guides/single.html
+++ b/themes/digital.gov/layouts/guides/single.html
@@ -9,12 +9,12 @@
     <div class="grid-container grid-container-widescreen">
       <div class="grid-row grid-gap-4">
 
-        <div class="grid-col-12 tablet-lg:grid-col-2" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+        <div class="grid-col-12 tablet-lg:grid-col-2" data-edit-this="{{- .Path -}}">
           {{- partial "core/guides/guide-nav" . -}}
         </div>
 
         <div class="grid-col-12 tablet-lg:grid-col-8">
-          <div class="guide-content usa-layout-docs__main usa-prose" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+          <div class="guide-content usa-layout-docs__main usa-prose" data-edit-this="{{- .Path -}}">
 
             {{- partial "core/guides/guide-page-head" . -}}
 

--- a/themes/digital.gov/layouts/news/card-article.html
+++ b/themes/digital.gov/layouts/news/card-article.html
@@ -1,4 +1,4 @@
-<div class="card card-article card-linked" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
+<div class="card card-article card-linked" data-edit-this="{{- .Path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
   <div class="grid-row tablet:grid-gap-4">
     <div class="grid-col-12 tablet:grid-col-4 tablet:order-2">
       {{- partial "core/img-featured" . -}}

--- a/themes/digital.gov/layouts/news/card-elsewhere.html
+++ b/themes/digital.gov/layouts/news/card-elsewhere.html
@@ -1,4 +1,4 @@
-<div class="card card-elsewhere card-linked" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
+<div class="card card-elsewhere card-linked" data-edit-this="{{- .Path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
   <div>
     <div class="icon">
       {{/* Favicon

--- a/themes/digital.gov/layouts/news/list.html
+++ b/themes/digital.gov/layouts/news/list.html
@@ -4,7 +4,7 @@
 
   <div class="grid-container grid-container-desktop">
     <div class="grid-row">
-      <div class="grid-col-12" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+      <div class="grid-col-12" data-edit-this="{{- .Path -}}">
         <header class="page-head page-head-{{- .Type -}}">
 
           {{/* Page Title */}}

--- a/themes/digital.gov/layouts/news/single.html
+++ b/themes/digital.gov/layouts/news/single.html
@@ -3,7 +3,7 @@
 <main role="main" id="main-content">
   <article {{ if .Params.short_url -}}data-short_url="{{- .Params.short_url -}}"{{- end -}}>
     <header>
-      <div class="grid-container grid-container-desktop" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+      <div class="grid-container grid-container-desktop" data-edit-this="{{- .Path -}}">
         <div class="grid-row">
           <div class="grid-col-12">
             <p class="breadcrumb"><a href="{{- "news" | absURL -}}"> <i class="fas fa-arrow-left"></i> <span>Latest News</span> </a></p>
@@ -33,7 +33,7 @@
     </header>
 
     <section>
-      <div class="grid-container grid-container-desktop" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+      <div class="grid-container grid-container-desktop" data-edit-this="{{- .Path -}}">
         <div class="grid-row tablet-lg:grid-gap-6">
 
           <div class="grid-col-12 tablet-lg:grid-col-9 tablet-lg:order-last">

--- a/themes/digital.gov/layouts/partials/core/collection.html
+++ b/themes/digital.gov/layouts/partials/core/collection.html
@@ -65,7 +65,7 @@
   {{- $href := .href -}}
   {{- $src := .src -}}
   {{- with .item -}}
-  <li data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+  <li data-edit-this="{{- .Path -}}">
 
     {{- template "collection-icon" dict "item" . "src" $src "href" $href -}}
 

--- a/themes/digital.gov/layouts/partials/core/get_related.html
+++ b/themes/digital.gov/layouts/partials/core/get_related.html
@@ -106,7 +106,7 @@
   {{- $href := .href -}}
   {{- $src := .src -}}
   {{- with .item -}}
-    <div class="promo" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+    <div class="promo" data-edit-this="{{- .Path -}}">
       <div>
         <h4>
           <a class="external-link" href="{{- .Params.source_url -}}?=dg" title="{{ .Title | markdownify -}}"><span>{{- .Title | markdownify -}}</span></a>

--- a/themes/digital.gov/layouts/partials/core/home/topics_featured.html
+++ b/themes/digital.gov/layouts/partials/core/home/topics_featured.html
@@ -13,7 +13,7 @@
           {{- if eq .Params.weight 3 -}}
 
             <div class="grid-col-6 tablet:grid-col-4 ">
-              <div class="topic" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+              <div class="topic" data-edit-this="{{- .Path -}}">
                 <h3>
                   <a href="{{- .Permalink | absURL -}}" title="{{- .Title -}}">{{- .Title -}} <span>&#8594;</span></a>
                 </h3>

--- a/themes/digital.gov/layouts/resources/list.html
+++ b/themes/digital.gov/layouts/resources/list.html
@@ -5,7 +5,7 @@
     <header class="page-head page-head-{{- .Type -}}">
       <div class="grid-container grid-container-desktop">
         <div class="grid-row">
-          <div class="grid-col-12" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+          <div class="grid-col-12" data-edit-this="{{- .Path -}}">
 
             {{/* Page Title */}}
             <h1>{{- .Title | markdownify -}} </h1>
@@ -156,7 +156,7 @@
             {{- with $.Site.GetPage (printf "/topics/%s" $name) -}}
               {{- if or (eq .Params.weight 2) (eq .Params.weight 3) -}}
                 <div class="grid-col-12 tablet:grid-col-4">
-                  <div class="topic" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+                  <div class="topic" data-edit-this="{{- .Path -}}">
                     <h3>
                       <a href="{{- .Permalink | absURL -}}" title="{{- .Title -}}">{{- .Title -}} <span>&#8594;</span></a>
                     </h3>

--- a/themes/digital.gov/layouts/resources/single.html
+++ b/themes/digital.gov/layouts/resources/single.html
@@ -5,7 +5,7 @@
     <header>
       <div class="grid-container grid-container-desktop">
         <div class="grid-row">
-          <div class="grid-col-12" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+          <div class="grid-col-12" data-edit-this="{{- .Path -}}">
             <p class="breadcrumb"><a href="{{- "resources/" | absURL -}}"> <i class="fas fa-arrow-left"></i> <span>All Resources</span> </a></p>
             {{- if .Params.kicker -}}
             <p class="kicker">{{- .Params.kicker -}}</p>
@@ -26,7 +26,7 @@
       <div class="grid-container grid-container-desktop">
         <div class="grid-row tablet-lg:grid-gap-6">
 
-          <div class="grid-col-12 tablet:grid-col-9" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+          <div class="grid-col-12 tablet:grid-col-9" data-edit-this="{{- .Path -}}">
 
             {{/* Content */}}
             <div class="content usa-prose">

--- a/themes/digital.gov/layouts/services/card-service-contact.html
+++ b/themes/digital.gov/layouts/services/card-service-contact.html
@@ -57,7 +57,7 @@
   {{- $href := .href -}}
   {{- $src := .src -}}
   {{- with .item -}}
-  <div class="card card-service-contact" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+  <div class="card card-service-contact" data-edit-this="{{- .Path -}}">
 
     <div class="grid-row grid-gap-2">
       <div class="grid-col-12 tablet:grid-col-3">

--- a/themes/digital.gov/layouts/services/card-service.html
+++ b/themes/digital.gov/layouts/services/card-service.html
@@ -1,4 +1,4 @@
-<div class="card-service" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+<div class="card-service" data-edit-this="{{- .Path -}}">
 
   {{/* set the href as a variable */}}
   {{- $href := "" -}}

--- a/themes/digital.gov/layouts/services/directory.html
+++ b/themes/digital.gov/layouts/services/directory.html
@@ -5,7 +5,7 @@
   <div class="grid-container grid-container-desktop">
     <div class="grid-row tablet-lg:grid-gap-4">
       <div class="grid-col-12">
-        <header class="page-head page-head-{{- .Type -}}" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+        <header class="page-head page-head-{{- .Type -}}" data-edit-this="{{- .Path -}}">
 
           {{/* Page Title */}}
           <h1>{{- .Title | markdownify -}} </h1>

--- a/themes/digital.gov/layouts/topics/list.html
+++ b/themes/digital.gov/layouts/topics/list.html
@@ -5,7 +5,7 @@
 
 <main role="main" id="main-content" class="main-topic">
   <div class="grid-container grid-container-desktop">
-    <div class="grid-row tablet-lg:grid-gap-4" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+    <div class="grid-row tablet-lg:grid-gap-4" data-edit-this="{{- .Path -}}">
       <div class="grid-col-12">
         <header class="page-header">
           <p class="breadcrumb"><a href="{{- "resources/" | absURL -}}"> <i class="fas fa-arrow-left"></i> <span>All Resources</span> </a></p>

--- a/themes/digital.gov/layouts/topics/terms.html
+++ b/themes/digital.gov/layouts/topics/terms.html
@@ -24,7 +24,7 @@
           {{- with $.Site.GetPage (printf "/topics/%s" $name) -}}
             {{- if eq .Params.weight 2 -}}
               <div class="grid-col-12 tablet:grid-col-4">
-                <div class="topic" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+                <div class="topic" data-edit-this="{{- .Path -}}">
                   <h3>
                     <a href="{{- .Permalink | absURL -}}" title="{{- .Title -}}">{{- .Title -}} <span>&#8594;</span></a>
                   </h3>
@@ -75,7 +75,7 @@
           {{/*
           Output the topic HTML
           */}}
-          <div class="topic" data-edit-this="/edit/{{- .Type -}}/?page=https://digital.gov{{- (urls.Parse .Permalink).Path -}}">
+          <div class="topic" data-edit-this="{{- .Path -}}">
             <p>
               <a href="{{- .Permalink -}}" title="{{- $name -}}"><span>{{- .Title -}}</span></a> <span class="count">{{- $taxonomy.Count -}}</span>
             </p>

--- a/themes/digital.gov/src/js/common/edit-this.js
+++ b/themes/digital.gov/src/js/common/edit-this.js
@@ -1,9 +1,8 @@
 jQuery(document).ready(function($) {
-
 	function enable_edit_this(){
 		$('*[data-edit-this]').each(function(){
 			var filepath = $(this).data('edit-this');
-			var edit_link = '<a class="edit_this_btn" href="https://workflow.digital.gov'+filepath+'" title="edit this" target="_blank"><span>edit</span></a>';
+			var edit_link = '<a class="edit_this_btn" href="https://github.com/'+git_org+'/'+git_repo+'/edit/'+branch+'/content/'+filepath+'" title="edit this" target="_blank"><span>edit</span></a>';
 			$(this).addClass('edit-this').append(edit_link);
 		});
 	}


### PR DESCRIPTION
This PR implements the following **changes:**

Use direct link to GitHub instead of workflow tool for editing content on site.

