### PR TITLE
Updated link

### DIFF
--- a/content/guides/dap/_index.md
+++ b/content/guides/dap/_index.md
@@ -32,7 +32,7 @@ aliases:
 **DAP is required:** 
 On November 8, 2016, the [Office of Management and Budget](https://www.whitehouse.gov/omb/) (OMB) released a memorandum on [Policies for Federal Agency Public Websites and Digital Services](https://www.whitehouse.gov/sites/whitehouse.gov/files/omb/memoranda/2017/m-17-06.pdf) (PDF, 1.2 MB, 18 pages), which requires executive branch federal agencies to implement the DAP JavaScript code on all public facing federal websites. 
 
-{{< card-policy src="https://www.whitehouse.gov/sites/whitehouse.gov/files/omb/memoranda/2017/m-17-06.pdf" kicker="Policy" title="**OMB M-17-06**: Policies for Federal Agency Public Websites and Digital Services" pdf="(PDF, 1.2 MB, 18 pages, November 2016)" >}}
+{{< card-policy src="https://obamawhitehouse.archives.gov/sites/default/files/omb/memoranda/2017/m-17-06.pdf" kicker="Policy" title="**OMB M-17-06**: Policies for Federal Agency Public Websites and Digital Services" pdf="(PDF, 1.2 MB, 18 pages, November 2016)" >}}
 
 **2. Use Analytics and User Feedback to Manage Websites and Digital Services**
 


### PR DESCRIPTION


This PR implements the following **changes:**

* OMB memo linked to a non-existent page on the current whitehouse.gov site. I have corrected the link to point at the Obama archive site


**URL / Link to page**

https://digital.gov/guides/dap/

