### PR TITLE
Update 2013-09-05-ssi-mobile-wage-reporting.md

### DIFF
--- a/content/news/2013/09/2013-09-05-ssi-mobile-wage-reporting.md
+++ b/content/news/2013/09/2013-09-05-ssi-mobile-wage-reporting.md
@@ -11,14 +11,15 @@ topics:
   - mobile-gov
   - SSA
   - thursday-mobile-products
+
 ---
 
-[{{< legacy-img src="2013/09/SSI-Mobile-pic-266x400.png" alt="The SSI Mobile Wage app allows SSI recipients and their families to report their monthly wages to Social Security from their finger tips. Consistent monthly wage reporting is a key aspect in preventing improper payments which can lead to SSI over and under payments." >}}](https://s3.amazonaws.com/digitalgov/_legacy-img/2013/09/SSI-Mobile-pic.png)Following up on their [mobile website]({{< ref "2013-05-30-social-securitys-mobile-website.md" >}} "Social Security’s Mobile Website"), the [Social Security Administration](http://www.ssa.gov/) recently released [the SSI Mobile Wage Reporting](http://apps.usa.gov/ssi-mobile-wage-reporting.shtml) app for Android and iOS devices.
+{{< legacy-img-right src="2013/09/SSI-Mobile-pic-266x400.png" alt="Screen capture of the Reporting For section of the Supplemental Security Income (SSI) Mobile Wage app. Text at the top reads, I am reporting wages for, and offers 3 choices: myself, other person or persons, or both. A button labeled Next is below the choices." >}}
 
-The [Supplemental Security Income](http://www.ssa.gov/pubs/EN-05-11000.pdf) (SSI) program pays benefits to disabled adults and [children](http://www.ssa.gov/pubs/EN-05-10026.pdf) who have limited income and resources. SSI benefits also are payable to people 65 and older without disabilities who meet the financial limits.
+Following up on their <a href="https://digital.gov/2013/05/30/social-securitys-mobile-website/">mobile website</a>, the [Social Security Administration](http://www.ssa.gov/) recently released the Supplemental Security Income (SSI) Mobile Wage Reporting app for <a href="https://play.google.com/store/apps/details?id=gov.ssa.mkwr&hl=en_US&gl=US">Android</a> and <a href="https://apps.apple.com/us/app/ssi-mobile-wage-reporting/id563535561">iOS</a> devices.
 
-The app allows SSI recipients and their families to report their monthly wages to Social Security from their finger tips. Consistent monthly wage reporting is a key aspect in preventing improper payments which can lead to SSI over and under payments.
+The [SSI program](to https://www.ssa.gov/ssi/) pays benefits to [disabled adults (PDF, 894 kb, 17 pages)](http://www.ssa.gov/pubs/EN-05-11000.pdf) and [children (PDF, 235 kb, 20 pages)](http://www.ssa.gov/pubs/EN-05-10026.pdf) who have limited income and resources. SSI benefits also are payable to people 65 and older without disabilities who meet the financial limits.
 
-Citizens interested in using this app are encouraged to contact their local Social Security field office to see if they are eligible.
+The app allows SSI recipients and their families to report their monthly wages to Social Security from their finger tips. Consistent monthly wage reporting is a key aspect in preventing improper payments which can lead to SSI over- and underpayments.
 
-You can find more mobile apps like [SSI Mobile Wage Reporting](http://apps.usa.gov/ssi-mobile-wage-reporting.shtml) on the [USA.gov Apps Gallery](http://apps.usa.gov/).
+Citizens interested in using this app are encouraged to contact their [local Social Security field office](https://secure.ssa.gov/ICON/main.jsp) to see if they are eligible.


### PR DESCRIPTION
1. Fix legacy image; was hyperlinked

>[{{< legacy-img src="2013/09/SSI-Mobile-pic-266x400.png" alt="The SSI Mobile Wage app allows SSI recipients and their families to report their monthly wages to Social Security from their finger tips. Consistent monthly wage reporting is a key aspect in preventing improper payments which can lead to SSI over and under payments." >}}](https://s3.amazonaws.com/digitalgov/_legacy-img/2013/09/SSI-Mobile-pic.png)

2. Update link from 

>[mobile website]({{< ref "2013-05-30-social-securitys-mobile-website.md" >}} "Social Security’s Mobile Website")

to https://digital.gov/2013/05/30/social-securitys-mobile-website/ (archiving mobile website page re issue https://github.com/GSA/digitalgov.gov/issues/4582) 

3. Saved https://digital.gov/2013/09/05/ssi-mobile-wage-reporting/ to Web Archive/Wayback Machine https://web.archive.org/

4. Update links in 2nd paragraph

5. Removed; no longer listed there
>You can find more mobile apps like [SSI Mobile Wage Reporting](http://apps.usa.gov/ssi-mobile-wage-reporting.shtml) on the [USA.gov Apps Gallery](http://apps.usa.gov/).

---

Next step: create Issue for redirect 
> redirectto: https://www.ssa.gov/ssi/

This PR implements the following **changes:**

* insert your summary of your request here, add more bullets as needed


**URL / Link to page**

<!-- Link to the page that will be changed -->
<!-- Delete this section if not needed -->

