### PR TITLE
Update 2020-11-19-uswds-monthly-call-november-2020.md

### DIFF
--- a/content/events/2020/11/2020-11-19-uswds-monthly-call-november-2020.md
+++ b/content/events/2020/11/2020-11-19-uswds-monthly-call-november-2020.md
@@ -4,12 +4,13 @@
 
 slug: uswds-monthly-call-november-2020
 title: "USWDS Monthly Call - November 2020"
-deck: "Join U.S. Web Design System Product Lead, Dan Williams, as we talk about the design system and answer your questions."
-summary: "Join U.S. Web Design System Product Lead, Dan Williams, as we talk about the design system and answer your questions."
+kicker: USWDS
+deck: "What's Next for USWDS"
+summary: "Join U.S. Web Design System Product Lead, Dan Williams, to hear about what's next for the design system as we come to the end of 2020."
 host: "U.S. Web Design System"
 event_organizer: "Digital.gov"
-registration_url:
-captions:
+registration_url: https://www.eventbrite.com/e/128291289701
+captions: https://www.captionedtext.com/client/event.aspx?EventID=4632755&CustomerID=321
 
 # start date
 date: 2020-11-19 14:30:00 -0500
@@ -29,7 +30,7 @@ authors:
   - dan-williams
 
 # Event platform (zoom, youtube_live, adobe_connect, google)
-event_platform:
+event_platform: zoom
 
 # YouTube ID
 youtube_id:
@@ -41,6 +42,7 @@ primary_image: "uswds-2-illio-feature-image"
 ---
 
 {{< img-right src="uswds-logo" >}}
+Join U.S. Web Design System Product Lead, Dan Williams, to hear about what's next for the design system as we come to the end of 2020. During this event, the design system team will discuss what we've learned this year and how we're thinking about the future of the design system.
 
 This event is part of a monthly series that takes place on the third Thursday of each month. We post the video on Digital.gov shortly after each event.
 


### PR DESCRIPTION
Updating the currently available page on Digital.gov/events. Looks like there are now two pages in the Workflow tool, which might be a bigger issue.

This PR implements the following **changes:**

* @mara-goldberg [updated the page](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/cms/events/2020/11/2020-11-09-uswds-monthly-call-november-2020/event/2020/11/19/uswds-monthly-call-november-2020/)
* Looks like it was a secondary build so never merged with the actual page on Digital.gov/events since the page was put in as 11-09 instead of 11-19
* I still don't event see the 11-09 page on Digital.gov though

**URL / Link to page**
https://digital.gov/event/2020/11/19/uswds-monthly-call-november-2020/


<!-- Link to the page that will be changed -->
<!-- Delete this section if not needed -->

