### PR TITLE
Added another video

### DIFF
--- a/content/events/2021/06/2021-06-03-2021-user-experience-summit.md
+++ b/content/events/2021/06/2021-06-03-2021-user-experience-summit.md
@@ -246,6 +246,8 @@ In this session you will hear from the following speakers:
 * **Randy Hart** &mdash; 18F, GSA TTS
 * **Karyn Lu** &mdash; Colorado Digital Service
 
+{{< youtube _zu5htrW8QA >}}
+
 - - -
 
 ## You’re a Human-Centered Designer! Trust Me! (3:00 pm - 4:00 pm, ET)


### PR DESCRIPTION
To the UX Summit event page, added the YouTube video for session: Iterating on a State-Level Digital Service Team: Colorado’s Year One Self-Retro.

**https://digital.gov/event/2021/06/22/2021-user-experience-summit/**

