### PR TITLE
Update 2021-02-01-tag-managers-part-2-configuration-framework.md

### DIFF
--- a/content/events/2021/02/2021-02-01-tag-managers-part-2-configuration-framework.md
+++ b/content/events/2021/02/2021-02-01-tag-managers-part-2-configuration-framework.md
@@ -1,6 +1,6 @@
 ---
 title: "Tag Managers Part 2: Configuration Framework"
-deck: Practical Framework for using GTM
+deck: Join the Data Analytics Team as they Provide a Practical Framework for using Google Tag Manager.
 kicker: "DAP Learning Series"
 summary: This session will help DAP users configure and use their tag manager, to augment their reporting on more advanced interactions with their websites.
 host: Data Analytics Program


### PR DESCRIPTION
Updating the deck, removing the google tag manager acronym, adding a period to the deck sentence.

This PR implements the following **changes:**

* deleted the google tag manager acronym
* reworked the deck statement and added a period at the end of the sentence. 

**https://digital.gov/event/2021/03/24/tag-managers-part-2-configuration-framework/*
