### PR TITLE
Removal of past events from community pages 

### DIFF
--- a/themes/digital.gov/layouts/communities/single.html
+++ b/themes/digital.gov/layouts/communities/single.html
@@ -132,8 +132,7 @@
               {{- .Content -}}
             </div>
               <div class="community_events">
-              {{- partial "core/get-upcomingevents" . -}}
-              {{- partial "core/get-pastevents" . -}}              
+              {{- partial "core/get-upcomingevents" . -}}         
             </div>
             
             <div class="Community_conduct">


### PR DESCRIPTION
This PR implements the following **changes:**

Removal of past events from community single page template until a more accurate delivery of past events can be provided to specific communities

**Test Steps**
1. Go to the /communities page
2. Select a community
3. You should no longer see Past Events showing on page (see screenshot below)

![PastEvents-Community-Pages-Before-Removal](https://user-images.githubusercontent.com/33358475/154351909-51fe6358-b59f-4fc2-86c0-7e6f93aa6264.png)

