### PR TITLE
AS_DevOps Redirect

### DIFF
--- a/content/communities/devops.md
+++ b/content/communities/devops.md
@@ -7,6 +7,7 @@ date: 2019-12-12 19:00:00 -0500
 title: "DevOps"
 deck: "Operating rapidly changing resilient systems at scale"
 summary: "The practice of operations and development staff participating in the entire service lifecycle to operate rapidly changing resilient systems at scale."
+redirectto: https://github.com/18F/DevOps-Community-of-Practice/wiki/DevOps-Community-of-Practice
 
 # see all topics at https://digital.gov/topics
 topics:


### PR DESCRIPTION
This PR implements the following **changes:**

* DevOps CoP redirect to https://github.com/18F/DevOps-Community-of-Practice/wiki/DevOps-Community-of-Practice


**URL / Link to page**

https://digital.gov/communities/devops/

