### PR TITLE
Add `.html` file name extension as a suffix to partial and partialCached usage

### DIFF
--- a/themes/digital.gov/layouts/404.html
+++ b/themes/digital.gov/layouts/404.html
@@ -30,17 +30,17 @@
               {{- .Content -}}
             </div>
 
-            {{- partial "core/page-data" (dict "page" . "page_type" "resource" "branch" ($.Scratch.Get "branch")) -}}
+            {{- partial "core/page-data.html" (dict "page" . "page_type" "resource" "branch" ($.Scratch.Get "branch")) -}}
 
           </div>
 
           <div class="grid-col-12 tablet:grid-col-3">
 
             {{/* Table of contents */}}
-            {{- partial "core/toc" . -}}
+            {{- partial "core/toc.html" . -}}
 
             {{/* Last updated */}}
-            {{/* {{- partial "last-updated" . -}}  */}}
+            {{/* {{- partial "last-updated.html" . -}}  */}}
 
           </div>
 

--- a/themes/digital.gov/layouts/_default/baseof.html
+++ b/themes/digital.gov/layouts/_default/baseof.html
@@ -58,7 +58,7 @@
 <script src='{{ "dist/common.js" | absURL }}'></script>
 
 {{/* Add to Calendar JS */}}
-{{- partial "core/addtocalendar-js" . -}}
+{{- partial "core/addtocalendar-js.html" . -}}
 
 <!-- Set the Images API as a variable -->
 <script type="text/javascript">

--- a/themes/digital.gov/layouts/_default/images.html
+++ b/themes/digital.gov/layouts/_default/images.html
@@ -35,7 +35,7 @@
 
             <div id="stream-images" class="stream usa-prose"></div>
 
-            {{- partial "core/page-data" (dict "page" . "page_type" "resource" "branch" ($.Scratch.Get "branch")) -}}
+            {{- partial "core/page-data.html" (dict "page" . "page_type" "resource" "branch" ($.Scratch.Get "branch")) -}}
 
           </div>
 

--- a/themes/digital.gov/layouts/_default/list.html
+++ b/themes/digital.gov/layouts/_default/list.html
@@ -33,26 +33,26 @@
               {{- .Content -}}
             </div>
 
-            {{- partial "core/page-data" (dict "page" . "page_type" "resource" "branch" ($.Scratch.Get "branch")) -}}
+            {{- partial "core/page-data.html" (dict "page" . "page_type" "resource" "branch" ($.Scratch.Get "branch")) -}}
 
           </div>
 
           <div class="grid-col-12 tablet:grid-col-3">
 
             {{/* Table of contents */}}
-            {{- partial "core/toc" . -}}
+            {{- partial "core/toc.html" . -}}
 
             {{/* Last updated */}}
-            {{/* {{- partial "last-updated" . -}}  */}}
+            {{/* {{- partial "last-updated.html" . -}}  */}}
 
             {{/* Related Communities and Services */}}
-            {{- partial "core/get_related" . -}}
+            {{- partial "core/get_related.html" . -}}
 
             {{/* Topics */}}
-            {{/* {{- partial "core/list-topics" . -}} */}}
+            {{/* {{- partial "core/list-topics.html" . -}} */}}
 
             {{/* Share Tools */}}
-            {{/* {{- partial "core/get_sharetools" . -}} */}}
+            {{/* {{- partial "core/get_sharetools.html" . -}} */}}
 
           </div>
 

--- a/themes/digital.gov/layouts/_default/list.json.json
+++ b/themes/digital.gov/layouts/_default/list.json.json
@@ -94,9 +94,9 @@
       {{- end -}}
 
 
-      {{- partial "api/primary_image" . -}}
+      {{- partial "api/primary_image.html" . -}}
 
-      {{- partial "api/featured_image" . -}}
+      {{- partial "api/featured_image.html" . -}}
 
       "branch" : {{ $.Scratch.Get "branch" | jsonify }},
       "filename" : {{- with .File -}}{{- .LogicalName | jsonify -}}{{- end -}},
@@ -130,7 +130,7 @@
       },
       {{- end -}}
 
-      {{- partial "api/slug" . -}}
+      {{- partial "api/slug.html" . -}}
       
       "url" : "{{- .Permalink -}}"
     }{{- if ne (add $index 1) $length -}},{{- end -}}

--- a/themes/digital.gov/layouts/_default/single.html
+++ b/themes/digital.gov/layouts/_default/single.html
@@ -39,28 +39,28 @@
               {{- .Content -}}
             </div>
 
-            {{- partial "core/touchpoints_feedback" . -}}
+            {{- partial "core/touchpoints_feedback.html" . -}}
 
-            {{- partial "core/page-data" (dict "page" . "page_type" "resource" "branch" ($.Scratch.Get "branch")) -}}
+            {{- partial "core/page-data.html" (dict "page" . "page_type" "resource" "branch" ($.Scratch.Get "branch")) -}}
 
           </div>
 
           <div class="grid-col-12 tablet:grid-col-3">
 
             {{/* Table of contents */}}
-            {{- partial "core/toc" . -}}
+            {{- partial "core/toc.html" . -}}
 
             {{/* Last updated */}}
-            {{/* {{- partial "last-updated" . -}}  */}}
+            {{/* {{- partial "last-updated.html" . -}}  */}}
 
             {{/* Related Communities and Services */}}
-            {{- partial "core/get_related" . -}}
+            {{- partial "core/get_related.html" . -}}
 
             {{/* Topics */}}
-            {{/* {{- partial "core/list-topics" . -}} */}}
+            {{/* {{- partial "core/list-topics.html" . -}} */}}
 
             {{/* Share Tools */}}
-            {{/* {{- partial "core/get_sharetools" . -}} */}}
+            {{/* {{- partial "core/get_sharetools.html" . -}} */}}
 
           </div>
 

--- a/themes/digital.gov/layouts/_default/single.json.json
+++ b/themes/digital.gov/layouts/_default/single.json.json
@@ -87,9 +87,9 @@
         },
       {{- end -}}
 
-      {{- partial "api/primary_image" . -}}
+      {{- partial "api/primary_image.html" . -}}
 
-      {{- partial "api/featured_image" . -}}
+      {{- partial "api/featured_image.html" . -}}
 
       "branch" : {{ $.Scratch.Get "branch" | jsonify }},
       "filename" : {{- with .File -}}{{- .LogicalName | jsonify -}}{{- end -}},
@@ -103,7 +103,7 @@
       "source_url" : "{{- .Params.source_url -}}",
       {{- end -}}
 
-      {{- partial "api/slug" . -}}
+      {{- partial "api/slug.html" . -}}
       
       "url" : "{{- .Permalink -}}",
       {{- if .Params.aliases -}}

--- a/themes/digital.gov/layouts/_default/taxonomy.html
+++ b/themes/digital.gov/layouts/_default/taxonomy.html
@@ -55,7 +55,7 @@
 
                 </header>
                 <footer>
-                  <a href="{{- .Permalink -}} " rel="nofollow" title="{{- .Title | markdownify -}} ">{{- .Date.Format "Jan _2" -}}</a><span>&#10038;</span>{{- partial "core/get_authors_short" . -}}
+                  <a href="{{- .Permalink -}} " rel="nofollow" title="{{- .Title | markdownify -}} ">{{- .Date.Format "Jan _2" -}}</a><span>&#10038;</span>{{- partial "core/get_authors_short.html" . -}}
                 </footer>
               </div>
             </div>

--- a/themes/digital.gov/layouts/authors/list.json.json
+++ b/themes/digital.gov/layouts/authors/list.json.json
@@ -24,7 +24,7 @@
     "pronoun" : "{{- .Params.pronoun -}}",
     {{- end -}}
 
-    {{- partial "api/slug" . -}}
+    {{- partial "api/slug.html" . -}}
 
     {{- if .Params.email -}}
     "email" : "{{- .Params.email -}}",
@@ -32,7 +32,7 @@
     {{- if .Params.location -}}
     "location" : "{{- .Params.location -}}",
     {{- end -}}
-    {{- partial "api/bio" . -}}
+    {{- partial "api/bio.html" . -}}
     {{- if .Params.bio_url -}}
     "bio_url" : "{{- .Params.bio_url -}}",
     {{- end -}}

--- a/themes/digital.gov/layouts/communities/archived.html
+++ b/themes/digital.gov/layouts/communities/archived.html
@@ -24,12 +24,12 @@
               This community was archived on {{ dateFormat "January 2, 2006" .Params.archive_date}} and is no longer active.
             </div>
               <div class="community_events">
-              {{- partial "core/get-upcomingevents" . -}}
-              {{- partial "core/get-pastevents" . -}}              
+              {{- partial "core/get-upcomingevents.html" . -}}
+              {{- partial "core/get-pastevents.html" . -}}              
             </div>
             <div>
               <br/>
-              {{- partial "core/page-data" (dict "page" . "page_type" "community" "branch" ($.Scratch.Get "branch")) -}}
+              {{- partial "core/page-data.html" (dict "page" . "page_type" "community" "branch" ($.Scratch.Get "branch")) -}}
              </div>
           </div>
 

--- a/themes/digital.gov/layouts/communities/list.html
+++ b/themes/digital.gov/layouts/communities/list.html
@@ -15,7 +15,7 @@
           <div class="deck">{{- .Params.deck | markdownify -}}</div>
           {{- end -}}
 
-          {{/* {{ partial "last-updated" . }} */}}
+          {{/* {{ partial "last-updated.html" . }} */}}
 
         </header>
       </div>

--- a/themes/digital.gov/layouts/communities/list.json.json
+++ b/themes/digital.gov/layouts/communities/list.json.json
@@ -93,11 +93,11 @@
         },
       {{- end -}}
 
-      {{- partial "api/community_lists" . -}}
+      {{- partial "api/community_lists.html" . -}}
 
-      {{- partial "api/primary_image" . -}}
+      {{- partial "api/primary_image.html" . -}}
 
-      {{- partial "api/featured_image" . -}}
+      {{- partial "api/featured_image.html" . -}}
 
       "branch" : {{ $.Scratch.Get "branch" | jsonify }},
       "filename" : {{- with .File -}}{{- .LogicalName | jsonify -}}{{- end -}},
@@ -131,7 +131,7 @@
       },
       {{- end -}}
 
-      {{- partial "api/slug" . -}}
+      {{- partial "api/slug.html" . -}}
       
       "url" : "{{- .Permalink -}}"
     }{{- if ne (add $index 1) $length -}},{{- end -}}

--- a/themes/digital.gov/layouts/communities/single.html
+++ b/themes/digital.gov/layouts/communities/single.html
@@ -77,22 +77,22 @@
                     */}}
                     {{/* Listserv Platforms without form sign-up option */}}
                     {{- if and (eq $e.platform "listserv") (not $e.subscribe_form ) -}}
-                      {{- partial "core/community-join-without-form" (dict "context" . "e" $e) -}}
+                      {{- partial "core/community-join-without-form.html" (dict "context" . "e" $e) -}}
                     {{- end -}}
 
                     {{/* Listserv Platforms with form as sign-up option */}}
                     {{- if and (eq $e.platform "listserv") ( $e.subscribe_form ) -}}
-                      {{- partial "core/community-join-with-form" (dict "context" . "e" $e) -}}
+                      {{- partial "core/community-join-with-form.html" (dict "context" . "e" $e) -}}
                     {{- end -}}
 
                     {{/* Google Group platforms */}}
                     {{- if and (eq $e.platform "google-group") ( $e.subscribe_form ) -}}
-                      {{- partial "core/community-join-google-group" (dict "context" . "e" $e) -}}
+                      {{- partial "core/community-join-google-group.html" (dict "context" . "e" $e) -}}
                     {{- end -}}
 
                     {{/* Slack platforms */}}
                     {{- if and (eq $e.platform "slack") ( $e.subscribe_form ) -}}
-                      {{- partial "core/community-join-slack" (dict "context" . "e" $e) -}}
+                      {{- partial "core/community-join-slack.html" (dict "context" . "e" $e) -}}
                     {{- end -}}
 
 
@@ -114,7 +114,7 @@
               {{- if .Params.authors -}}
               <div class="community_managers">
                 <h3>Community Managers</h3>
-                {{- partial "core/get_authors" . -}}
+                {{- partial "core/get_authors.html" . -}}
               </div>
               {{- end -}}
 
@@ -132,17 +132,17 @@
               {{- .Content -}}
             </div>
               <div class="community_events">
-              {{- partial "core/get-upcomingevents" . -}}         
+              {{- partial "core/get-upcomingevents.html" . -}}         
             </div>
             
             <div class="Community_conduct">
               <h2 id="community-conduct">Community Conduct</h2>
-              {{- partial "core/community_pagefooter" . -}}
+              {{- partial "core/community_pagefooter.html" . -}}
               <br>
             </div>
             <div>
               <br/>
-              {{- partial "core/page-data" (dict "page" . "page_type" "community" "branch" ($.Scratch.Get "branch")) -}}
+              {{- partial "core/page-data.html" (dict "page" . "page_type" "community" "branch" ($.Scratch.Get "branch")) -}}
              </div>
           </div>
 

--- a/themes/digital.gov/layouts/communities/single.json.json
+++ b/themes/digital.gov/layouts/communities/single.json.json
@@ -88,11 +88,11 @@
         },
       {{- end -}}
 
-      {{- partial "api/community_lists" . -}}
+      {{- partial "api/community_lists.html" . -}}
 
-      {{- partial "api/primary_image" . -}}
+      {{- partial "api/primary_image.html" . -}}
 
-      {{- partial "api/featured_image" . -}}
+      {{- partial "api/featured_image.html" . -}}
 
       "branch" : {{ $.Scratch.Get "branch" | jsonify }},
       "filename" : {{- with .File -}}{{- .LogicalName | jsonify -}}{{- end -}},
@@ -106,7 +106,7 @@
       "source_url" : "{{- .Params.source_url -}}",
       {{- end -}}
 
-      {{- partial "api/slug" . -}}
+      {{- partial "api/slug.html" . -}}
 
       "url" : "{{- .Permalink -}}",
       {{- if .Params.aliases -}}

--- a/themes/digital.gov/layouts/docs/single.html
+++ b/themes/digital.gov/layouts/docs/single.html
@@ -15,7 +15,7 @@
             {{- if .Params.deck -}}
             <div>{{- .Params.deck | markdownify -}}</div>
             {{- end -}}
-            {{/* {{ partial "last-updated" . }} */}}
+            {{/* {{ partial "last-updated.html" . }} */}}
           </header>
         </div>
       </div>
@@ -32,7 +32,7 @@
 
       <div class="grid-row tablet-lg:grid-gap-6">
         <div class="grid-col-12">
-          {{ partial "core/page-data" (dict "page" . "page_type" "guide" "branch" ($.Scratch.Get "branch")) }}
+          {{ partial "core/page-data.html" (dict "page" . "page_type" "guide" "branch" ($.Scratch.Get "branch")) }}
         </div>
       </div>
 
@@ -40,6 +40,6 @@
   </article>
 </main>
 
-  {{ partial "core/overlay" . }}
+  {{ partial "core/overlay.html" . }}
 
 {{ end }} {{/* end 'content' block */}}

--- a/themes/digital.gov/layouts/events/card-event-past.html
+++ b/themes/digital.gov/layouts/events/card-event-past.html
@@ -26,10 +26,10 @@
         <div class="deck">{{ .Params.summary | markdownify -}}</div>
       {{- end -}}
 
-      {{- partial "core/get_authors_short" . -}}
+      {{- partial "core/get_authors_short.html" . -}}
 
       <div class="meta">
-        {{- partial "core/get_clicks" . -}}
+        {{- partial "core/get_clicks.html" . -}}
         <div class="date">{{ dateFormat "Jan 02, 2006" .Date }}</div>
       </div>
 

--- a/themes/digital.gov/layouts/events/list.json.json
+++ b/themes/digital.gov/layouts/events/list.json.json
@@ -81,9 +81,9 @@
       "registration_url" : "{{- .Params.registration_url -}}",
       {{- end -}}
 
-      {{- partial "api/captions" . -}}
+      {{- partial "api/captions.html" . -}}
 
-      {{- partial "api/youtube_id" . -}}
+      {{- partial "api/youtube_id.html" . -}}
 
       {{- if (isset .Params "zoom_id") -}}
       "zoom_id" : "{{- .Params.zoom_id -}}",
@@ -130,9 +130,9 @@
         },
       {{- end -}}
 
-      {{- partial "api/primary_image" . -}}
+      {{- partial "api/primary_image.html" . -}}
 
-      {{- partial "api/featured_image" . -}}
+      {{- partial "api/featured_image.html" . -}}
 
       "branch" : {{ $.Scratch.Get "branch" | jsonify }},
       "filename" : {{- with .File -}}{{- .LogicalName | jsonify -}}{{- end -}},
@@ -160,7 +160,7 @@
       },
       {{- end -}}
 
-      {{- partial "api/slug" . -}}
+      {{- partial "api/slug.html" . -}}
       
       "url" : "{{- .Permalink -}}"
     }{{- if ne (add $index 1) $length -}},{{- end -}}

--- a/themes/digital.gov/layouts/events/single.html
+++ b/themes/digital.gov/layouts/events/single.html
@@ -141,7 +141,7 @@
               {{- .Content -}}
             </div>
 
-            {{- partial "core/page-data" (dict "page" . "page_type" "event" "cc" "digitalgovu@gsa.gov" "prompt" "Have questions about this event or future events?" "branch" ($.Scratch.Get "branch")) -}}
+            {{- partial "core/page-data.html" (dict "page" . "page_type" "event" "cc" "digitalgovu@gsa.gov" "prompt" "Have questions about this event or future events?" "branch" ($.Scratch.Get "branch")) -}}
 
           </div>
 
@@ -150,7 +150,7 @@
             {{/* Authors */}}
             {{- if .Params.authors -}}
             <h4>In this talk</h4>
-            {{- partial "core/get_authors" . -}}
+            {{- partial "core/get_authors.html" . -}}
             {{- end -}}
 
             {{- if eq .Params.event_platform "youtube_live" -}}
@@ -178,13 +178,13 @@
             {{- end -}}
 
             {{/* Related Communities and Services */}}
-            {{- partial "core/get_related" . -}}
+            {{- partial "core/get_related.html" . -}}
 
             {{/* Topics */}}
-            {{- partial "core/list-topics" . -}}
+            {{- partial "core/list-topics.html" . -}}
 
             {{/* Share Tools */}}
-            {{- partial "core/get_sharetools" . -}}
+            {{- partial "core/get_sharetools.html" . -}}
           </div>
         </div>
 

--- a/themes/digital.gov/layouts/events/single.json.json
+++ b/themes/digital.gov/layouts/events/single.json.json
@@ -75,9 +75,9 @@
       "registration_url" : "{{- .Params.registration_url -}}",
       {{- end -}}
 
-      {{- partial "api/captions" . -}}
+      {{- partial "api/captions.html" . -}}
 
-      {{- partial "api/youtube_id" . -}}
+      {{- partial "api/youtube_id.html" . -}}
 
       {{- if (isset .Params "zoom_id") -}}
       "zoom_id" : "{{- .Params.zoom_id -}}",
@@ -123,9 +123,9 @@
         },
       {{- end -}}
 
-      {{- partial "api/primary_image" . -}}
+      {{- partial "api/primary_image.html" . -}}
 
-      {{- partial "api/featured_image" . -}}
+      {{- partial "api/featured_image.html" . -}}
 
       "content" : {{- .Content | jsonify -}},
       "branch" : {{ $.Scratch.Get "branch" | jsonify }},
@@ -154,7 +154,7 @@
       },
       {{- end -}}
 
-      {{- partial "api/slug" . -}}
+      {{- partial "api/slug.html" . -}}
 
       "url" : "{{- .Permalink -}}"
     }

--- a/themes/digital.gov/layouts/guides/list.html
+++ b/themes/digital.gov/layouts/guides/list.html
@@ -4,23 +4,23 @@
 
   <article>
 
-    {{- partial "core/breadcrumbs" . -}}
+    {{- partial "core/breadcrumbs.html" . -}}
 
     <div class="grid-container grid-container-desktop">
       <div class="grid-row grid-gap-4">
 
         <div class="grid-col-12 tablet-lg:grid-col-2">
-          {{- partial "core/guides/guide-nav" . -}}
+          {{- partial "core/guides/guide-nav.html" . -}}
         </div>
 
         <div class="grid-col-12 tablet-lg:grid-col-8">
           <div class="usa-layout-docs__main usa-prose">
 
-            {{- partial "core/guides/guide-page-head" . -}}
+            {{- partial "core/guides/guide-page-head.html" . -}}
 
             {{- .Content -}}
 
-            {{- partial "core/guides/guide-prev-next" . -}}
+            {{- partial "core/guides/guide-prev-next.html" . -}}
           </div>
 
         </div>

--- a/themes/digital.gov/layouts/guides/single.html
+++ b/themes/digital.gov/layouts/guides/single.html
@@ -4,31 +4,31 @@
 
   <article>
 
-    {{- partial "core/breadcrumbs" . -}}
+    {{- partial "core/breadcrumbs.html" . -}}
 
     <div class="grid-container grid-container-desktop">
       <div class="grid-row grid-gap-4">
 
         <div class="grid-col-12 tablet-lg:grid-col-2" data-edit-this="{{- .Path -}}">
-          {{- partial "core/guides/guide-nav" . -}}
+          {{- partial "core/guides/guide-nav.html" . -}}
         </div>
 
         <div class="grid-col-12 tablet-lg:grid-col-8">
           <div class="guide-content usa-layout-docs__main usa-prose" data-edit-this="{{- .Path -}}">
 
-            {{- partial "core/guides/guide-page-head" . -}}
+            {{- partial "core/guides/guide-page-head.html" . -}}
 
             {{/*
               Checks if the page has the "guide-section-nav" shortcode
               If not, it will render the "guide-section-nav".
             */}}
             <!-- {{- if not (.HasShortcode "guide-toc") -}}
-              {{- partial "core/guides/guide-toc" . -}}
+              {{- partial "core/guides/guide-toc.html" . -}}
             {{- end -}} -->
 
             {{ .Content }}
 
-            {{- partial "core/guides/guide-prev-next" . -}}
+            {{- partial "core/guides/guide-prev-next.html" . -}}
           </div>
 
         </div>

--- a/themes/digital.gov/layouts/home.html
+++ b/themes/digital.gov/layouts/home.html
@@ -28,7 +28,7 @@
           {{/* Sort all of the resources by weight */}}
           {{- $resourcesfeatured := (sort $resourcesfeatured "Weight" "desc" ) -}}
 
-          {{- partialCached "core/collection" (dict "list" $resourcesfeatured "heading" "Popular Guides and Resources") -}}
+          {{- partialCached "core/collection.html" (dict "list" $resourcesfeatured "heading" "Popular Guides and Resources") -}}
 
           <footer>
             <div class="grid-row tablet-lg:grid-gap-2">
@@ -46,7 +46,7 @@
 
 
   {{/* News */}}
-  {{- partialCached "core/home/news_featured" . -}}
+  {{- partialCached "core/home/news_featured.html" . -}}
 
 </main>
 

--- a/themes/digital.gov/layouts/news/card-article.html
+++ b/themes/digital.gov/layouts/news/card-article.html
@@ -1,7 +1,7 @@
 <div class="card card-article card-linked" data-edit-this="{{- .Path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
   <div class="grid-row tablet:grid-gap-4">
     <div class="grid-col-12 tablet:grid-col-4 tablet:order-2">
-      {{- partial "core/img-featured" . -}}
+      {{- partial "core/img-featured.html" . -}}
     </div>
     <div class="grid-col-12 tablet:grid-col-8 tablet:order-1">
 
@@ -18,11 +18,11 @@
       <div class="summary">{{ .Params.summary | markdownify }}</div>
       {{- end -}}
 
-      {{- partial "core/get_authors_short" . -}}
+      {{- partial "core/get_authors_short.html" . -}}
 
       <div class="meta">
         <div class="date">{{ dateFormat "Jan 02, 2006" .Date }}</div>
-        {{- partial "core/get_clicks" . -}}
+        {{- partial "core/get_clicks.html" . -}}
       </div>
     </div>
 

--- a/themes/digital.gov/layouts/news/card-elsewhere.html
+++ b/themes/digital.gov/layouts/news/card-elsewhere.html
@@ -34,6 +34,6 @@
   </div>
   <div class="meta">
     <p class="date">{{ dateFormat "Jan 02, 2006" .Date }}</p>
-    {{- partial "core/get_clicks" . -}}
+    {{- partial "core/get_clicks.html" . -}}
   </div>
 </div>

--- a/themes/digital.gov/layouts/news/single.html
+++ b/themes/digital.gov/layouts/news/single.html
@@ -18,13 +18,13 @@
             <div class="deck">{{- .Params.deck | markdownify -}}</div>
             {{- end -}}
 
-            {{- partial "core/get_authors_short" . -}}
+            {{- partial "core/get_authors_short.html" . -}}
 
             <div class="meta">
               <div class="date">
                 <a href="{{- .Permalink -}} " rel="nofollow" title="{{- .Title | markdownify -}} ">{{- .Date.Format "Jan _2, 2006" -}}</a>
               </div>
-              {{- partial "core/get_clicks" . -}}
+              {{- partial "core/get_clicks.html" . -}}
             </div>
 
           </div>
@@ -43,14 +43,14 @@
               {{- .Content -}}
             </div>
 
-            {{- partial "core/page-data" (dict "page" . "page_type" "post" "branch" ($.Scratch.Get "branch")) -}}
+            {{- partial "core/page-data.html" (dict "page" . "page_type" "post" "branch" ($.Scratch.Get "branch")) -}}
 
           </div>
 
           <div class="grid-col-12 tablet-lg:grid-col-3">
 
             {{/* Authors */}}
-            {{- partial "core/get_authors" . -}}
+            {{- partial "core/get_authors.html" . -}}
 
             <div class="meta">
 
@@ -59,21 +59,21 @@
                 <a href="{{- .Permalink -}} " rel="nofollow" title="{{- .Title | markdownify -}} ">{{- .Date.Format "Jan _2, 2006" -}} </a>
               </div>
 
-              {{- partial "core/get_clicks" . -}}
+              {{- partial "core/get_clicks.html" . -}}
 
             </div>
 
             {{/* Last updated */}}
-            {{/* {{- partial "last-updated" . -}}  */}}
+            {{/* {{- partial "last-updated.html" . -}}  */}}
 
             {{/* Related Communities and Services */}}
-            {{- partial "core/get_related" . -}}
+            {{- partial "core/get_related.html" . -}}
 
             {{/* Topics */}}
-            {{- partial "core/list-topics" . -}}
+            {{- partial "core/list-topics.html" . -}}
 
             {{/* Share Tools */}}
-            {{- partial "core/get_sharetools" . -}}
+            {{- partial "core/get_sharetools.html" . -}}
 
           </div>
 
@@ -84,6 +84,6 @@
   </article>
 </main>
 
-  {{- partial "core/overlay" . -}}
+  {{- partial "core/overlay.html" . -}}
 
 {{- end -}}

--- a/themes/digital.gov/layouts/partials/core/get_authors.html
+++ b/themes/digital.gov/layouts/partials/core/get_authors.html
@@ -29,7 +29,7 @@
         <div class="author grid-row">
           <div class="grid-col-auto">
             <div class="photo">
-              {{- partial "core/get_author_image" (dict "author" $author ) -}}
+              {{- partial "core/get_author_image.html" (dict "author" $author ) -}}
             </div>
           </div>
           <div class="grid-col-9">

--- a/themes/digital.gov/layouts/partials/core/get_authors_short.html
+++ b/themes/digital.gov/layouts/partials/core/get_authors_short.html
@@ -28,7 +28,7 @@
 
       <a class="author" href="{{- (printf "authors/%s/" $uid) | absURL -}} " title="Posts by {{- .Params.display_name | default $uid -}} " rel="author">
 
-        {{- partial "core/get_author_image" (dict "author" . ) -}}
+        {{- partial "core/get_author_image.html" (dict "author" . ) -}}
 
         <span>{{- .Params.display_name | default $uid | markdownify -}}</span>
       </a>{{ if lt (add $i 1) $length }}<!--,--> {{ end }}

--- a/themes/digital.gov/layouts/partials/core/guides/guide-page-head.html
+++ b/themes/digital.gov/layouts/partials/core/guides/guide-page-head.html
@@ -1,6 +1,6 @@
 <header class="page-head page-head-{{- .Type -}}">
 
-  {{- partial "core/guides/guide-read-time" . -}}
+  {{- partial "core/guides/guide-read-time.html" . -}}
 
   {{- if not .IsNode -}}
     {{- if .Params.kicker -}}

--- a/themes/digital.gov/layouts/partials/core/home/training_featured.html
+++ b/themes/digital.gov/layouts/partials/core/home/training_featured.html
@@ -24,7 +24,7 @@
               <div aria-label="an image from the video" class="youtube-player" data-id="{{ .Params.youtube_id }}"></div>
               <h3><a href="{{ .Permalink }}" title="{{ .Title | markdownify }}">{{ .Title | markdownify }}</a></h3>
               {{ $topics := .Params.topics }}
-              {{- partial "core/list-topics" . -}}
+              {{- partial "core/list-topics.html" . -}}
             </div>
           {{ end }}
         {{ end }}

--- a/themes/digital.gov/layouts/resources/list.html
+++ b/themes/digital.gov/layouts/resources/list.html
@@ -15,7 +15,7 @@
             <div class="deck">{{- .Params.deck | markdownify | emojify -}}</div>
             {{- end -}}
 
-            {{/* {{ partial "last-updated" . }} */}}
+            {{/* {{ partial "last-updated.html" . }} */}}
           </div>
         </div>
 
@@ -47,7 +47,7 @@
             {{- $resourcesfeatured := (sort $resourcesfeatured "Weight" "desc" ) -}}
 
             {{/* Pass $resourcesfeatured to the collection template */}}
-            {{- partial "core/collection" (dict "list" $resourcesfeatured "heading" "Popular Guides and Resources") -}}
+            {{- partial "core/collection.html" (dict "list" $resourcesfeatured "heading" "Popular Guides and Resources") -}}
 
           </div>
         </div>
@@ -93,7 +93,7 @@
                     <div class="grid-col-12 tablet-lg:grid-col-10">
 
                       {{/* Pass the $resources_by_topic to the collection template */}}
-                      {{- partial "core/collection" (dict "list" $resources_by_topic) -}}
+                      {{- partial "core/collection.html" (dict "list" $resources_by_topic) -}}
 
                     </div>
                   </div>

--- a/themes/digital.gov/layouts/resources/single.html
+++ b/themes/digital.gov/layouts/resources/single.html
@@ -33,28 +33,28 @@
               {{- .Content -}}
             </div>
 
-            {{- partial "core/touchpoints_feedback" . -}}
+            {{- partial "core/touchpoints_feedback.html" . -}}
             
-            {{- partial "core/page-data" (dict "page" . "page_type" "resource" "branch" ($.Scratch.Get "branch")) -}}
+            {{- partial "core/page-data.html" (dict "page" . "page_type" "resource" "branch" ($.Scratch.Get "branch")) -}}
 
           </div>
 
           <div class="grid-col-12 tablet:grid-col-3">
 
             {{/* Table of contents */}}
-            {{- partial "core/toc" . -}}
+            {{- partial "core/toc.html" . -}}
 
             {{/* Last updated */}}
-            {{/* {{- partial "last-updated" . -}}  */}}
+            {{/* {{- partial "last-updated.html" . -}}  */}}
 
             {{/* Related Communities and Services */}}
-            {{- partial "core/get_related" . -}}
+            {{- partial "core/get_related.html" . -}}
 
             {{/* Topics */}}
-            {{/* {{- partial "core/list-topics" . -}} */}}
+            {{/* {{- partial "core/list-topics.html" . -}} */}}
 
             {{/* Share Tools */}}
-            {{/* {{- partial "core/get_sharetools" . -}} */}}
+            {{/* {{- partial "core/get_sharetools.html" . -}} */}}
 
           </div>
 

--- a/themes/digital.gov/layouts/services/card-service-contact.html
+++ b/themes/digital.gov/layouts/services/card-service-contact.html
@@ -88,7 +88,7 @@
             <a class="contact" href="mailto:{{- .Params.contact -}}" title="Contact"><span><i class="fas fa-envelope"></i>&nbsp;Contact</span></a>
           {{- end -}}
 
-          {{- partial "core/get_authors_short" . -}}
+          {{- partial "core/get_authors_short.html" . -}}
         </div>
 
       </div>

--- a/themes/digital.gov/layouts/services/card-service.html
+++ b/themes/digital.gov/layouts/services/card-service.html
@@ -34,7 +34,7 @@
     <p>{{- .Params.summary | markdownify -}}</p>
 
     {{- if .Params.topics -}}
-      {{- partial "core/list-topics" . -}}
+      {{- partial "core/list-topics.html" . -}}
     {{- end -}}
 
   </div>

--- a/themes/digital.gov/layouts/services/directory.html
+++ b/themes/digital.gov/layouts/services/directory.html
@@ -15,7 +15,7 @@
           <div class="deck">{{- .Params.deck | markdownify -}}</div>
           {{- end -}}
 
-          {{/* {{ partial "last-updated" . }} */}}
+          {{/* {{ partial "last-updated.html" . }} */}}
 
         </header>
       </div>

--- a/themes/digital.gov/layouts/services/single.html
+++ b/themes/digital.gov/layouts/services/single.html
@@ -38,26 +38,26 @@
               {{- .Content -}}
             </div>
 
-            {{- partial "core/page-data" (dict "page" . "page_type" "resource" "branch" ($.Scratch.Get "branch")) -}}
+            {{- partial "core/page-data.html" (dict "page" . "page_type" "resource" "branch" ($.Scratch.Get "branch")) -}}
 
           </div>
 
           <div class="grid-col-12 tablet:grid-col-3">
 
             {{/* Table of contents */}}
-            {{- partial "core/toc" . -}}
+            {{- partial "core/toc.html" . -}}
 
             {{/* Last updated */}}
-            {{/* {{- partial "last-updated" . -}}  */}}
+            {{/* {{- partial "last-updated.html" . -}}  */}}
 
             {{/* Related Communities and Services */}}
-            {{- partial "core/get_related" . -}}
+            {{- partial "core/get_related.html" . -}}
 
             {{/* Topics */}}
-            {{/* {{- partial "core/list-topics" . -}} */}}
+            {{/* {{- partial "core/list-topics.html" . -}} */}}
 
             {{/* Share Tools */}}
-            {{/* {{- partial "core/get_sharetools" . -}} */}}
+            {{/* {{- partial "core/get_sharetools.html" . -}} */}}
 
           </div>
 

--- a/themes/digital.gov/layouts/shortcodes/api-authors.html
+++ b/themes/digital.gov/layouts/shortcodes/api-authors.html
@@ -33,7 +33,7 @@
         "pronoun" : "{{- .Params.pronoun -}}",
         {{- end -}}
 
-        {{- partial "api/slug" . -}}
+        {{- partial "api/slug.html" . -}}
 
         {{- if .Params.email -}}
         "email" : "{{- .Params.email -}}",
@@ -42,7 +42,7 @@
         "location" : "{{- .Params.location -}}",
         {{- end -}}
 
-        {{- partial "api/bio" . -}}
+        {{- partial "api/bio.html" . -}}
         
         {{- if .Params.bio_url -}}
         "bio_url" : "{{- .Params.bio_url -}}",

--- a/themes/digital.gov/layouts/shortcodes/guide-toc.html
+++ b/themes/digital.gov/layouts/shortcodes/guide-toc.html
@@ -1,1 +1,1 @@
-{{- partial "core/guides/guide-toc" . -}}
+{{- partial "core/guides/guide-toc.html" . -}}

--- a/themes/digital.gov/layouts/sources/list.json.json
+++ b/themes/digital.gov/layouts/sources/list.json.json
@@ -13,7 +13,7 @@
     "items" : [
     {{- range $index, $element := $list -}}
     {
-        {{- partial "api/slug" . -}}
+        {{- partial "api/slug.html" . -}}
         
         {{- if (isset .Params "name") -}}
         "name" : "{{- .Params.name | markdownify -}}",

--- a/themes/digital.gov/layouts/topics/list.html
+++ b/themes/digital.gov/layouts/topics/list.html
@@ -40,17 +40,17 @@
             {{/* Gets the resource .Pages associated with this topic */}}
             {{- $resources := (where .Pages "Section" "resources") -}}
             {{/* Pass $resources to the collection template */}}
-            {{- partial "core/collection" (dict "list" $resources "heading" (print "Resources on " .Title)) -}}
+            {{- partial "core/collection.html" (dict "list" $resources "heading" (print "Resources on " .Title)) -}}
 
             {{/* Gets the services .Pages associated with this topic */}}
             {{- $services := (where .Pages "Section" "services") -}}
             {{/* Pass $services to the collection template */}}
-            {{- partial "core/collection" (dict "list" $services "heading" "Tools and Services") -}}
+            {{- partial "core/collection.html" (dict "list" $services "heading" "Tools and Services") -}}
 
             {{/* Gets the communities .Pages associated with this topic */}}
             {{- $communities := (where .Pages "Section" "communities") -}}
             {{/* Pass $communities to the collection template */}}
-            {{- partial "core/collection" (dict "list" $communities "heading" "Join a Community of Practice") -}}
+            {{- partial "core/collection.html" (dict "list" $communities "heading" "Join a Community of Practice") -}}
 
           {{- end -}}
 


### PR DESCRIPTION
# Add `.html` file name extension as a suffix to partial and partialCached usage

This PR implements the following **changes:**

* Add `.html` file name extension as a suffix to `partial` usage
* Add `.html` file name extension as a suffix to `partialCached` usage

## Additional information and references
Since 2017, [Hugo recommend that projects include the suffix](https://discourse.gohugo.io/t/fixed-calling-partial-without-specifying-html-suffix/6028/3)
> "Note that from Hugo 0.20 the suffix will start to make some difference, but we will still append and look for partials with *.html to avoid breakage."
- This came up in a [recent discussion about the `--templateMetrics` feature.](https://discourse.gohugo.io/t/duplicate-entries-in-templatemetrics/37459/10)
- This is a "should" not a "must" (especially for `partialCached` per this [Hugo discussion](https://discourse.gohugo.io/t/proposal-phase-out-partial-lookup-without-suffix/37556)
- Because `GSA / digitalgov.gov` is a larger site and even references testing with `--templateMetrics` in the readme, it may make sense to take this opportunity to fix this usage before the `digitalgov.gov` project upgrades Hugo
- Example of a [similar PR on gohugoio:master](https://github.com/gohugoio/hugoDocs/pull/1678)