### PR TITLE
newsletter confirmation message update

### DIFF
--- a/themes/digital.gov/layouts/partials/core/newsletter-signup.html
+++ b/themes/digital.gov/layouts/partials/core/newsletter-signup.html
@@ -17,8 +17,7 @@
           <script>
             hbspt.forms.create({
             portalId: "1962994",
-            formId: "f8c8ff73-dbc9-4242-90e4-e8cbcee02f6a",
-            cssRequired: ".submitted-message { color: #f0f0f0;}"
+            formId: "f8c8ff73-dbc9-4242-90e4-e8cbcee02f6a"
           });
           </script>
         </div>

--- a/themes/digital.gov/layouts/partials/core/newsletter-signup.html
+++ b/themes/digital.gov/layouts/partials/core/newsletter-signup.html
@@ -17,7 +17,8 @@
           <script>
             hbspt.forms.create({
             portalId: "1962994",
-            formId: "f8c8ff73-dbc9-4242-90e4-e8cbcee02f6a"
+            formId: "f8c8ff73-dbc9-4242-90e4-e8cbcee02f6a",
+            cssRequired: ".submitted-message { color: #f0f0f0;}"
           });
           </script>
         </div>

--- a/themes/digital.gov/src/scss/new/_newsletter-signup.scss
+++ b/themes/digital.gov/src/scss/new/_newsletter-signup.scss
@@ -117,6 +117,18 @@
       }
 
     }
+    .hbspt-form{
+      div{
+        @include u-margin-top('105');
+        @include u-font('sans', 'lg');
+        @include u-text('light');
+        @include u-text('white');
+        @include u-line-height('sans', 3);
+        strong{
+          @include u-text('bold');
+        }
+      }
+    }
   }
 }
 //


### PR DESCRIPTION
This PR implements the following **changes:**

* Updated newsletter confirmation message white text on black background [Newsletter Confirmation Message Difficult to Read #3539](https://github.com/GSA/digitalgov.gov/issues/3539)

Test Steps:
1. Navigate to bottom of page where news letter resides to the text, "Join 60,000 others in government and sign-up for our newsletter..."
2. Enter a valid email in the Email* textbox
3. Click submit
4. See legible confirmation message reading, "Thanks for subscribing! Welcome to the community!"