### PR TITLE
WIP: Several small copy edits for site scanning pages 

### DIFF
--- a/content/guides/site-scanning/learn-more-about-the-program.md
+++ b/content/guides/site-scanning/learn-more-about-the-program.md
@@ -8,8 +8,8 @@ aliases:
   - /guide/site-scanning/learn-more-about-the-program/
 ---
 
-The Site Scanning program builds on a series of [earlier projects](https://github.com/18F/site-scanning-documentation/blob/main/about/project-management/project-history.md) to offer real-time, automatic data about all federal websites.  It begins by taking the [.gov registry export](https://github.com/GSA/data/tree/master/dotgov-domains) and joins several additional data sources to aggregate a list of subdomains within those domains.  The result is approximately 25,000 websites on 1,200 domains.  
+The Site Scanning program builds on a series of [earlier projects](https://github.com/GSA/site-scanning-documentation/blob/main/about/project-management/project-history.md) to offer real-time, automatic data about all federal websites.  It begins by taking the [.gov registry export](https://github.com/cisagov/dotgov-data/blob/main/current-federal.csv) and joins several additional data sources to aggregate a list of subdomains within those domains.  The result is approximately 25,000 websites on 1,200 domains.  
 
 The system then runs a series of scans against the complete list of websites daily, making the results [available as open data](/guide/site-scanning/data/). While many users want the data in a spreadsheet or machine-readable file, we've also [created an API](https://open.gsa.gov/api/site-scanning-api/) that allows interactive access to the data.  
 
-To learn more about this program, be sure to check out the [documentation repository](https://github.com/18F/site-scanning-documentation). To get in touch with the team, [file an issue](https://github.com/18F/site-scanning/issues) or email us at site-scanning@gsa.gov.  
+To learn more about this program, be sure to check out the [documentation repository](https://github.com/GSA/site-scanning-documentation). To get in touch with the team, [file an issue](https://github.com/GSA/site-scanning/issues) or email us at site-scanning@gsa.gov.  


### PR DESCRIPTION
This PR implements the following **changes:**

We're do a bit of light copy-editing and link update on the four /site-scanning/ pages.  

* https://digital.gov/guides/site-scanning/
* https://digital.gov/guides/site-scanning/data/
* https://digital.gov/guides/site-scanning/learn-more-about-the-program/
* https://digital.gov/guides/site-scanning/understand-the-data/

We'll update this PR and holler in slack when it's ready to merge.

