### PR TITLE
replace package jsonlint with jsonlint-mod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3422,12 +3422,6 @@
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
       "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
     },
-    "has-color": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
-      "dev": true
-    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -4165,14 +4159,15 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "jsonlint": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.3.tgz",
-      "integrity": "sha512-jMVTMzP+7gU/IyC6hvKyWpUU8tmTkK5b3BPNuMI9U8Sit+YAWLlZwB6Y6YrdCxfg2kNz05p3XY3Bmm4m26Nv3A==",
+    "jsonlint-mod": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/jsonlint-mod/-/jsonlint-mod-1.7.6.tgz",
+      "integrity": "sha512-oGuk6E1ehmIpw0w9ttgb2KsDQQgGXBzZczREW8OfxEm9eCQYL9/LCexSnh++0z3AiYGcXpBgqDSx9AAgzl/Bvg==",
       "dev": true,
       "requires": {
-        "JSV": "^4.0.x",
-        "nomnom": "^1.5.x"
+        "JSV": "^4.0.2",
+        "chalk": "^2.4.2",
+        "underscore": "^1.9.1"
       }
     },
     "jsprim": {
@@ -4814,47 +4809,6 @@
       "requires": {
         "has": "^1.0.3",
         "is": "^3.2.1"
-      }
-    },
-    "nomnom": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-      "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
-      "dev": true,
-      "requires": {
-        "chalk": "~0.4.0",
-        "underscore": "~1.6.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "~1.0.0",
-            "has-color": "~0.1.0",
-            "strip-ansi": "~0.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
-          "dev": true
-        },
-        "underscore": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-          "dev": true
-        }
       }
     },
     "noop-logger": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "gulp-strip-css-comments": "^2.0.0",
     "gulp-tap": "^2.0.0",
     "image-size": "^0.8.3",
-    "jsonlint": "^1.6.3",
+    "jsonlint-mod": "^1.7.6",
     "markdownlint-cli": "^0.23.2",
     "postcss": "^8.4.6",
     "vinyl-paths": "^3.0.1"


### PR DESCRIPTION
This PR implements the following **changes:**
Uninstalled jsonlint@1.6.3 which relies on underscore@1.6.1 package,
which relies on security vulnerable and deprecated package, "nomnom."
Replaced with jsonlint-mod which is not dependent on nomnom package

*Local Test Steps*
1. Running npm run-script lint:json 
- npm run-script lint:json produced the same output as with previous package
2. Running npm start
- No issues were found upon npm start 