### PR TITLE
removing leads until new board is added

### DIFF
--- a/content/communities/federal-communicators-network.md
+++ b/content/communities/federal-communicators-network.md
@@ -16,14 +16,7 @@ topics:
 
 # See all authors at https://digital.gov/authors
 authors:
-  - jamie-stark
-  - wendy-wagner-smith
-  - brett-hollowell
-  - tracey-batacan
-  - jeku-j-r-arce
-  - holland-gormley
-  - lisa-novak
-  - catie-miller
+
 
 community_list:
   - platform: listserv


### PR DESCRIPTION
This PR implements the following **changes:**

* waiting for new author pages for new board 

https://digital.gov/communities/federal-communicators-network/

