### PR TITLE
Update 2021-02-25-plain-language-and-section-508.md

### DIFF
--- a/content/events/2021/02/2021-02-25-plain-language-and-section-508.md
+++ b/content/events/2021/02/2021-02-25-plain-language-and-section-508.md
@@ -24,6 +24,7 @@ topics:
 authors:
   - bethany-letalien
   - katherine-spivey
+  - alex-wilson
 slug: plain-language-and-section-508
 # zoom, youtube_live, adobe_connect, google
 event_platform: zoom
@@ -42,6 +43,7 @@ The presentation will focus on concerns and opportunities shared by the Section 
 #### Presenter:
 
 * Bethany Letalien, Section 508 Program Manager, U.S. Office of Personnel Management, Office of Communications
+* Alex Wilson, Program Analyst, U.S. General Services Administration, Office of Government-wide Policy
 
 - - -
 

--- a/content/events/2021/02/2021-02-25-plain-language-and-section-508.md
+++ b/content/events/2021/02/2021-02-25-plain-language-and-section-508.md
@@ -3,7 +3,7 @@ title: Plain Language and Section 508
 deck: "Learn what the plain language and accessibility communities share:
   opportunities to help people get and understand information. Find out what you
   can do to help."
-kicker: "Learn how plain language and accessibility concerns intersect. "
+kicker: "Learn how plain language and accessibility concerns intersect"
 summary: Come join us  as we focus on concerns and opportunities shared by the
   Section 508 and plain language communities in Government!
 host: Plain Language Community of Practice
@@ -29,8 +29,8 @@ slug: plain-language-and-section-508
 # zoom, youtube_live, adobe_connect, google
 event_platform: zoom
 primary_image: ""
+
 ---
-- - -
 
 The presentation will focus on concerns and opportunities shared by the Section 508 and plain language communities. Topics will include:
 
@@ -40,10 +40,10 @@ The presentation will focus on concerns and opportunities shared by the Section 
 * Headings, lists, and tables
 * Graphics
 
-#### Presenter:
+## Presenters:
 
-* Bethany Letalien, Section 508 Program Manager, U.S. Office of Personnel Management, Office of Communications
-* Alex Wilson, Program Analyst, U.S. General Services Administration, Office of Government-wide Policy
+* **Bethany Letalien**, Section 508 Program Manager, U.S. Office of Personnel Management, Office of Communications
+* **Alex Wilson**, Program Analyst, U.S. General Services Administration, Office of Government-wide Policy
 
 - - -
 


### PR DESCRIPTION
Adding Alex Wilson for Section 508 CoP as a secondary speaker.

This PR implements the following **changes:**

Adding Alex Wilson to the event page

**https://digital.gov/event/2021/03/10/plain-language-and-section-508/** 

Preview: https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/Gabr1elleKING-patch-1/event/2021/03/10/plain-language-and-section-508/ 