### PR TITLE
Update 2021-11-16-results-of-the-2021-federal-report-card.md

### DIFF
--- a/content/events/2021/11/2021-11-16-results-of-the-2021-federal-report-card.md
+++ b/content/events/2021/11/2021-11-16-results-of-the-2021-federal-report-card.md
@@ -47,6 +47,8 @@ This year, the judges focused on the main Freedom of Information Act (FOIA) requ
 * **Katherine Spivey** — U.S. General Services Administration (GSA)
 * **Katina Stapleton** — U.S. Department of Education (ED)
 
+[View the slides](https://digital.gov/files/results-of-the-fplrc.pptx) (PowerPoint, 1.4 MB, 9 pages)
+
 ### Related Resources
 
 * [2021 Federal Plain Language Report Card](https://centerforplainlanguage.org/2021-federal-plain-language-report-card/) 


### PR DESCRIPTION
Adding PPTX to the event page

This PR implements the following **changes:**

* Adding the powerpoint presentation to the events page


**(https://digital.gov/event/2021/12/08/results-of-the-2021-federal-report-card/)**