### PR TITLE
Update mobile-application-development-program.md

### DIFF
--- a/content/resources/mobile-application-development-program.md
+++ b/content/resources/mobile-application-development-program.md
@@ -31,7 +31,7 @@ authors:
 
       <ul>
         <li>
-          See what other agencies are doing in the mobile space on the <a href="http://www.usa.gov/mobileapps.shtml">Federal Mobile Apps Directory</a>.
+          See what other agencies are doing in the mobile space on the <a href="https://www.usa.gov/mobile-apps">Federal Mobile Apps Directory</a>.
         </li>
         <li>
           Learn how agencies created these mobile products with our more than <a href="{{< ref "/topics/mobile-gov-experience" >}}">25 Mobile Gov Case Studies</a>.
@@ -84,7 +84,7 @@ authors:
           Use the federal friendly <a title="Federal-Compatible Terms of Service Agreements" href="{{< ref "/resources/federal-compatible-terms-of-service-agreements.md" >}}">Terms of Service agreements</a> and get your app in the app stores.
         </li>
         <li>
-          Register your mobile product (app or mobile web site) with the <a title="The Federal Mobile Products Registry" href="{{< ref "service_us-digital-registry.md" >}}">Federal Mobile Products Registry</a> for placement on the <a href="http://www.usa.gov/mobileapps.shtml">Federal Mobile Apps Directory</a>.
+          Register your mobile product (app or mobile web site) with the <a title="The Federal Mobile Products Registry" href="{{< ref "service_us-digital-registry.md" >}}">Federal Mobile Products Registry</a> for placement on the <a href="https://www.usa.gov/mobile-apps">Federal Mobile Apps Directory</a>.
         </li>
         <li>
           PROMOTE! Use the <a href="http://www.usa.gov/About/developer-resources/mobile-app-gallery/index.shtml">Federal Mobile Product API</a> and create widgets to highlight yours and other agencies’ mobile products.


### PR DESCRIPTION
Updated a broken link on this page per user feedback to digital.gov.

This PR implements the following **changes:**

* http://www.usa.gov/mobileapps.shtml has been changed to correct URL https://www.usa.gov/mobile-apps


**URL / Link to page**
https://digital.gov/resources/mobile-application-development-program/


