### PR TITLE
Removing Jenn as an author

### DIFF
--- a/content/communities/web-analytics-and-optimization.md
+++ b/content/communities/web-analytics-and-optimization.md
@@ -19,7 +19,6 @@ aliases:
 # See all authors at https://digital.gov/authors
 authors:
   - kelley-holden
-  - jenn-wingerberg
   - tlowden
 slug: web-analytics-and-optimization
 # Controls how this page appears across the site


### PR DESCRIPTION
This PR implements the following **changes:**

* removing Jenn as an author 


**URL / Link to page**

https://digital.gov/communities/web-analytics-and-optimization/

