### PR TITLE
Update on Manage Listserv Instruction

### DIFF
--- a/content/communities/manage-listserv-subscription.md
+++ b/content/communities/manage-listserv-subscription.md
@@ -148,6 +148,8 @@ When using these commands, always:
   </tr>
 </table>
 
+Note that these instructions reference a sample Listserv called _TESTLIST@listserv.gsa.gov_. Just substitute the name of YOUR Listserv (e.g., _CONTENT-MANAGERS-L_@listserv.gsa.gov) whenever you see _TESTLIST_, to apply these instructions to your Listserv.
+
 ### “Out of Office” Messages
 
 Think of the Listserv when setting “out of office” messages. Create a rule to either avoid sending “out of office” message to Listserv groups, or only send an “out of office” to people who’ve directly sent you a personal email. Ask your IT staff if you need help with this.


### PR DESCRIPTION
This PR implements the following **changes:**

* Adding instruction bullet on how to write to an actual LISTSEERV underneath the LISTSERV command instructions example table. I've noticed that folks are sending messages to _TESTLIST_, rather than an actual list. The instruction is stated at the beginning of the page, but folks seem to be navigating directly to the commands and missing the instruction. 

The instruction is: Note that these instructions reference a sample Listserv called TESTLIST@listserv.gsa.gov. Just substitute the name of YOUR Listserv (e.g., CONTENT-MANAGERS-L@listserv.gsa.gov) whenever you see TESTLIST, to apply these instructions to your Listserv.

**URL / Link to page**

https://digital.gov/communities/manage-your-subscription/

