### PR TITLE
Update rpa-community.md

### DIFF
--- a/content/communities/rpa-community.md
+++ b/content/communities/rpa-community.md
@@ -14,7 +14,6 @@ topics:
 
 # see all authors at https://digital.gov/authors
 authors:
-  - james-gregory
   - gabrielle-perret
 
 # Page weight: controls how this page appears across the site
@@ -45,24 +44,7 @@ The CoP helps agencies convert RPA enthusiasm into action. Specifically, the CoP
 
 ## Who We Are
 
-The RPA CoP comprises leaders across the federal government who share a passion for RPA.
-
-**Executive Sponsor**  
-Gerard Badorrek, General Services Administration
-
-**Community Lead**  
-James Gregory, General Services Administration: [james2.gregory@gsa.gov](mailto:james2.gregory@gsa.gov)
-
-**Management Committee**  
-Anju Anand, National Science Foundation  
-Kyle Brooks, Department of State  
-Christine Gex, National Aeronautics and Space Administration  
-Lattrice Goldsby, United States Department of Agriculture  
-Russell Kuehn, Social Security Administration  
-Michael Levinson, Army  
-Erica Thomas, Office of the Under Secretary of Defense  
-Paul Weekley, Department of the Treasury  
-Francis Wood, Defense Logistics Agency  
+The RPA CoP comprises leaders across the federal government who share a passion for RPA.  
 
 ## Resources
 


### PR DESCRIPTION
Removing outdated contacts

This PR implements the following **changes:**

* Removed author, James Gregory - no longer in government. Removed contacts under the, "who we are section" of the page. Gerard and James G. no longer in government. The RPA members of the committee are out of date.

**[URL / Link to page](https://digital.gov/communities/rpa/)**

