### PR TITLE
AS_CitSci redirect

### DIFF
--- a/content/communities/crowdsourcing-and-citizen-science.md
+++ b/content/communities/crowdsourcing-and-citizen-science.md
@@ -7,7 +7,7 @@ date: 2015-09-29 2:17:00 -0500
 title: "Crowdsourcing and Citizen Science"
 deck: ""
 summary: "We work across government develop best practices for designing, implementing, and evaluating crowdsourcing and citizen science initiatives."
-redirectto: https://www.citizenscience.gov/about/community-of-practice/#
+redirectto: https://www.citizenscience.gov/about/community-of-practice/
 # Redirects: enter the path of the URL that you want redirected to this page
 aliases:
   - /federal-crowdsourcing-and-citizen-science/

--- a/content/communities/crowdsourcing-and-citizen-science.md
+++ b/content/communities/crowdsourcing-and-citizen-science.md
@@ -7,7 +7,7 @@ date: 2015-09-29 2:17:00 -0500
 title: "Crowdsourcing and Citizen Science"
 deck: ""
 summary: "We work across government develop best practices for designing, implementing, and evaluating crowdsourcing and citizen science initiatives."
-
+redirectto: https://www.citizenscience.gov/about/community-of-practice/#
 # Redirects: enter the path of the URL that you want redirected to this page
 aliases:
   - /federal-crowdsourcing-and-citizen-science/


### PR DESCRIPTION
This PR implements the following **changes:**

Redirecting citsci community to its own page

**URL / Link to page**

https://digital.gov/communities/crowdsourcing-citizen-science/ 

TB saved to http://web.archive.org/ 