### PR TITLE
Update rpa guide title

### DIFF
--- a/content/guides/rpa/_index.md
+++ b/content/guides/rpa/_index.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-05-15 09:00:00 -0500
-title: "Guide to Robotics Process Automation"
+title: "Guide to Robotic Process Automation"
 deck: "Automate reptitive business processes without writing code"
 summary: 'Configure bots to execute repetitive tasks to save users from performing mundane tasks repeatedly for the same process.'
 guide: rpa


### PR DESCRIPTION
This PR implements the following **changes:**

* update RPA guide to `Robotic` instead of `Robotics`


**URL / Link to page**
https://digital.gov/guides/rpa/
<!-- Link to the page that will be changed -->
<!-- Delete this section if not needed -->

