### PR TITLE
Add FEC to Content Management Systems Used by Government Agencies

### DIFF
--- a/content/resources/content-management-systems-used-by-government-agencies.md
+++ b/content/resources/content-management-systems-used-by-government-agencies.md
@@ -86,6 +86,8 @@ We do our best to keep the list current based on information we get from agencie
 
 [Federal Communications Commission](http://www.fcc.gov/) (Drupal/Documentum)
 
+[Federal Election Commission](https://www.fec.gov/) (Wagtail)
+
 [Federal Reserve Board of Governors](http://www.federalreserve.gov/) (RedDot)
 
 [Federal Trade Commission](http://www.ftc.gov/) (Drupal)


### PR DESCRIPTION
This PR implements the following **changes:**

- Adds the Federal Election Commission to the page [Add FEC to Content Management Systems Used by Government Agencies](https://digital.gov/resources/content-management-systems-used-by-government-agencies/), noting their use of Wagtail
