### PR TITLE
AS_Redirect to web-analytics-and-optimization/

### DIFF
--- a/content/communities/a-b-testing.md
+++ b/content/communities/a-b-testing.md
@@ -11,6 +11,7 @@ summary: "We encourage data-driven decisions and continuous optimization through
 # Redirects: enter the path of the URL that you want redirected to this page
 aliases:
   - /communities/web-analytics-and-optimization/
+  - /communities/a-b-testing-community
 
 # see all topics at https://digital.gov/topics
 topics:

--- a/content/communities/a-b-testing.md
+++ b/content/communities/a-b-testing.md
@@ -11,6 +11,7 @@ summary: "We encourage data-driven decisions and continuous optimization through
 # Redirects: enter the path of the URL that you want redirected to this page
 aliases:
   - /communities/a-b-testing-community
+  - /communities/web-analytics-and-optimization/
 
 # see all topics at https://digital.gov/topics
 topics:

--- a/content/communities/a-b-testing.md
+++ b/content/communities/a-b-testing.md
@@ -10,7 +10,6 @@ summary: "We encourage data-driven decisions and continuous optimization through
 
 # Redirects: enter the path of the URL that you want redirected to this page
 aliases:
-  - /communities/a-b-testing-community
   - /communities/web-analytics-and-optimization/
 
 # see all topics at https://digital.gov/topics


### PR DESCRIPTION
This PR implements the following **changes:**

* internal redirect in the A/B page front matter to the  web-analytics-and-optimization to remove it from the Communities page


**URL / Link to page**

https://digital.gov/communities/a-b-testing-community/
https://digital.gov/communities/web-analytics-and-optimization/

