### PR TITLE
Added videos

### DIFF
--- a/content/events/2021/04/2021-04-20-social-media-spring-session-2021.md
+++ b/content/events/2021/04/2021-04-20-social-media-spring-session-2021.md
@@ -25,10 +25,12 @@ authors:
 slug: social-media-spring-session-2021
 # zoom, youtube_live, adobe_connect, google
 event_platform: zoom
----
-On April 28th and 29th, 2021, the SocialGov Community of Practice will bring federal government experts together to provide updates on social media advertising and best practices.
 
-There will be one session each day. You will need to register for each one to receive the correct Zoom for Government link and conference details. Below is a short description of each session.
+---
+
+On April 28th and 29th, 2021, the SocialGov Community of Practice brought federal government experts together to provide updates on social media advertising and best practices.
+
+There was one session each day. Below are the videos and a short description for each session.
 
 ### Wednesday, April 28
 

--- a/content/events/2021/04/2021-04-20-social-media-spring-session-2021.md
+++ b/content/events/2021/04/2021-04-20-social-media-spring-session-2021.md
@@ -41,6 +41,8 @@ In this session you will hear from the following speakers:
 
 The event on April 28th will showcase how to conduct paid social media advertising campaigns in the federal government. It will detail justifications, contract language, campaign management, and reporting techniques so that civil servants will better understand the advantages of paid social media advertising and how they might be able to conduct paid social media campaigns at their agency.
 
+{{< youtube Wj5SP_Ap0n8 >}}
+
 ### Thursday, April 29
 
 #### Second Session (02:00 pm - 03:00 pm, ET)
@@ -60,6 +62,9 @@ In this session you will hear from the following speakers:
 ##### 2:30 pm - 03:00 pm, ET
 
 **Updates in Government Podcasting.** You’ve spent months planning your content strategy and have a great show in the works – but how do you get people to actually listen? It might seem obvious, but building a loyal audience for your podcast takes time and effort. In this session, Tanner Iskra of VA, and Dominique Gebru of FAA will share what works.
+
+{{< youtube 1xVZkdNpaow >}}
+
 - - -
 
 *This talk is hosted by the [SocialGov Community of Practice (CoP)](https://digital.gov/communities/social-media/). This community hosts educational and networking events, and provides free resources to government employees with the goal of improving social media and new digital media outreach efforts at every level of government. Social media managers face many of the same challenges – join SocialGov to connect with others who get it.*


### PR DESCRIPTION
YouTube videos from both Spring SocialGov sessions now added to the event page.


**https://digital.gov/event/2021/04/28/social-media-spring-session-2021/**

