### PR TITLE
fix favicon bug

### DIFF
--- a/themes/digital.gov/layouts/shortcodes/termsofservice-compatible.html
+++ b/themes/digital.gov/layouts/shortcodes/termsofservice-compatible.html
@@ -7,7 +7,7 @@
   </tr>
   {{ range where .Site.Data.termsofservice.termsofservice "status" "!=" (slice "closed" "not-compatible") }}
   <tr>
-    <td><a href="{{ .Params.url }}" title="{{ .name }}"><img class="favicon" src="https://www.google.com/s2/favicons?domain={{ .Params.url }}" alt="{{ .name }}"> <strong><span>{{ .name }}</span></strong></a> {{ if .description }} — {{ .description -}}{{- end -}}</td>
+    <td><a href="{{ .url }}" title="{{ .name }}"><img class="favicon" src="https://www.google.com/s2/favicons?domain={{ .url }}" alt="{{ .name }}"> <strong><span>{{ .name }}</span></strong></a> {{ if .description }} — {{ .description -}}{{- end -}}</td>
 
     {{ $.Scratch.Set "filepath" (printf "%s" "null") }}
     {{ if eq .type "PDF" }}

--- a/themes/digital.gov/layouts/shortcodes/termsofservice-inactive.html
+++ b/themes/digital.gov/layouts/shortcodes/termsofservice-inactive.html
@@ -6,7 +6,7 @@
   </tr>
   {{ range where .Site.Data.termsofservice.termsofservice "status" "==" "inactive" }}
   <tr>
-    <td><a href="{{ .Params.url }}" title="{{ .name }}"><img class="favicon" src="https://www.google.com/s2/favicons?domain={{ .Params.url }}" alt="{{ .name }}"> <strong><span>{{ .name }}</span></strong></a> {{ if .description }} — {{ .description -}}{{- end -}}</td>
+    <td><a href="{{ .url }}" title="{{ .name }}"><img class="favicon" src="https://www.google.com/s2/favicons?domain={{ .url }}" alt="{{ .name }}"> <strong><span>{{ .name }}</span></strong></a> {{ if .description }} — {{ .description -}}{{- end -}}</td>
   </tr>
   {{ end }}
 </table>


### PR DESCRIPTION
This PR implements the following **changes:**

* fixes the template parameters for the Terms of Service shortcodes to properly show the favicon and use the correct URL


**URL / Link to page**
https://digital.gov/resources/negotiated-terms-of-service-agreements/
<!-- Link to the page that will be changed -->
<!-- Delete this section if not needed -->

Closes #3451 

After: 
<img width="931" alt="Screen Shot 2020-11-27 at 12 34 01 PM" src="https://user-images.githubusercontent.com/2197515/100473734-079ae800-30ad-11eb-9004-da0dee5101fb.png">
