### PR TITLE
removed 'host an event' buttons on home, /events, /news (#3854)

### DIFF
--- a/themes/digital.gov/layouts/events/list.html
+++ b/themes/digital.gov/layouts/events/list.html
@@ -17,7 +17,6 @@
           <div class="join-buttons">
             <a href="https://www.youtube.com/digitalgov">Video library</a>
             <a href="#events-past">Past events</a>
-            <a href="{{- "/join" | absURL -}}">Host an event</a>
           </div>
 
 

--- a/themes/digital.gov/layouts/news/list.html
+++ b/themes/digital.gov/layouts/news/list.html
@@ -17,7 +17,6 @@
 
           <div class="join-buttons">
             <a href="{{- "/join" | absURL -}}">Write for us</a>
-            <a href="{{- "/join" | absURL -}}">Host an event</a>
           </div>
 
         </header>

--- a/themes/digital.gov/layouts/partials/core/home/events_featured.html
+++ b/themes/digital.gov/layouts/partials/core/home/events_featured.html
@@ -25,7 +25,6 @@
             <div class="join-buttons">
               <a href="{{- "/join" | absURL -}}">Contribute</a>
               <a href="{{- "/communities" | absURL -}}">Join a community</a>
-              <a href="{{- "/join" | absURL -}}">Host an event</a>
             </div>
 
           </header>

--- a/themes/digital.gov/layouts/partials/core/home/news_featured.html
+++ b/themes/digital.gov/layouts/partials/core/home/news_featured.html
@@ -12,7 +12,6 @@
 
             <div class="join-buttons">
               <a href="{{- "/join" | absURL -}}">Write for us</a>
-              <a href="{{- "/join" | absURL -}}">Host an event</a>
             </div>
 
           </header>


### PR DESCRIPTION
Resolves #3854 

"Host an event" button is removed from the following pages:

- home
- /events
- /news

Before:
<img width="1063" alt="#3854-host-an-event-button" src="https://user-images.githubusercontent.com/104778659/169334237-aabae318-c95c-4c90-a0ae-4c6ab2f2d091.png">

After:

<img width="942" alt="#3854-events-page" src="https://user-images.githubusercontent.com/104778659/169332954-145f14d8-2745-4052-a1fc-2f5fa00ebd03.png">
<img width="1049" alt="#3854-home-page" src="https://user-images.githubusercontent.com/104778659/169332961-a11d0443-62fa-49bf-97eb-db7dad01859f.png">
<img width="1000" alt="#3854-news-page" src="https://user-images.githubusercontent.com/104778659/169332965-bf25ceae-5c5f-4098-bc24-5c6aba689f56.png">

