### PR TITLE
Add info on BOD 20-01

### DIFF
--- a/content/resources/required-web-content-and-links.md
+++ b/content/resources/required-web-content-and-links.md
@@ -517,8 +517,7 @@ Required by:
 
 - Department of Homeland Security (DHS) Binding Operational Directive 20-01
 
-POLICY
-[DHS Binding Operational Directive 20-01](https://cyber.dhs.gov/bod/20-01/#required-actions)
+POLICY: [DHS Binding Operational Directive 20-01](https://cyber.dhs.gov/bod/20-01/#required-actions)
 
 
 ---

--- a/content/resources/required-web-content-and-links.md
+++ b/content/resources/required-web-content-and-links.md
@@ -499,6 +499,28 @@ A method for reporting evidence of waste, fraud, or abuse to the Inspector Gener
 - (2) a mechanism on the Offices of Inspectors General website by which individuals may anonymously report cases of waste, fraud, or abuse with respect to those Departments, agencies, and commissions.
 {{< / card-policy >}}
 
+## Security
+Agencies must have a way for the public to report potential security vulnerabilities, and explain how the agency will respond to such reports.
+
+- Ensure your site's Security Contact and Organization are current in the [.gov registrar](https://domains.dotgov.gov/)
+- Publish a vulnerability disclosure policy at [agency].gov/vulnerability-disclosure-policy
+
+Suggested link text:
+
+- Vulnerability Disclosure Policy
+
+Required on:
+
+- Your website policies page
+
+Required by:
+
+- Department of Homeland Security (DHS) Binding Operational Directive 20-01
+
+POLICY
+[DHS Binding Operational Directive 20-01](https://cyber.dhs.gov/bod/20-01/#required-actions)
+
+
 ---
 
 _These requirements apply to executive branch departments and agencies and their public websites. Check the specific law or policy to see if it also applies to the judicial or legislative agencies, or intranets._

--- a/content/resources/required-web-content-and-links.md
+++ b/content/resources/required-web-content-and-links.md
@@ -503,21 +503,23 @@ A method for reporting evidence of waste, fraud, or abuse to the Inspector Gener
 Agencies must have a way for the public to report potential security vulnerabilities, and explain how the agency will respond to such reports.
 
 - Ensure your site's Security Contact and Organization are current in the [.gov registrar](https://domains.dotgov.gov/)
-- Publish a vulnerability disclosure policy at [agency].gov/vulnerability-disclosure-policy
+- Publish a vulnerability disclosure policy at [agency].gov/vulnerability-disclosure-policy  
 
-Suggested link text:
+{{< box >}}
+##### Suggested link text:
 
-- Vulnerability Disclosure Policy
+`Vulnerability Disclosure Policy`
 
-Required on:
+##### Required on:
 
 - Your website policies page
 
-Required by:
+##### Required by:
 
 - Department of Homeland Security (DHS) Binding Operational Directive 20-01
-
-POLICY: [DHS Binding Operational Directive 20-01](https://cyber.dhs.gov/bod/20-01/#required-actions)
+{{< / box >}}
+{{< card-policy src="https://cyber.dhs.gov/bod/20-01/#required-actions" kicker="Policy" title="DHS Binding Operational Directive 20-01">}}
+{{< / card-policy >}}
 
 
 ---


### PR DESCRIPTION
This PR implements the following **changes:**

DHS issued a new binding operational directive in Sept 2020 requiring agencies to create a new agency.gov/vulnerability-disclosure-policy page.
We'll need to add guidance for agencies on how to implement this directive.

The DHS BOD 20-01 page (https://cyber.dhs.gov/bod/20-01/) contains the implementation instructions.

Also coordinate w/USWDS team so they can update the Identifier component.


**URL / Link to page**
https://digital.gov/resources/required-web-content-and-links/?dg

Closes #3456 

