### PR TITLE
Remove link to Accessible Joe

### DIFF
--- a/content/resources/improving-the-accessibility-of-social-media-in-government.md
+++ b/content/resources/improving-the-accessibility-of-social-media-in-government.md
@@ -186,13 +186,10 @@ Digital Government University (DGU) offers a series of trainings based on these 
 
 ### Other Web resources
 
-* [a11yTips](http://dboudreau.tumblr.com/)
 * [WebAIM](http://webaim.org/)
 * [Usability.gov](http://www.usability.gov/)
-* [DANYA T.H.I.S. Social Media Accessibility Google Hangout](https://www.youtube.com/watch?v=DKXXKtFRNlQ)
 * [W3 Accessibility Testing](http://www.w3.org/wiki/Accessibility_testing)
 * [WAVE Accessibility Testing](http://wave.webaim.org/)
-* [Ask JAN SNAP Tool](http://askjan.org/bulletins/SNAPTool.htm)
 * [W3 Web Accessibility Initiative](http://www.w3.org/WAI/)
 
 <h2 id="provide" style="padding-top: 50px">

--- a/content/resources/improving-the-accessibility-of-social-media-in-government.md
+++ b/content/resources/improving-the-accessibility-of-social-media-in-government.md
@@ -187,7 +187,6 @@ Digital Government University (DGU) offers a series of trainings based on these 
 ### Other Web resources
 
 * [a11yTips](http://dboudreau.tumblr.com/)
-* [Accessible Joe](http://accessiblejoe.com/tools/)
 * [WebAIM](http://webaim.org/)
 * [Usability.gov](http://www.usability.gov/)
 * [DANYA T.H.I.S. Social Media Accessibility Google Hangout](https://www.youtube.com/watch?v=DKXXKtFRNlQ)


### PR DESCRIPTION
The links on this page need to be updated https://digital.gov/resources/improving-the-accessibility-of-social-media-in-government/

Sadly Joseph Karr O’Connor died and this link no ([Accessible Joe](http://accessiblejoe.com/tools/)) longer works. I thought about pointing back to the archive.org page, but really that's not useful for information that was out of date at the time of the last social media update.

This PR implements the following **changes:**

Removes the link to Joseph's post and some of the other posts that are outdated.  Anything not updated since 2014 about social media can be assumed to be irrelevant. 

We're building out a resource here https://accessibility.civicactions.com/guide/social-media which we would love to get more contributions to.  Government resources like this one is valuable. 

