### PR TITLE
Hugo bind for development server access

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "gulpfile.js",
   "scripts": {
     "federalist": "export NODE_ENV=production && gulp build-assets",
-    "hugo": "export $(grep -v '^#' .env | xargs) && hugo serve",
+    "hugo": "export $(grep -v '^#' .env | xargs) && hugo serve --bind='0.0.0.0'",
     "lint:json": "find public/**/v1/json/index.html -print0 | xargs -0I {} jsonlint '{}'",
     "lint:markdown": "markdownlint --config ./.markdown-lint.yml ./content/**/*.md --ignore './content/apis/*.md'",
     "lint": "hugo && run-p lint:*",


### PR DESCRIPTION
This PR implements the following **changes:**

Binds Hugo server to 0.0.0.0 for those with development servers on same network. Closes #3293 

**URL / Link to page**

Localhost site rendering - https://digital.gov/.