### PR TITLE
Added "Acronym"

### DIFF
--- a/content/authors/whitney-levandusky/_index.md
+++ b/content/authors/whitney-levandusky/_index.md
@@ -1,19 +1,55 @@
 ---
+
+# Your author profile page lives at:
+# https://digital.gov/authors/whitney-levandusky
+
 display_name: Whitney Levandusky
 first_name: Whitney
 last_name: Levandusky
-# List your pronoun(s) if you want them displayed alongside your name.
-# If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: She/her
-# If you include an email address, it will be displayed on your profile page
-email: wlev@copyright.gov
-# Keep it under 50 words and only one paragraph
-bio: Whitney Levandusky is an Attorney-Advisor for the Office of Public Information and Education, where she advises the Public Information Office, teaches in the Copyright Academy, manages various administrative functions, and provides legal guidance for external facing Office materials. She joined the Copyright Office in 2015.
-# e.g. U.S. General Services Administration
-agency_full_name: U.S. Copyright Office
-# Agency Acronym [e.g., GSA]
-agency: Copyright Office
+
+# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
+# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
+# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
+# Examples: they/them, she/her, or he/him
+pronoun: "she/her"
+
+# slug — the specific user-id for an author.
 slug: whitney-levandusky
+
+# if you include an email address, it will be displayed on your profile page
+email: "wlev@copyright.gov"
+
+# Bio — keep it under 50 words
+bio: "Whitney Levandusky is an attorney advisor for the Office of Public Information and Education (PIE) in the U.S. Copyright Office, where she advises the Public Information Office, teaches in the Copyright Academy, manages various administrative functions, and provides legal guidance for external-facing Office materials. She joined the Copyright Office in 2015."
+
+# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
+bio_url: "https://digital.gov/about/"
+
+# Agency Full Name [e.g. U.S. General Services Administration]
+agency_full_name: "U.S. Copyright Office"
+
+# Agency Acronym [e.g., GSA]
+agency: "USCO"
+
 # Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: Baltimore, Maryland
+location: "Baltimore, Maryland"
+
+# Your GitHub username [e.g. 'jeremyzilar']
+# See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
+github: ""
+
+# Profile Photo
+# See [URL] for a full list of profile photo options
+# github-photo — requires a github ID
+profile_source: ""
+
+# Professional Social Media [e.g., Digital_Gov]
+twitter: ""
+facebook: ""
+linkedin: ""
+YouTube: ""
+
+# For more information on managing your author page,
+# see https://workflow.digital.gov/authors
+
 ---

--- a/content/authors/whitney-levandusky/_index.md
+++ b/content/authors/whitney-levandusky/_index.md
@@ -11,6 +11,8 @@ email: wlev@copyright.gov
 bio: Whitney Levandusky is an Attorney-Advisor for the Office of Public Information and Education, where she advises the Public Information Office, teaches in the Copyright Academy, manages various administrative functions, and provides legal guidance for external facing Office materials. She joined the Copyright Office in 2015.
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. Copyright Office
+# Agency Acronym [e.g., GSA]
+agency: Copyright Office
 slug: whitney-levandusky
 # Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
 location: Baltimore, Maryland


### PR DESCRIPTION
Because the U.S. Copyright Office doesn't have an acronym, I didn't originally include an acronym in the workflow. But it looks inconsistent with the other authors on the SocialGov Summer event page, so I added "Copyright Office" to the acronym line so least something appears on the event page.


**https://digital.gov/authors/whitney-levandusky/**
**https://digital.gov/event/2021/08/25/socialgov-summer-sessions-2021/**


