### PR TITLE
Update challenges-prizes.md

### DIFF
--- a/content/communities/challenges-prizes.md
+++ b/content/communities/challenges-prizes.md
@@ -30,10 +30,10 @@ aliases:
 community_list:
   - platform: listserv
     type: government
-    subscribe_email: "team@challenge.gov"
+    subscribe_email: "challenges-subscribe-request@listserv.gsa.gov"
     subscribe_email_subject: "Join Challenges Community"
-    subscribe_email_body: "enter your name + agency you work for"
-    members: 738
+    subscribe_email_body: "your name + agency you work for"
+    members: 794
 
 
 # Make it better ♥


### PR DESCRIPTION
This PR implements the following **changes:**

- Update Listserv / COP sign-up instructions to promote self-signup vs. email to challenge.gov team
- URL to page that will be changed: https://digital.gov/communities/challenges-prizes/

