### PR TITLE
Add alias for old eCPIC URL Update folio.md

### DIFF
--- a/content/services/folio.md
+++ b/content/services/folio.md
@@ -6,6 +6,9 @@ source: "digitalgov"
 logo: 'digitalgov'
 weight: 1
 
+aliases:
+  - /services/electronic-capital-planning-and-investment-control-ecpic/
+
 ---
 
 <div class="deck"><p>The GSA Office of Government-wide Policy is proud to announce the successful launch of its newest IT Portfolio management tool, Folio. Folio, designed by the Federal eCPIC Steering Committee (FESCOM), is the successor to the Electronic Capital Planning and Investment Control (eCPIC) application, which served as the premier government-wide shared service for over 15 years! This modern application provides federal agencies with new benefits through Folio’s improved user interface, flexible data collection capabilities, and modern technology stack.</p></div>


### PR DESCRIPTION
This PR implements the following **changes:**

* insert your summary of your request here, add more bullets as needed


**URL / Link to page**

Preview
https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/ecpic-alias/services/electronic-capital-planning-and-investment-control-ecpic/ 

redirects to

https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/ecpic-alias/services/folio/ 

