### PR TITLE
Add a11y event statement

### DIFF
--- a/themes/digital.gov/layouts/events/stage-adobe_connect.html
+++ b/themes/digital.gov/layouts/events/stage-adobe_connect.html
@@ -6,7 +6,7 @@
   </div>
   <div>
     <p><strong>This event will be held over Adobe Connect.</strong> A link to join this event will be sent via email to those who register. Before the meeting, <a href="https://helpx.adobe.com/adobe-connect/connect-downloads-updates.html" title="Download and install Adobe Connect">download and install Adobe Connect</a> and ensure that your computer and network connections are configured by <a href="https://helpx.adobe.com/adobe-connect/using/connection-test-connect-meeting.html">running a test</a>.</p>
-
+    <p>Please contact us directly at <a href="mailto:digitalgov@gsa.gov">digitalgov@gsa.gov</a> if you need accessible accommodations to be able to attend. </p>
     {{- if .Params.captions -}}
     <p><a class="captions" href="{{- .Params.captions -}}" title="Captions for the {{ .Title -}}"><strong><i class="far fa-closed-captioning"></i> <span>View captions</span></strong></a></p>
     {{- end -}}

--- a/themes/digital.gov/layouts/events/stage-google.html
+++ b/themes/digital.gov/layouts/events/stage-google.html
@@ -6,7 +6,7 @@
   </div>
   <div>
     <p><strong>This event will be held over Google Meet.</strong> A link to join this event will be sent via email to those who register. <a href="https://support.google.com/meet/answer/9303069" title="Learn more about joining a video meeting over Google Meet">Learn more about joining a video meeting over Google Meet</a>.</p>
-
+    <p>Please contact us directly at <a href="mailto:digitalgov@gsa.gov">digitalgov@gsa.gov</a> if you need accessible accommodations to be able to attend. </p>
     {{- if .Params.captions -}}
     <p><a class="captions" href="{{- .Params.captions -}}" title="Captions for the {{ .Title -}}"><strong><i class="far fa-closed-captioning"></i> <span>View captions</span></strong></a></p>
     {{- end -}}

--- a/themes/digital.gov/layouts/events/stage-zoom.html
+++ b/themes/digital.gov/layouts/events/stage-zoom.html
@@ -7,7 +7,7 @@
   <div>
     <p><strong>This event will be held and recorded over <a href="https://zoom.us/government">Zoom for Government</a>.</strong> A link and password will be sent via email 24 hours and 1 hour prior to the event start time for those who register. For more info, see the <a href="https://support.zoom.us/hc/en-us/articles/201362023-System-Requirements-for-PC-Mac-and-Linux" title="Zoom computer and device requirements">computer and device requirements</a> and <a href="https://support.zoom.us/hc/en-us/sections/200277708-Frequently-Asked-Questions" title="View the Zoom Frequently Asked Questions">Frequently Asked Questions</a>. If you have specific questions or security concerns about Zoom for Government, please visit  <a href="https://www.zoomgov.com/">ZoomGov.com</a>.  </p><p>Before the event, visit the <a href="https://zoomgov.com/download">Zoom Download Center</a> to install the Zoom web browser client.
     </p>
-
+    <p>Please contact us directly at <a href="mailto:digitalgov@gsa.gov">digitalgov@gsa.gov</a> if you need accessible accommodations to be able to attend. </p>
     {{- if .Params.captions -}}
     <p><a class="captions" href="{{- .Params.captions -}}" title="Captions for the {{ .Title -}}"><strong><i class="far fa-closed-captioning"></i> <span>View captions</span></strong></a></p>
     {{- end -}}


### PR DESCRIPTION
This PR implements the following **changes:**

* Update the event platforms to include an accessibility statement
"Please contact us directly at digitalgov@gsa.gov if you need accessible accommodations to be able to attend."

Closes #3108 

<img width="802" alt="Screen Shot 2020-10-07 at 9 38 55 AM" src="https://user-images.githubusercontent.com/2197515/95338779-48cb0480-0881-11eb-9162-5b9c41bd4f4f.png">

