### PR TITLE
Fixed the link to the Q&A blog post

### DIFF
--- a/content/events/2022/02/2022-02-11-language-connections-tips-to-create-maintain-and-present-non-english-digital-content.md
+++ b/content/events/2022/02/2022-02-11-language-connections-tips-to-create-maintain-and-present-non-english-digital-content.md
@@ -34,7 +34,7 @@ This webinar will include ideas, resources, and examples of how you can improve 
 
 The presentation will be based on the new guide, [Improving Access to Public Websites and Digital Services for Limited English Proficient (LEP) Persons (PDF, 2.5 MB, 17 pages)](https://www.lep.gov/sites/lep/files/media/document/2021-12/2021_12_07_Website_Language_Access_Guide_508.pdf), created by the [LEP subcommittee](https://www.lep.gov/) of Title VI of the Civil Rights Act of 1964 interagency working group.
 
-[Read the Q&A Recap](https://https://digital.gov/2022/05/23/10-tips-to-create-maintain-and-present-non-english-digital-content-a-qa-with-michael-mule/).
+[Read the Q&A Recap](https://digital.gov/2022/05/23/10-tips-to-create-maintain-and-present-non-english-digital-content-a-qa-with-michael-mule/).
 
 *This talk is co-hosted by Digital.gov, the Multilingual Community of Practice, and the Web Managers Community of Practice.*
 

--- a/content/events/2022/02/2022-02-11-language-connections-tips-to-create-maintain-and-present-non-english-digital-content.md
+++ b/content/events/2022/02/2022-02-11-language-connections-tips-to-create-maintain-and-present-non-english-digital-content.md
@@ -34,7 +34,7 @@ This webinar will include ideas, resources, and examples of how you can improve 
 
 The presentation will be based on the new guide, [Improving Access to Public Websites and Digital Services for Limited English Proficient (LEP) Persons (PDF, 2.5 MB, 17 pages)](https://www.lep.gov/sites/lep/files/media/document/2021-12/2021_12_07_Website_Language_Access_Guide_508.pdf), created by the [LEP subcommittee](https://www.lep.gov/) of Title VI of the Civil Rights Act of 1964 interagency working group.
 
-[Read the Q&A Recap](https://digital.gov/2022/05/23/10-tips-to-create-maintain-and-present-non-english-digital-content-a-qa-with-michael-mule/).
+[Read the Q&A recap](https://digital.gov/2022/05/23/10-tips-to-create-maintain-and-present-non-english-digital-content-a-qa-with-michael-mule/).
 
 *This talk is co-hosted by Digital.gov, the Multilingual Community of Practice, and the Web Managers Community of Practice.*
 


### PR DESCRIPTION
This PR implements the following **changes:**

On the page below, fixed the link to the blog post. 

https://digital.gov/event/2022/02/24/language-connections-tips-to-create-maintain-and-present-non-english-digital-content/

Preview: https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/lchidlow-patch-5/event/2022/02/24/language-connections-tips-to-create-maintain-and-present-non-english-digital-content/ 