### PR TITLE
Update stale action

### DIFF
--- a/.github/workflows/close-stale-issue.yml
+++ b/.github/workflows/close-stale-issue.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v1
+    - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Hello! 👋 It looks like this issue is stale because it has been open 60 days with no activity. This is usually because the request was already solved or it is no longer applicable. If this issue should remain open, remove the stale label or add a comment. Otherwise, this will be closed in 7 days.'

--- a/.github/workflows/close-stale-issue.yml
+++ b/.github/workflows/close-stale-issue.yml
@@ -19,6 +19,9 @@ jobs:
         days-before-stale: 120
         days-before-close: 14
         stale-issue-label: '[status] stale'
-        exempt-issue-label: '---- HOLD ----'
+        exempt-issue-label: 
+          - '---- HOLD ----'
+          - 'Bug: broken links'
+          - 'Bug: Content Cleanup'
         stale-pr-label: '[status] stale'
         exempt-pr-label: '---- HOLD ----'


### PR DESCRIPTION
This PR implements the following **changes:**

* update the Stale Action to v3 from v1
* add 2 additional exempt issue labels
  - 'Bug: broken links'
  - 'Bug: Content Cleanup'


Full documentation for this Action is located at https://github.com/actions/stale




