### PR TITLE
Update devops.md

### DIFF
--- a/content/communities/devops.md
+++ b/content/communities/devops.md
@@ -6,8 +6,7 @@ slug: devops
 date: 2019-12-12 19:00:00 -0500
 title: "DevOps"
 deck: "Operating rapidly changing resilient systems at scale"
-summary: "The practice of operations and development staff participating in the entire service lifecycle to operate rapidly changing resilient systems at scale."
-redirectto: https://github.com/18F/DevOps-Community-of-Practice/wiki/DevOps-Community-of-Practice
+summary: "To join our federal government employee only Listserv, send an email from your official government email to: devops-today-subscribe-request@listserv.gsa.gov."
 
 # see all topics at https://digital.gov/topics
 topics:


### PR DESCRIPTION
This PR implements the following **changes:**

* Bringing redirect back to Digtial.gov. Want the community to just exist as a tile on the community listing page with simple information on how to join written. 

removed `redirectto: https://github.com/18F/DevOps-Community-of-Practice/wiki/DevOps-Community-of-Practice`. 

**URL / Link to page**
https://digital.gov/communities/

https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/AS_DevOps-DG-Back/communities/ 

https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/AS_DevOps-DG-Back/communities/devops/ 