### PR TITLE
Update 2021-09-14-2021-federal-plain-language-summit.md

### DIFF
--- a/content/events/2021/09/2021-09-14-2021-federal-plain-language-summit.md
+++ b/content/events/2021/09/2021-09-14-2021-federal-plain-language-summit.md
@@ -67,7 +67,7 @@ In this session you will hear from the following speaker:
 
 - - -
 
-### How Feedback and Partnerships Helped IRS Respond to COVID-19 (11:30 am - 12:00 pm, ET)
+### How Feedback and Plain Language Helped the IRS Respond to COVID-19 (11:30 am - 12:00 pm, ET)
 
 José Vejarano explains how listening to feedback and embracing plain language best practices helped the Internal Revenue Service respond to COVID-19.
 


### PR DESCRIPTION
Updating the title of the IRS session per Kathryn's (from IRS) request

This PR implements the following **changes: Email from Kathryn H on 09/30 - 
"Hi,
I wanted to see if you could help make a small edit to this page: https://digital.gov/event/2021/09/21/2021-federal-plain-language-summit/
Can you change the title of Jose’s presentation to read: How Feedback and Plain Language Helped the IRS Respond to COVID-19

**https://digital.gov/event/2021/09/21/2021-federal-plain-language-summit/**