### PR TITLE
Update _index.md

### DIFF
--- a/content/authors/michael-mule/_index.md
+++ b/content/authors/michael-mule/_index.md
@@ -4,7 +4,7 @@
 
 # slug — the specific user-id for an author.
 slug: michael-mule
-display_name: "Michael Mul&#233;"
+display_name: "Michael Mul&eacute;"
 first_name: "Michael"
 last_name: "Mul&eacute;"
 

--- a/content/authors/michael-mule/_index.md
+++ b/content/authors/michael-mule/_index.md
@@ -4,7 +4,7 @@
 
 # slug — the specific user-id for an author.
 slug: michael-mule
-display_name: "Michael Mul&eacute;"
+display_name: "Michael Mulé"
 first_name: "Michael"
 last_name: "Mul&eacute;"
 

--- a/content/authors/michael-mule/_index.md
+++ b/content/authors/michael-mule/_index.md
@@ -6,7 +6,7 @@
 slug: michael-mule
 display_name: "Michael Mul&#233;"
 first_name: "Michael"
-last_name: "Mul&#233;"
+last_name: "Mul&eacute;"
 
 # List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
 pronoun: ""


### PR DESCRIPTION
Using HTML Entity code, `Mul&#233;` displays ok as `Mulé` on the Author page https://digital.gov/authors/michael-mule/ 
but not in the Event page sidebar listing https://digital.gov/event/2022/02/24/language-connections-tips-to-create-maintain-and-present-non-english-digital-content/ 

The numerical Entity is used in `display_name` and `last_name` in the front matter 
~ would alpha `&eacute;` work better? changed to `Mul&eacute;` in `last_name` to test

This PR implements the following **changes:**

* insert your summary of your request here, add more bullets as needed


**URL / Link to page**

<!-- Link to the page that will be changed -->
<!-- Delete this section if not needed -->

