### PR TITLE
Redirect USWDS CoP page

### DIFF
--- a/content/communities/uswds.md
+++ b/content/communities/uswds.md
@@ -36,6 +36,8 @@ community_list:
     members: 108
     emails_per_week:
 
+redirectto: https://designsystem.digital.gov/about/community/
+
 # Make it better ♥
 
 ---

--- a/content/services/service_uswds.md
+++ b/content/services/service_uswds.md
@@ -36,5 +36,4 @@ topics:
 authors:
   - dan-williams
   - ammie-farraj-feijoo
-
 ---


### PR DESCRIPTION
This PR implements the following **changes:**

* Redirect the  USWDS community page to https://designsystem.digital.gov/about/community/



**URL / Link to page**
https://digital.gov/communities/uswds/

<!-- Link to the page that will be changed -->
<!-- Delete this section if not needed -->

