### PR TITLE
Remove program author

### DIFF
--- a/content/services/service_mobile-testing-program.md
+++ b/content/services/service_mobile-testing-program.md
@@ -34,7 +34,6 @@ topics:
 # see all authors at https://digital.gov/authors
 authors:
   - jparcell
-  - david-fern
 
 ---
 


### PR DESCRIPTION
This PR implements the following **changes:**

Removes David as an author since he's no longer a point of contact for this program.

**URL / Link to pages**

1. https://digital.gov/services/directory/
1. https://digital.gov/services/mobile-application-testing-program/