### PR TITLE
Changing upcoming meetings

### DIFF
--- a/content/communities/devops.md
+++ b/content/communities/devops.md
@@ -48,10 +48,11 @@ Government agencies are investing in cloud capabilities and are seeking to work 
 
 ## Upcoming Meetings
 
-- **[September Meeting: A Fresh Start With DevOps - Maybe](https://digital.gov/event/2020/09/22/a-fresh-start-with-devops-maybe/)**
+- **Please check back soon for upcoming meetings**
 
 ## Past Meetings
 
+- **[September Meeting: A Fresh Start With DevOps - Maybe](https://digital.gov/event/2020/09/22/a-fresh-start-with-devops-maybe/)**
 - **[August Special Event: The Continuous DevOps Dilemma with Andrew Clay Shafer](https://digital.gov/event/2020/08/04/continuous-devops-dilemma-with-andrew-clay/)**
 - **[June Meeting: Air Force COOL and 18F, Partnership and Flight Operations Software Agile Lessons Learned](https://digital.gov/event/2020/06/23/air-force-cool-18f-partnership-flight/)**
 - **[May Meeting: DevOps Lessons Learned from the Air Force’s Early Cloud Journey](https://digital.gov/event/2020/05/19/devops-lessons-learned-from-air-forces/)**


### PR DESCRIPTION
This PR implements the following **changes:**

* Removing upcoming meeting 


**URL / Link to page**

https://digital.gov/communities/devops/

