### PR TITLE
3239: Update misspelling

### DIFF
--- a/content/authors/william-bagayoko/_index.md
+++ b/content/authors/william-bagayoko/_index.md
@@ -43,5 +43,8 @@ instagram: ""
 linkedin: ""
 youtube: ""
 
+aliases:
+    - /authors/william-bagakoyo
+
 # Make it better ♥
 ---

--- a/content/authors/william-bagayoko/_index.md
+++ b/content/authors/william-bagayoko/_index.md
@@ -1,12 +1,12 @@
 ---
-# View this page at https://digital.gov/authors/william-bagakoyo
+# View this page at https://digital.gov/authors/william-bagayoko
 # Learn how to edit our pages at https://workflow.digital.gov
 
 # slug — the specific user-id for an author.
-slug: william-bagakoyo
-display_name: "William Bagakoyo"
+slug: william-bagayoko
+display_name: "William Bagayoko"
 first_name: "William"
-last_name: "Bagakoyo"
+last_name: "Bagayoko"
 
 # List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
 pronoun: ""

--- a/content/events/2020/05/2020-05-21-uswds-monthly-call-may-2020.md
+++ b/content/events/2020/05/2020-05-21-uswds-monthly-call-may-2020.md
@@ -27,7 +27,7 @@ authors:
   - dan-williams
   - james-mejia
   - jared-cunha
-  - william-bagakoyo
+  - william-bagayoko
 
 # YouTube ID
 youtube_id: kP-9tJFm3Ag

--- a/content/events/2020/07/2020-07-16-uswds-monthly-call-july-2020.md
+++ b/content/events/2020/07/2020-07-16-uswds-monthly-call-july-2020.md
@@ -26,7 +26,7 @@ topics:
 authors: 
   - dan-williams
   - jared-cunha
-  - william-bagakoyo
+  - william-bagayoko
   - james-mejia
   - ben-judy
 


### PR DESCRIPTION
 fixes #3239

This PR implements the following **changes:**

* updates the spelling of 'William Bagayoko' which is currently misspelled as 'William Bagakoyo'

Thanks for looking at this!

**URL / Link to page**

The page with the misspelled name - https://digital.gov/authors/william-bagakoyo/

The url with the corrected name (which shouldn't currently be working in production) - https://digital.gov/authors/william-bagayoko/

