### PR TITLE
10x Digital Experience Guide: Read Time

### DIFF
--- a/themes/digital.gov/layouts/partials/core/guides/guide-page-head.html
+++ b/themes/digital.gov/layouts/partials/core/guides/guide-page-head.html
@@ -1,5 +1,7 @@
 <header class="page-head page-head-{{- .Type -}}">
 
+  {{- partial "core/guides/guide-read-time" . -}}
+
   {{- if not .IsNode -}}
     {{- if .Params.kicker -}}
     <p class="kicker">{{- .Params.kicker -}}</p>

--- a/themes/digital.gov/layouts/partials/core/guides/guide-read-time.html
+++ b/themes/digital.gov/layouts/partials/core/guides/guide-read-time.html
@@ -1,0 +1,19 @@
+{{- $guide_data := index $.Site.Data.guidenav (.Params.guide) -}}
+
+{{- if and $guide_data $guide_data.showReadTime -}}
+
+    {{- $readTime := 0 -}}
+
+    {{ if isset .Params "readtime" }}
+        {{- $readTime = .Params.readTime -}}
+    {{- else -}}
+        {{- $readTime = .ReadingTime -}}
+    {{- end -}}
+
+    {{ if $readTime }}
+        {{ $readTimeMinutes := cond (gt $readTime 1) "minutes" "minute" }}
+        <p>Reading time: {{ $readTime }} {{ $readTimeMinutes }}</p>
+    {{- end -}}
+{{- end -}}
+
+

--- a/themes/digital.gov/layouts/partials/core/guides/guide-read-time.html
+++ b/themes/digital.gov/layouts/partials/core/guides/guide-read-time.html
@@ -15,5 +15,3 @@
         <p>Reading time: {{ $readTime }} {{ $readTimeMinutes }}</p>
     {{- end -}}
 {{- end -}}
-
-


### PR DESCRIPTION
##### You can show read time for a guide
<img width="505" alt="Screen Shot 2020-09-22 at 3 41 11 PM" src="https://user-images.githubusercontent.com/1385752/93936065-3a121880-fceb-11ea-914e-8576b0365974.png">
<img width="770" alt="Screen Shot 2020-09-22 at 3 41 20 PM" src="https://user-images.githubusercontent.com/1385752/93936069-3aaaaf00-fceb-11ea-8fe4-74885531fe3c.png">

##### Override it with a custom value
<img width="677" alt="Screen Shot 2020-09-22 at 3 41 47 PM" src="https://user-images.githubusercontent.com/1385752/93936075-3bdbdc00-fceb-11ea-8709-6e73a5e8490c.png">
<img width="947" alt="Screen Shot 2020-09-22 at 3 42 08 PM" src="https://user-images.githubusercontent.com/1385752/93936076-3c747280-fceb-11ea-999f-f82b8d6735b7.png">

﻿﻿﻿##### Hide the time on a page by setting the read time to false
<img width="640" alt="Screen Shot 2020-09-22 at 3 42 54 PM" src="https://user-images.githubusercontent.com/1385752/93936077-3d0d0900-fceb-11ea-823e-aaa5b52b354f.png">
<img width="922" alt="Screen Shot 2020-09-22 at 3 43 06 PM" src="https://user-images.githubusercontent.com/1385752/93936078-3d0d0900-fceb-11ea-933e-08aabf69010b.png">

##### You can also hide the time by setting read time to 0
<img width="675" alt="Screen Shot 2020-09-22 at 3 43 32 PM" src="https://user-images.githubusercontent.com/1385752/93936079-3da59f80-fceb-11ea-91df-e61dc2623d1a.png">
<img width="879" alt="Screen Shot 2020-09-22 at 3 43 41 PM" src="https://user-images.githubusercontent.com/1385752/93936080-3da59f80-fceb-11ea-8b03-4f6fd75ffe97.png">

Needs changes in Next / Previous Button merged in before