### PR TITLE
making cop open to public

### DIFF
--- a/content/communities/plain-language-community-of-practice.md
+++ b/content/communities/plain-language-community-of-practice.md
@@ -13,7 +13,7 @@ topics:
 weight: 1
 community_list:
   - platform: "listserv"
-    type: government
+    type: public
     subscribe_form: "https://listserv.gsa.gov/cgi-bin/wa.exe?SUBED1=PL-COP-MAIN"
     members: 1169
     emails_per_week: 1.1


### PR DESCRIPTION
This PR implements the following **changes:**

* making listserv open to public


**URL / Link to page**

https://digital.gov/communities/plain-language/
