### PR TITLE
Update markdown lint to allow 2 trailing spaces

### DIFF
--- a/.markdown-lint.yml
+++ b/.markdown-lint.yml
@@ -20,6 +20,8 @@
 ###############
 MD001: false # Header levels should only increment by one level at a time
 MD004: false # Unordered list style
+MD009:
+  br_spaces: 2 # Trailing spaces
 MD007:
   indent: 4 # Unordered list indentation
 MD013: false # Line length


### PR DESCRIPTION
This PR implements the following **changes:**

* update the Markdown Lint ruleset to allow for 2 trailing spaces

Reasoning:
The [Best Practices for Writing for the Accessible Web](https://digital.gov/resources/best-practices-for-writing-for-accessible/) post is failing the markdown lint tests because of trailing spaces. We sometimes use 2 trailing spaces in markdown to force a line break. This modification will allow the 2 trailing spaces at the end of a line.


**URL / Link to page**

<!-- Link to the page that will be changed -->
<!-- Delete this section if not needed -->

