### PR TITLE
Netlify CMS config changes

### DIFF
--- a/themes/digital.gov/static/workflow/config.yml
+++ b/themes/digital.gov/static/workflow/config.yml
@@ -71,7 +71,7 @@ collections:
     folder: "content/authors"
     identifier_field: display_name
     path: "{{slug}}/_index"
-    preview_path: authors/{{slug}}
+    preview_path: authors/{{display_name}}
     fields:
       - label: "Display Name"
         name: "display_name"
@@ -352,7 +352,7 @@ collections:
     summary: "{{title}} ({{year}}-{{month}}-{{day}})"
     path: "{{year}}/{{month}}/{{slug}}"
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
-    preview_path: event/{{year}}/{{month}}/{{day}}/{{slug}}
+    preview_path: event/{{year}}/{{month}}/{{day}}/{{title}}
     preview_path_date_field: "date"
     fields:
       - label: "Event Title"
@@ -475,7 +475,7 @@ collections:
     summary: "{{title}} ({{year}}-{{month}}-{{day}})"
     path: "{{year}}/{{month}}/{{slug}}"
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
-    preview_path: "{{year}}/{{month}}/{{day}}/{{slug}}"
+    preview_path: "{{year}}/{{month}}/{{day}}/{{title}}"
     preview_path_date_field: "date"
     fields:
       - label: "Source Url"
@@ -824,7 +824,7 @@ collections:
     description: "This page will help create a new topic on Digital.gov"
     folder: "content/topics"
     path: "{{slug}}/_index"
-    preview_path: topics/{{slug}}
+    preview_path: topics/{{title}}
     fields:
       - label: "Topic Title"
         name: "title"

--- a/themes/digital.gov/static/workflow/config.yml
+++ b/themes/digital.gov/static/workflow/config.yml
@@ -37,6 +37,7 @@ defaults: &defaults
     preview: false
   create: true
   delete: false
+  publish: false
 
 editorComponents: &editorComponents
   editorComponents:
@@ -867,6 +868,7 @@ collections:
     description: "This page will help upload a new image to Digital.gov"
     folder: "content/images/_inbox"
     identifier_field: image
+    publish: true
     fields:
       - label: "Image"
         name: "image"


### PR DESCRIPTION
This PR implements the following **changes:**

- Disables publishing from CMS (aka merging to main)
- Reverts some changes to the preview path to try and get Federalist/live preview links working correctly
