### PR TITLE
remove community guidelines footer

### DIFF
--- a/themes/digital.gov/layouts/communities/list.html
+++ b/themes/digital.gov/layouts/communities/list.html
@@ -23,8 +23,8 @@
   </div>
 
 
-  <section class="communities-list">
-    <div class="grid-container grid-container-desktop">
+  <section class="communities-list usa-section">
+    <div class="grid-container-desktop">
       <div class="grid-row tablet-lg:grid-gap-2">
 
         {{/* Gets all communities pages */}}
@@ -49,25 +49,6 @@
           </div>
         {{ end }}
 
-      </div>
-    </div>
-  </section>
-
-  <section class="community-guidelines">
-    <div class="grid-container grid-container-desktop">
-      <div class="grid-row">
-        <div class="grid-col-12 tablet:grid-col-8">
-          <h2>Community Guidelines</h2>
-        </div>
-      </div>
-      <div class="grid-row tablet-lg:grid-gap-4">
-        <div class="grid-col-12 tablet:grid-col-8">
-          <p>Our lawyers wanted to remind you — <em>Members of a Community must use official .gov or .mil email addresses, and understand that they are acting in their official capacities represented through their U.S. government agencies. No commercial communications or endorsements are permitted. All listserv communications are subject to release under the <a href="https://www.foia.gov/">Freedom of Information Act</a> (FOIA).</em></p>
-
-        </div>
-        <div class="grid-col-12 tablet:grid-col-4">
-          <p><strong>For more information on Communities</strong>, or to propose a new inter-agency group, please send an email to <a href="mailto:digitalgovu@gsa.gov?subject=Communities">digitalgovu@gsa.gov</a>.</p>
-        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION


This PR implements the following **changes:**

* removes the extra community guidelines footer


**URL / Link to page**

https://digital.gov/communities/


Before: 
<img width="1133" alt="Screen Shot 2021-01-07 at 3 50 54 PM" src="https://user-images.githubusercontent.com/2197515/104023475-bd1e8800-518f-11eb-8705-d6d7a19b4da0.png">
