### PR TITLE
Use current whitehouse.gov copy instead of an archive

### DIFF
--- a/content/resources/social-media-web-based-interactive-technologies-and-the-paperwork-reduction-act.md
+++ b/content/resources/social-media-web-based-interactive-technologies-and-the-paperwork-reduction-act.md
@@ -14,7 +14,7 @@ Inspired by the goal of promoting flexible and open interactions between federal
 
 Under established principles, the PRA does not apply to many uses of such media and technologies. To engage the public, Federal agencies are expanding their use of social media and webbased interactive technologies. For example, agencies are increasingly using web-based technologies, such as blogs, wikis, and social networks, as a means of “publishing” solicitations for public comment and for conducting virtual public meetings.  This memo explains that certain uses of social media and web-based interactive technologies will be **treated as equivalent** to activities that are currently excluded from the PRA.
 
-<a class="button" style="color: #000000" href="https://obamawhitehouse.archives.gov/sites/default/files/omb/assets/inforeg/SocialMediaGuidance_04072010.pdf">View Social Media, Web-Based Interactive Technologies, and the Paperwork Reduction Act</a>
+<a class="button" style="color: #000000" href="https://www.whitehouse.gov/sites/whitehouse.gov/files/omb/assets/inforeg/SocialMediaGuidance_04072010.pdf">View Social Media, Web-Based Interactive Technologies, and the Paperwork Reduction Act</a>
 
 ## Related Links
 


### PR DESCRIPTION
This small change updates the link for OMB's 2010 PRA social media guidance to use a file hosted on the current administration's whitehouse.gov.
