### PR TITLE
Updates for htmlproofer

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "hugo && run-p lint:*",
     "local-build": "gulp build-assets && gulp watch",
     "start": "npm-run-all --parallel local-build hugo workflow",
+    "test:htmlproofer": "htmlproofer ./public --allow-hash-href --check-html --empty-alt-ignore --disable-external",
     "test:pa11y": "pa11y-ci --config .pa11yci",
     "workflow": "npx netlify-cms-proxy-server"
   },

--- a/readme.md
+++ b/readme.md
@@ -198,7 +198,10 @@ Accessibility testing configuration is located in the .pa11yci file.
 
 To test the validity of API JSON files, run `npm run lint:json` in the terminal on your local machine.  This will check the validity of the Hugo generated JSON files used for the API. Currently, it validates authors, images, and topics using the tool `jsonlint`. If an issue is found with the JSON, `jsonlint` will return a non-zero exit code causing CircleCI to fail. See the [wiki API page](https://github.com/GSA/digitalgov.gov/wiki/APIs) for fixing API issues.
 
-Markdown linting can be performed by running `npm run lint:json`. The rules that are used for the linter can be found in `.markdown-lint.yml`.
+Markdown testing can be performed by running `npm run lint:json`. The rules that are used for the linter can be found in `.markdown-lint.yml`.
+
+HTML linting can be performed by running 'npm run test:htmlproofer'. 
+To have HTMLproofer ignore certain content see: https://github.com/gjtorikian/html-proofer#ignoring-content
 
 ## Common Regex scripts
 

--- a/themes/digital.gov/layouts/partials/core/head.html
+++ b/themes/digital.gov/layouts/partials/core/head.html
@@ -106,7 +106,7 @@
   {{- end }}
 
   {{ "<!-- JSON Feed -->" | safeHTML }}
-  <link href="{{- .Permalink -}}index.json" rel="alternate" type="application/json" title="{{- .Site.Title -}}" />
+  <link href="{{- .Permalink -}}index.json" data-proofer-ignore rel="alternate" type="application/json" title="{{- .Site.Title -}}" />
 
   {{ "<!-- Sitemap-->" | safeHTML }}
   <link rel="sitemap" type="application/xml" title="Digital.gov Sitemap" href="{{- "sitemap.xml" | absURL -}}" />


### PR DESCRIPTION
This PR implements the following **changes:**

* add an NPM script to run HTMLproofer from the command line locally
* have HTMLproofer to ignore the JSON pages which are generated for the Topics by adding `data-proofer-ignore` to the template which builds those links in `head.html`.  (see [htmlproofer ignoring content for more info on doing that](https://github.com/gjtorikian/html-proofer#ignoring-content))

This reduces the HTMLproofer errors from over 2000 to under 100.

```htmlproofer 3.16.0 | Error:  HTML-Proofer found 66 failures!```



