### PR TITLE
AS_IA Redirect

### DIFF
--- a/content/communities/innovation-adoption.md
+++ b/content/communities/innovation-adoption.md
@@ -15,6 +15,7 @@ authors:
   - tina-chen
   - julia-begley
 slug: innovation-adoption
+redirectto: https://coe.gsa.gov/communities/innovation-adoption.html
 # Controls how this page appears across the site
 # 0 -- hidden
 # 1 -- visible


### PR DESCRIPTION
This PR implements the following **changes:**

* redirecting IA cop page off digital.gov


**URL / Link to page**

https://digital.gov/communities/innovation-adoption/

Preview: https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/AS_IA-Redirect/communities/innovation-adoption/ 