### PR TITLE
Update 2013-05-30-social-securitys-mobile-website.md

### DIFF
--- a/content/news/2013/05/2013-05-30-social-securitys-mobile-website.md
+++ b/content/news/2013/05/2013-05-30-social-securitys-mobile-website.md
@@ -2,8 +2,9 @@
 slug: social-securitys-mobile-website
 date: 2013-05-30 5:06:51 -0400
 redirectto: https://www.ssa.gov
+expirydate: "2020-05-16"
 title: 'Social Security&#8217;s Mobile Website'
-summary: The Social Security Administration recently announced their new optimized mobile website which is compatible with Android, Blackberry, iPhone, and Windows devices. The mobile website offers a user friendly tabular icon driven navigation, which makes it very easy to find information anytime, anywhere.
+summary: The Social Security Administration recently announced their new optimized mobile website which is compatible with Android, Blackberry, iPhone, and Windows devices. The mobile website offers a user-friendly, tabular, icon-driven navigation, which makes it very easy to find information anytime, anywhere.
 authors:
   - kanika-tolver
 topics:
@@ -16,7 +17,7 @@ topics:
 
 ---
 
-The [Social Security Administration](http://www.ssa.gov) recently announced their new optimized mobile website which is compatible with Android, Blackberry, iPhone, and Windows devices. The mobile website offers a user friendly tabular icon driven navigation, which makes it very easy to find information anytime, anywhere.
+The [Social Security Administration](http://www.ssa.gov) recently announced their new optimized mobile website which is compatible with Android, Blackberry, iPhone, and Windows devices. The mobile website offers a user-friendly, tabular, icon-driven navigation, which makes it very easy to find information anytime, anywhere.
 
 {{< legacy-img src="2013/05/SSA.govmobilewebsite_.png" alt="Social Security Administration Mobile Website" >}}
 

--- a/content/news/2013/05/2013-05-30-social-securitys-mobile-website.md
+++ b/content/news/2013/05/2013-05-30-social-securitys-mobile-website.md
@@ -13,7 +13,6 @@ topics:
   - SSA
   - the-united-states-social-security-administration
   - thursday-mobile-products
-redirectto: https://www.ssa.gov/
 
 ---
 

--- a/content/news/2013/05/2013-05-30-social-securitys-mobile-website.md
+++ b/content/news/2013/05/2013-05-30-social-securitys-mobile-website.md
@@ -1,8 +1,9 @@
 ---
 slug: social-securitys-mobile-website
 date: 2013-05-30 5:06:51 -0400
+expirydate: "2020-03-15"
 title: 'Social Security&#8217;s Mobile Website'
-summary: The Social Security Administration recently announced their new optimized mobile website which is compatible with Android, Blackberry, iPhone, and Windows devices. The mobile website offers a user friendly tabular icon driven navigation, which makes it very easy to find information anytime, anywhere. This mobile website was
+summary: The Social Security Administration recently announced their new optimized mobile website which is compatible with Android, Blackberry, iPhone, and Windows devices. The mobile website offers a user friendly tabular icon driven navigation, which makes it very easy to find information anytime, anywhere.
 authors:
   - kanika-tolver
 topics:
@@ -12,6 +13,7 @@ topics:
   - SSA
   - the-united-states-social-security-administration
   - thursday-mobile-products
+redirectto: https://www.ssa.gov/
 
 ---
 

--- a/content/news/2013/05/2013-05-30-social-securitys-mobile-website.md
+++ b/content/news/2013/05/2013-05-30-social-securitys-mobile-website.md
@@ -1,7 +1,7 @@
 ---
 slug: social-securitys-mobile-website
 date: 2013-05-30 5:06:51 -0400
-expirydate: "2020-03-16"
+redirectto: https://www.ssa.gov
 title: 'Social Security&#8217;s Mobile Website'
 summary: The Social Security Administration recently announced their new optimized mobile website which is compatible with Android, Blackberry, iPhone, and Windows devices. The mobile website offers a user friendly tabular icon driven navigation, which makes it very easy to find information anytime, anywhere.
 authors:

--- a/content/news/2013/05/2013-05-30-social-securitys-mobile-website.md
+++ b/content/news/2013/05/2013-05-30-social-securitys-mobile-website.md
@@ -1,7 +1,7 @@
 ---
 slug: social-securitys-mobile-website
 date: 2013-05-30 5:06:51 -0400
-expirydate: "2020-03-15"
+expirydate: "2020-03-16"
 title: 'Social Security&#8217;s Mobile Website'
 summary: The Social Security Administration recently announced their new optimized mobile website which is compatible with Android, Blackberry, iPhone, and Windows devices. The mobile website offers a user friendly tabular icon driven navigation, which makes it very easy to find information anytime, anywhere.
 authors:


### PR DESCRIPTION
This PR implements the following **changes:**

Archive blog page; the 2013 mobile site no longer relevant. 

1. expirydate set for for tomorrow, 3/16/22 
2. redirectto set to SSA's website

From Issue https://github.com/GSA/digitalgov.gov/issues/4582 

**URL / Link to page**

https://digital.gov/2013/05/30/social-securitys-mobile-website/ 

Added to Internet Archive/Wayback Machine
https://web.archive.org/web/*/https://digital.gov/2013/05/30/social-securitys-mobile-website/ 

Previews: 
1. https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/archive-expire-redirect/news/page/94/ (Note: even though the `expirydate` is set to tomorrow, it disappears from the News page listing once added to front matter)
3. https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/archive-expire-redirect/2013/05/30/social-securitys-mobile-website/ (note: doesn't work with `expirydate` set)

Live page -- test "mobile website" link in first paragraph of: https://digital.gov/2013/09/05/ssi-mobile-wage-reporting/ 
