### PR TITLE
Update 18f-guide-product-management.md

### DIFF
--- a/content/resources/18f-guide-product-management.md
+++ b/content/resources/18f-guide-product-management.md
@@ -22,6 +22,6 @@ source: '18f'
 
 # What is the URL for this product or service?
 # Note: We'll add a ?dg to the end of the URL in the code for tracking purposes
-source_url: 'https://product-guide.18f.gov/we-do-product-well/'
+source_url: 'https://product-guide.18f.gov/'
 
 ---


### PR DESCRIPTION
In the page:
https://digital.gov/topics/agile/ 

This PR implements the following changes:
Within the https://digital.gov/topics/agile/ page, the hyperlink for 18F guide to product management (https://product-guide.18f.gov/we-do-product-well/%7B) has a 404 error / is broken. Updating to correct link: https://product-guide.18f.gov/

**https://digital.gov/topics/agile/ **
