### PR TITLE
Update Netlify CMS

### DIFF
--- a/themes/digital.gov/static/workflow/config.yml
+++ b/themes/digital.gov/static/workflow/config.yml
@@ -12,7 +12,7 @@ backend:
   base_url: https://federalistapp.18f.gov
   auth_endpoint: external/auth/github
   preview_context: federalist/build
-  use_graphql: true
+  use_graphql: false
   branch: main
   open_authoring: true
   squash_merges: true


### PR DESCRIPTION
This PR implements the following **changes:**

* In the Workflow tool, update Netlify CMS setting `use_graphql` to false.

