### PR TITLE
Update onrr-card-issue-2021-ux-summit.yml

### DIFF
--- a/data/images/onrr-card-issue-2021-ux-summit.yml
+++ b/data/images/onrr-card-issue-2021-ux-summit.yml
@@ -10,4 +10,4 @@ height   : 553
 format   : png
 credit   : "" 
 caption  : "" 
-alt      : "" 
+alt      : "Screenshot showing how participants moving the card is tracked in the GitHub issue for the card. It shows an open issue in GitHub for the card. The title of the issue is Freedom of Information Act (FOIA). The updates in the issue show that I have put the card in the Uncategorized category for several participants and that the nrrdparticipant account we use for participants moved the card a couple of times in the GitHub project we used to test the process." 


### PR DESCRIPTION
This PR implements the following **changes:**

Added alt text for `uid: onrr-card-issue-2021-ux-summit` on https://digital.gov/images/ 
 ~ didn't work in [previous pull request; some sort of branch conflict](https://github.com/GSA/digitalgov.gov/pull/4437).

**URL / Link to page**
https://digital.gov/images/ 

Preview: https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/alt-card-issue/images/ 

