### PR TITLE
Update 2017-10-12-dap-learning-series-visualizing-analytics-data-part…

### DIFF
--- a/content/events/2017/10/2017-10-12-dap-learning-series-visualizing-analytics-data-part-2.md
+++ b/content/events/2017/10/2017-10-12-dap-learning-series-visualizing-analytics-data-part-2.md
@@ -38,8 +38,10 @@ youtube_id: TQ2CXlEY3qw
 # Redirects: enter the path of the URL that you want redirected to this page
 aliases: 
   - /event/online-dap-learning-series-visualizing-analytics-data-part-2/
+  - /event/dap-learning-series-visualizing-analytics-data-in-excel/
 
 # Make it better ♥
+
 ---
 
 ## About the training
@@ -54,14 +56,12 @@ There are both paid and free tools where you can create dashboards with logos, c
 - How to style and size charts, editing font, color, placement, etc
 - How to embed a dashboard you created into a web page
 
----
-
 ### Related Resources
 
 * [Guide to the Digital Analytics Program](https://digital.gov/guides/dap/)
 * [DAP Learning Series Recording – Visualizing Analytics Data Part 1](https://www.youtube.com/watch?v=HSJq7OTaF0Q) 
 * [DAP Learning Series Recording – Visualizing Analytics Data Part 2](https://www.youtube.com/watch?v=TQ2CXlEY3qw) 
-* [DAP Playlist - Youtube](https://www.youtube.com/playlist?list=PLd9b-GuOJ3nEz1NYl66orgVZIu17laKba)
+* [DAP Playlist - YouTube](https://www.youtube.com/playlist?list=PLd9b-GuOJ3nEz1NYl66orgVZIu17laKba)
 
 ## Presenters
 

--- a/content/events/2017/10/2017-10-12-dap-learning-series-visualizing-analytics-data-part-2.md
+++ b/content/events/2017/10/2017-10-12-dap-learning-series-visualizing-analytics-data-part-2.md
@@ -54,6 +54,15 @@ There are both paid and free tools where you can create dashboards with logos, c
 - How to style and size charts, editing font, color, placement, etc
 - How to embed a dashboard you created into a web page
 
+---
+
+### Related Resources
+
+* [Guide to the Digital Analytics Program](https://digital.gov/guides/dap/)
+* [DAP Learning Series Recording – Visualizing Analytics Data Part 1](https://www.youtube.com/watch?v=HSJq7OTaF0Q) 
+* [DAP Learning Series Recording – Visualizing Analytics Data Part 2](https://www.youtube.com/watch?v=TQ2CXlEY3qw) 
+* [DAP Playlist - Youtube](https://www.youtube.com/playlist?list=PLd9b-GuOJ3nEz1NYl66orgVZIu17laKba)
+
 ## Presenters
 
 **Freddie Blicher** is a Program Analyst on the DAP team. He has 10 years experience managing and implementing web analytics tools on websites and mobile apps for Hilton, Audi, Macy’s, Marriott International and Ritz-Carlton. He specializes in implementation, reporting and analysis using Google Analytics, Adobe, IBM Coremetrics and Webtrends analytics tools.


### PR DESCRIPTION
…-2.md

This PR implements the following **changes:**

*Added related resources to DAP Learning Series 2 page

URL: https://digital.gov/event/2017/10/12/online-dap-learning-series-visualizing-analytics-data-part-2/ 

**Preview** https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/Gabr1elleKING-patch-28/event/2017/10/12/online-dap-learning-series-visualizing-analytics-data-part-2/ 

**Note**: `/event/dap-learning-series-visualizing-analytics-data-in-excel/` and `/event/online-dap-learning-series-visualizing-analytics-data-part-2/` redirect to the current Part 2 page above