### PR TITLE
Retire lost-and-found-mapping-page.md

### DIFF
--- a/content/about/lost-and-found-mapping-page.md
+++ b/content/about/lost-and-found-mapping-page.md
@@ -3,8 +3,9 @@ url: /lost-and-found-mapping-page/
 date: 2014-09-16 4:20:55 -0400
 title: "Lost and Found &#8211; Mapping Page"
 summary: "Had a HowTo.gov page bookmarked that you&#8217;re looking for on DigitalGov? Take a look at the list below for the corresponding DigitalGov URL. About Us Policies and Guidelines for Federal Public Websites: Recommendations of ICGI Report howto.gov/about-us/documents/icgi-report-recommendations ICGI Report Attachments ICGI Recommendations for Federal Public Websites &ndash; 2004 howto.gov/about-us/documents/icgi-report-summary-and-background ICGI Summary and Background Site Policies"
+expiryDate: 2020-10-20
 aliases:
-  - /about/lost-and-found-mapping-page/
+  - /resources/
 ---
 
 Had a HowTo.gov page bookmarked that you&#8217;re looking for on DigitalGov? Take a look at the list below for the corresponding DigitalGov URL.


### PR DESCRIPTION
This PR implements the following **changes:**

* add an `expiryDate` to no longer build the page
* update the alias


**URL / Link to page**
https://digital.gov/lost-and-found-mapping-page/
<!-- Link to the page that will be changed -->
<!-- Delete this section if not needed -->

Closes #1571 