### PR TITLE
Netlify CMS feedback

### DIFF
--- a/themes/digital.gov/layouts/authors/list.json.json
+++ b/themes/digital.gov/layouts/authors/list.json.json
@@ -74,7 +74,7 @@
         "deck" : "{{- .Params.deck | markdownify -}}",
         {{- end -}}
         {{- if (isset .Params "summary") -}}
-        "summary" : "{{- .Params.summary -}}",
+        "summary" : "{{- replace .Params.summary "\n" "\\n" -}}",
         {{- end -}}
         "date" : "{{- .Date.Format "2006-01-02T15:04:05Z07:00" -}}",
         {{- if .Lastmod -}}

--- a/themes/digital.gov/layouts/communities/list.json.json
+++ b/themes/digital.gov/layouts/communities/list.json.json
@@ -43,7 +43,7 @@
       "deck" : "{{- .Params.deck | markdownify -}}",
       {{- end -}}
       {{- if (isset .Params "summary") -}}
-      "summary" : "{{- .Params.summary -}}",
+      "summary" : "{{- replace .Params.summary "\n" "\\n" -}}",
       {{- end -}}
       "date" : "{{- .Date.Format "2006-01-02T15:04:05" -}}-0500",
       {{- if .Lastmod -}}

--- a/themes/digital.gov/layouts/communities/single.json.json
+++ b/themes/digital.gov/layouts/communities/single.json.json
@@ -34,7 +34,7 @@
       {{- end -}}
       "title" : {{- .Title | jsonify -}},
       {{- if (isset .Params "summary") -}}
-      "summary" : "{{- .Params.summary -}}",
+      "summary" : "{{- replace .Params.summary "\n" "\\n" -}}",
       {{- end -}}
       {{- if (isset .Params "deck") -}}
       "deck" : "{{- .Params.deck | markdownify -}}",
@@ -107,7 +107,7 @@
       {{- end -}}
 
       {{- partial "api/slug" . -}}
-      
+
       "url" : "{{- .Permalink -}}",
       {{- if .Params.aliases -}}
       "aliases" : {

--- a/themes/digital.gov/layouts/events/list.json.json
+++ b/themes/digital.gov/layouts/events/list.json.json
@@ -42,7 +42,7 @@
       "deck" : "{{- .Params.deck | markdownify -}}",
       {{- end -}}
       {{- if (isset .Params "summary") -}}
-      "summary" : "{{- .Params.summary -}}",
+      "summary" : "{{- replace .Params.summary "\n" "\\n" -}}",
       {{- end -}}
       "date" : "{{- .Date.Format "2006-01-02T15:04:05Z07:00" -}}",
       {{- if .Lastmod -}}

--- a/themes/digital.gov/layouts/events/single.json.json
+++ b/themes/digital.gov/layouts/events/single.json.json
@@ -36,7 +36,7 @@
       "deck" : "{{- .Params.deck | markdownify -}}",
       {{- end -}}
       {{- if (isset .Params "summary") -}}
-      "summary" : "{{- .Params.summary -}}",
+      "summary" : "{{- replace .Params.summary "\n" "\\n" -}}",
       {{- end -}}
       "date" : "{{- .Date.Format "2006-01-02T15:04:05Z07:00" -}}",
       {{- if .Lastmod -}}

--- a/themes/digital.gov/layouts/partials/api/bio.html
+++ b/themes/digital.gov/layouts/partials/api/bio.html
@@ -1,3 +1,3 @@
 {{- with .Params.bio -}}
-"bio" : "{{- . -}}",
+"bio" : "{{- replace . "\n" "\\n" -}}",
 {{- end -}}

--- a/themes/digital.gov/layouts/shortcodes/api-topics.html
+++ b/themes/digital.gov/layouts/shortcodes/api-topics.html
@@ -14,7 +14,7 @@
       {
         "slug" : "{{- with .File -}}{{- .Path | replaceRE "^topics/([^/]+).*" "$1" -}}{{- end -}}",
         "title" : "{{- .Title -}}",
-        "summary" : "{{- .Params.summary -}}",
+        "summary" : "{{- replace .Params.summary "\n" "\\n" -}}",
         {{- if .Params.aliases -}}
         "aliases" : {
           {{- $aliaslen := .Params.aliases | len -}}

--- a/themes/digital.gov/layouts/sources/list.json.json
+++ b/themes/digital.gov/layouts/sources/list.json.json
@@ -19,7 +19,7 @@
         "name" : "{{- .Params.name | markdownify -}}",
         {{- end -}}
         {{- if (isset .Params "summary") -}}
-        "summary" : "{{- .Params.summary -}}",
+        "summary" : "{{- replace .Params.summary "\n" "\\n" -}}",
         {{- end -}}
         {{- if (isset .Params "domain") -}}
         "domain" : "{{- .Params.domain -}}",

--- a/themes/digital.gov/static/workflow/config.yml
+++ b/themes/digital.gov/static/workflow/config.yml
@@ -71,7 +71,7 @@ collections:
     folder: "content/authors"
     identifier_field: display_name
     path: "{{slug}}/_index"
-    preview_path: authors/{{fields.slug}}
+    preview_path: authors/{{slug}}
     fields:
       - label: "Display Name"
         name: "display_name"
@@ -192,7 +192,7 @@ collections:
     label_singular: "Community"
     description: "This page will help create a new community on Digital.gov"
     folder: "content/communities"
-    preview_path: communities/{{fields.slug}}
+    preview_path: communities/{{slug}}
     fields:
       - label: "Date"
         name: "date"
@@ -342,7 +342,7 @@ collections:
     summary: "{{title}} ({{year}}-{{month}}-{{day}})"
     path: "{{year}}/{{month}}/{{slug}}"
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
-    preview_path: event/{{year}}/{{month}}/{{day}}/{{fields.slug}}
+    preview_path: event/{{year}}/{{month}}/{{day}}/{{slug}}
     preview_path_date_field: "date"
     fields:
       - label: "Event Title"
@@ -465,7 +465,7 @@ collections:
     summary: "{{title}} ({{year}}-{{month}}-{{day}})"
     path: "{{year}}/{{month}}/{{slug}}"
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
-    preview_path: "{{year}}/{{month}}/{{day}}/{{fields.slug}}"
+    preview_path: "{{year}}/{{month}}/{{day}}/{{slug}}"
     preview_path_date_field: "date"
     fields:
       - label: "Source Url"
@@ -578,7 +578,7 @@ collections:
     label_singular: "Resource"
     description: "This page will help create a new resource on Digital.gov"
     folder: "content/resources"
-    preview_path: resources/{{fields.slug}}
+    preview_path: resources/{{slug}}
     fields:
       - label: "Date"
         name: "date"
@@ -814,7 +814,7 @@ collections:
     description: "This page will help create a new topic on Digital.gov"
     folder: "content/topics"
     path: "{{slug}}/_index"
-    preview_path: topics/{{title}}
+    preview_path: topics/{{slug}}
     fields:
       - label: "Topic Title"
         name: "title"

--- a/themes/digital.gov/static/workflow/styles.css
+++ b/themes/digital.gov/static/workflow/styles.css
@@ -4,7 +4,7 @@ img[alt="Logo"] {
 }
 
 div[class*="LibraryTop"] button[class*="DeleteButton"],
-div[class$="WorkflowCardContainer-card"] div[class$="CardDateContainer-text"] {
+div[class*="WorkflowCardContainer-card"] div[class*="CardDateContainer-text"] {
   display: none;
 }
 


### PR DESCRIPTION
This PR implements the following **changes:**

- Hide date in workflow tab (css selector was wrong previously)
- Modify the preview path of various collections to point to correct location on federalist
- Remove extra line breaks in Hugo generated JSON
