### PR TITLE
update spelling of 'parallax'

### DIFF
--- a/content/resources/best-practices-for-writing-for-accessible.md
+++ b/content/resources/best-practices-for-writing-for-accessible.md
@@ -79,7 +79,7 @@ When developing accessible content, authors need to think about how users will a
 
 *DON'T*
 
-1. Use gifs or parralyx features to avoid visual strain.
+1. Use gifs or parallax features to avoid visual strain.
   
 ## Color Contrast
 


### PR DESCRIPTION
This PR implements the following **changes:**

Fixes spelling of 'parallax'


[Best Practices for Writing for the Accessible Web](https://digital.gov/resources/best-practices-for-writing-for-accessible/?dg)

