### PR TITLE
Use main branch for action

### DIFF
--- a/.github/workflows/pr-preview-link.yml
+++ b/.github/workflows/pr-preview-link.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Comment Pull Request
-        uses: thollander/actions-comment-pull-request@master
+        uses: thollander/actions-comment-pull-request@main
         with:
           message: ':mag: [__Preview in Federalist__](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/${{ github.head_ref }})'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The [actions-comment-pull-request](https://github.com/thollander/actions-comment-pull-request) action updated its primary branch to `main` from `master`. This updates the github action to reference the proper branch.