### PR TITLE
Added links to videos and slides

### DIFF
--- a/content/events/2020/10/2020-10-01-plain-language-summit-2020.md
+++ b/content/events/2020/10/2020-10-01-plain-language-summit-2020.md
@@ -52,43 +52,50 @@ There will be two sessions each day. You will need to register for each one to r
 
 **First Session (10:00 am - 12:15 pm, ET)**
 
-- Recording Coming Soon
+- [Watch the video](https://youtu.be/EsJh0GuGYDA)
 
 In this session you will hear from the following speakers:
 
 * **10:00 am - 10:30 am: Welcome & Annual Report**&mdash;Katherine Spivey, GSA’s Plain Language Launcher and co-chair of the Plain Language Action and Information Network (PLAIN) and Katina Stapleton, co-chair of PLAIN
 * **10:35 am - 11:15 am: Putting Plain Language to the Test**&mdash;Nicole Fenton, Senior Content Strategist
+  - [View the slides](https://digital.gov/pdf/pl-summit-2020-nicole-fenton.pdf) (PDF, 18.7 MB, 43 pages)
 * **11:15 am - 12:15 pm: Keynote**&mdash;Mark Mchale, GSA's Senior Plain Language Official Associate Administrator, Office of Strategic Communications, GSA
 
 **Second Session (2:00 pm – 4:15 pm, ET)**
 
-- Recording Coming Soon
+- [Watch the video](https://youtu.be/-pP0JEJ3FHo)
 
 In this session you will hear from the following speakers:
 
-* **2:00 pm - 3:00 pm: Government CX: Intersection of CX and PL**&mdash;Martha Dorris, Independent Consultant 
+* **2:00 pm - 3:00 pm: Government CX: Intersection of CX and PL**&mdash;Martha Dorris, Independent Consultant
+  - [View the slides](https://digital.gov/pdf/pl-summit-2020-martha-dorris.pdf) (PDF, 4.68 MB, 20 pages)
 * **3:00 pm - 3:30 pm: How We Got the Plain Writing Act Passed**&mdash;Annetta Cheek, Chair, Standards Committee, International Federation for Plain Language
 * **3:30 pm - 4:15 pm: Flimsy Claims for Legalese and False Criticisms of Plain Language: A 30-Year Collection**&mdash;Joe Kimble, Professor Emeritus, Western Michigan University
+  - [View the slides](https://digital.gov/pdf/pl-summit-2020-joseph-kimble.pdf) (PDF, 112 KB, 14 pages)
 
 ### Wednesday, October 28
 
 **Third Session (9:30 am – 12:00 pm, ET)**
 
-- Recording Coming Soon
+- [Watch the video](https://youtu.be/iXxy9b9NHRg)
 
 In this session you will hear from the following speakers:
 
 * **9:30 am - 10:00 am: Use Plain Language to Influence, Motivate & Mobilize for Change**&mdash;Bethany Blakey, Chief Modernization Strategist, CoE, TTS
+  - [View the slides](https://digital.gov/pdf/pl-summit-2020-bethany-blakey.pdf) (PDF, 1020 KB, 16 pages)
 * **10:00 am - 11:00 am: Content Strategy**&mdash;Ginny Redish
+  - [View the slides](https://digital.gov/pdf/pl-summit-2020-ginny-redish.pdf) (PDF, 9.15 MB, 40 pages)
 * **11:00 am - 12:00 pm: Sense making lessons from the Private Sector**&mdash;Abby Covert, Information Architect & Author
+  - [View the slides](https://digital.gov/pdf/pl-summit-2020-abby-covert.pdf) (PDF, 11.2 MB, 53 pages)
 
 **Fourth Session (2:00 pm – 4:15 pm, ET)**
 
-- Recording Coming Soon
+- [Watch the video](https://youtu.be/OllB0f5fNc0)
 
 In this session you will hear from the following speakers:
 
 * **2:00 pm - 3:00 pm: How Smart Teams Create and Train Writers**&mdash;Scott Kubie, Independent Consultant
+  - [View the slides](https://digital.gov/pdf/pl-summit-2020-scott-kubie.pdf) (PDF, 9.26 MB, 23 pages)
 * **3:00 pm - 4:00 pm: Plain Language**&mdash;Katherine Spivey, GSA’s Plain Language Launcher and co-chair of the Plain Language Action and Information Network (PLAIN)
 
 ---

--- a/content/events/2020/10/2020-10-01-plain-language-summit-2020.md
+++ b/content/events/2020/10/2020-10-01-plain-language-summit-2020.md
@@ -50,9 +50,7 @@ There will be two sessions each day. You will need to register for each one to r
 
 ### Tuesday, October 27
 
-**First Session (10:00 am - 12:15 pm, ET)**
-
-- [Watch the video](https://youtu.be/EsJh0GuGYDA)
+#### First Session (10:00 am - 12:15 pm, ET)
 
 In this session you will hear from the following speakers:
 
@@ -61,9 +59,9 @@ In this session you will hear from the following speakers:
   - [View the slides](https://digital.gov/pdf/pl-summit-2020-nicole-fenton.pdf) (PDF, 18.7 MB, 43 pages)
 * **11:15 am - 12:15 pm: Keynote**&mdash;Mark Mchale, GSA's Senior Plain Language Official Associate Administrator, Office of Strategic Communications, GSA
 
-**Second Session (2:00 pm – 4:15 pm, ET)**
+{{< youtube EsJh0GuGYDA >}}
 
-- [Watch the video](https://youtu.be/-pP0JEJ3FHo)
+#### Second Session (2:00 pm – 4:15 pm, ET)**
 
 In this session you will hear from the following speakers:
 
@@ -73,11 +71,12 @@ In this session you will hear from the following speakers:
 * **3:30 pm - 4:15 pm: Flimsy Claims for Legalese and False Criticisms of Plain Language: A 30-Year Collection**&mdash;Joe Kimble, Professor Emeritus, Western Michigan University
   - [View the slides](https://digital.gov/pdf/pl-summit-2020-joseph-kimble.pdf) (PDF, 112 KB, 14 pages)
 
+
+{{< youtube -pP0JEJ3FHo >}}
+
 ### Wednesday, October 28
 
-**Third Session (9:30 am – 12:00 pm, ET)**
-
-- [Watch the video](https://youtu.be/iXxy9b9NHRg)
+#### Third Session (9:30 am – 12:00 pm, ET)
 
 In this session you will hear from the following speakers:
 
@@ -88,15 +87,17 @@ In this session you will hear from the following speakers:
 * **11:00 am - 12:00 pm: Sense making lessons from the Private Sector**&mdash;Abby Covert, Information Architect & Author
   - [View the slides](https://digital.gov/pdf/pl-summit-2020-abby-covert.pdf) (PDF, 11.2 MB, 53 pages)
 
-**Fourth Session (2:00 pm – 4:15 pm, ET)**
+{{< youtube iXxy9b9NHRg >}}
 
-- [Watch the video](https://youtu.be/OllB0f5fNc0)
+#### Fourth Session (2:00 pm – 4:15 pm, ET)
 
 In this session you will hear from the following speakers:
 
 * **2:00 pm - 3:00 pm: How Smart Teams Create and Train Writers**&mdash;Scott Kubie, Independent Consultant
   - [View the slides](https://digital.gov/pdf/pl-summit-2020-scott-kubie.pdf) (PDF, 9.26 MB, 23 pages)
 * **3:00 pm - 4:00 pm: Plain Language**&mdash;Katherine Spivey, GSA’s Plain Language Launcher and co-chair of the Plain Language Action and Information Network (PLAIN)
+
+{{< youtube OllB0f5fNc0 >}}
 
 ---
 

--- a/content/events/2020/10/2020-10-01-plain-language-summit-2020.md
+++ b/content/events/2020/10/2020-10-01-plain-language-summit-2020.md
@@ -61,7 +61,7 @@ In this session you will hear from the following speakers:
 
 {{< youtube EsJh0GuGYDA >}}
 
-#### Second Session (2:00 pm – 4:15 pm, ET)**
+#### Second Session (2:00 pm – 4:15 pm, ET)
 
 In this session you will hear from the following speakers:
 


### PR DESCRIPTION
For Plain Language Summit 2020 event page, added links to YouTube videos and slides (as PDFs)

This PR implements the following **changes:**

For Plain Language Summit 2020 event page, added links to YouTube videos and slides (as PDFs)


**URL / Link to page**

https://digital.gov/event/2020/10/27/plain-language-summit-2020/

