### PR TITLE
removed emails from non-federal authors

### DIFF
--- a/content/authors/cliff-tyllick/_index.md
+++ b/content/authors/cliff-tyllick/_index.md
@@ -17,7 +17,7 @@ pronoun: ""
 slug: cliff-tyllick
 
 # if you include an email address, it will be displayed on your profile page
-email: "cliff.tyllick@tceq.texas.gov"
+email:
 
 # Bio — keep it under 50 words
 bio: "Cliff Tyllick has worked on clear communication, usability, and Web development since the new authoring tools were HyperCard and Owl Guide—in other words, long before there was a World Wide Web. He is now the accessibility coordinator of the Texas Department of Aging and Disability Services."

--- a/content/authors/loren-siebert/_index.md
+++ b/content/authors/loren-siebert/_index.md
@@ -17,7 +17,7 @@ pronoun: ""
 slug: loren-siebert
 
 # if you include an email address, it will be displayed on your profile page
-email: "loren@siebert.org"
+email:
 
 # Bio — keep it under 50 words
 bio: "Loren Siebert is the Technical Lead for the DigitalGov Search program, where he focuses on search and analytics."

--- a/content/authors/ryan-leisinger/_index.md
+++ b/content/authors/ryan-leisinger/_index.md
@@ -17,7 +17,7 @@ pronoun: ""
 slug: ryan-leisinger
 
 # if you include an email address, it will be displayed on your profile page
-email: "ryan.leisinger@ocio.wa.gov"
+email:
 
 # Bio — keep it under 50 words
 bio: ""


### PR DESCRIPTION
Removed emails for the following 3 non-federal authors in their respective markdown files.

- cliff-tyllick/_index.md
- loren-siebert/_index.md
- ryan-leisinger/_index.md

Previews:

https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/nl-clean-authors-data/authors/cliff-tyllick/ 

https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/nl-clean-authors-data/authors/loren-siebert/ 

https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/nl-clean-authors-data/authors/ryan-leisinger/ 