### PR TITLE
hugo deprecation updates

### DIFF
--- a/content/news/2016/09/2016-09-12-the-content-corner-using-social-media-to-promote-enhance-preparedness-for-the-public-we-serve.md
+++ b/content/news/2016/09/2016-09-12-the-content-corner-using-social-media-to-promote-enhance-preparedness-for-the-public-we-serve.md
@@ -36,19 +36,19 @@ These days, you probably use social media to update your audience on what you ar
 
 Government agencies—federal, tribal, state, and local—are using social media in many ways to keep the public informed and hopefully safer.
 
-When a natural disaster such as a tornado, wildfire, or hurricane hits, the National Weather Service (NWS), Federal Emergency Management Agency (FEMA), and the National Guard are among many agencies who are communicating key info to the public on social media platforms. Just check out the hashtags #SMEM, #LESM, etc., and you’ll see some of the chatter. (_Do you have any others to share? – send me a tweet [@SSgtKRich](https://twitter.com/SSgtKRich)_) 
+When a natural disaster such as a tornado, wildfire, or hurricane hits, the National Weather Service (NWS), Federal Emergency Management Agency (FEMA), and the National Guard are among many agencies who are communicating key info to the public on social media platforms. Just check out the hashtags #SMEM, #LESM, etc., and you’ll see some of the chatter. (_Do you have any others to share? – send me a tweet [@SSgtKRich](https://twitter.com/SSgtKRich)_)
 
-{{< tweet 773627409509777408 >}}
+{{< tweet user="SchaumburgNebl" id="773627409509777408" >}}
 
-As the #ReyFire wildfires continue to affect parts of Southern California, the California National Guard is pushing out key information on Twitter such as fire locations, including video and photos. 
+As the #ReyFire wildfires continue to affect parts of Southern California, the California National Guard is pushing out key information on Twitter such as fire locations, including video and photos.
 
-{{< tweet 768290839390851078 >}}
+{{< tweet user="146AirliftWing" id="768290839390851078" >}}
 
-Sonny Saghera, who&#8217;s a firefighter and Public Information Officer for Heartland Fire and Rescue, uses social media increasingly to get messages out. Sonny talks about his agency’s use of live video like Periscope to share exactly what&#8217;s going on with the public. 
+Sonny Saghera, who&#8217;s a firefighter and Public Information Officer for Heartland Fire and Rescue, uses social media increasingly to get messages out. Sonny talks about his agency’s use of live video like Periscope to share exactly what&#8217;s going on with the public.
 
 {{< youtube Q1zgLgA6dPI >}}
 
-As data use continues to skyrocket for the general public and first responders alike, [FirstNet](http://www.firstnet.gov/), a relatively new federal agency, is tasked with the mission of ensuring the building, operation, and maintenance of a nationwide public safety broadband network. When so much is at stake, public safety shouldn&#8217;t have to compete with the general public for bandwidth. 
+As data use continues to skyrocket for the general public and first responders alike, [FirstNet](http://www.firstnet.gov/), a relatively new federal agency, is tasked with the mission of ensuring the building, operation, and maintenance of a nationwide public safety broadband network. When so much is at stake, public safety shouldn&#8217;t have to compete with the general public for bandwidth.
 
 Chrissie Coon, FirstNet Public Safety Liaison and former Public Information Officer at North Las Vegas Police Department, shares her perspective on the continued reliance on social media by public safety agencies. “It is vital to an effective response to have a presence on social media as more and more people are turning to social media during crisis to get firsthand, credible information from public safety agencies,” said Chrissie. “Official Twitter, Facebook, and YouTube accounts have become vital channels for first responders to communicate with the community during emergency response for everything from evacuation information to incident status updates.”
 

--- a/themes/digital.gov/layouts/404.html
+++ b/themes/digital.gov/layouts/404.html
@@ -1,9 +1,10 @@
 {{- define "content" -}}
 {{- with site.GetPage "/404" -}}
+{{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+
 <main role="main" id="main-content">
   <article>
     <header>
-      {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
       <div class="grid-container grid-container-desktop" data-edit-this="{{- $path -}}">
         <div class="grid-row">
           <div class="grid-col-12">
@@ -21,7 +22,6 @@
     </header>
 
     <section>
-      {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
       <div class="grid-container grid-container-desktop" data-edit-this="{{- $path -}}">
         <div class="grid-row tablet-lg:grid-gap-6">
 

--- a/themes/digital.gov/layouts/404.html
+++ b/themes/digital.gov/layouts/404.html
@@ -3,7 +3,8 @@
 <main role="main" id="main-content">
   <article>
     <header>
-      <div class="grid-container grid-container-desktop" data-edit-this="{{- .Path -}}">
+      {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+      <div class="grid-container grid-container-desktop" data-edit-this="{{- $path -}}">
         <div class="grid-row">
           <div class="grid-col-12">
 
@@ -20,7 +21,8 @@
     </header>
 
     <section>
-      <div class="grid-container grid-container-desktop" data-edit-this="{{- .Path -}}">
+      {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+      <div class="grid-container grid-container-desktop" data-edit-this="{{- $path -}}">
         <div class="grid-row tablet-lg:grid-gap-6">
 
           <div class="grid-col-12 tablet:grid-col-9">

--- a/themes/digital.gov/layouts/_default/images.html
+++ b/themes/digital.gov/layouts/_default/images.html
@@ -5,7 +5,8 @@
     <header>
       <div class="grid-container grid-container-desktop">
         <div class="grid-row">
-          <div class="grid-col-12" data-edit-this="{{- .Path -}}">
+          {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+          <div class="grid-col-12" data-edit-this="{{- $path -}}">
             <p class="breadcrumb"><a href="{{- "/" | absURL -}}"> <i class="fas fa-arrow-left"></i> <span>Home</span> </a></p>
             {{- if .Params.kicker -}}
             <p class="kicker">{{- .Params.kicker -}}</p>
@@ -25,8 +26,8 @@
     <section>
       <div class="grid-container grid-container-desktop">
         <div class="grid-row">
-
-          <div class="grid-col-12" data-edit-this="{{- .Path -}}">
+          {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+          <div class="grid-col-12" data-edit-this="{{- $path -}}">
 
             {{/* Content */}}
             <div class="content">

--- a/themes/digital.gov/layouts/_default/images.html
+++ b/themes/digital.gov/layouts/_default/images.html
@@ -1,11 +1,10 @@
 {{- define "content" -}}
-
+{{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
 <main role="main" id="main-content">
   <article>
     <header>
       <div class="grid-container grid-container-desktop">
         <div class="grid-row">
-          {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
           <div class="grid-col-12" data-edit-this="{{- $path -}}">
             <p class="breadcrumb"><a href="{{- "/" | absURL -}}"> <i class="fas fa-arrow-left"></i> <span>Home</span> </a></p>
             {{- if .Params.kicker -}}
@@ -26,7 +25,6 @@
     <section>
       <div class="grid-container grid-container-desktop">
         <div class="grid-row">
-          {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
           <div class="grid-col-12" data-edit-this="{{- $path -}}">
 
             {{/* Content */}}

--- a/themes/digital.gov/layouts/_default/list.json.json
+++ b/themes/digital.gov/layouts/_default/list.json.json
@@ -100,9 +100,10 @@
 
       "branch" : {{ $.Scratch.Get "branch" | jsonify }},
       "filename" : {{- with .File -}}{{- .LogicalName | jsonify -}}{{- end -}},
-      "filepath" : {{- with .File -}}{{- .Path | jsonify -}}{{- end -}},
-      "filepathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/blob/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") .Path | jsonify -}}{{- end -}},
-      "editpathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/edit/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") .Path | jsonify -}}{{- end -}},
+      {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+      "filepath" : {{- with .File -}}{{- $path | jsonify -}}{{- end -}},
+      "filepathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/blob/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $path | jsonify -}}{{- end -}},
+      "editpathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/edit/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $path | jsonify -}}{{- end -}},
       {{- if .Params.source -}}
       "source" : "{{- .Params.source -}}",
       {{- end -}}
@@ -131,7 +132,7 @@
       {{- end -}}
 
       {{- partial "api/slug.html" . -}}
-      
+
       "url" : "{{- .Permalink -}}"
     }{{- if ne (add $index 1) $length -}},{{- end -}}
     {{- end -}}

--- a/themes/digital.gov/layouts/_default/single.html
+++ b/themes/digital.gov/layouts/_default/single.html
@@ -3,7 +3,8 @@
 <main role="main" id="main-content">
   <article>
     <header>
-      <div class="grid-container grid-container-desktop" data-edit-this="{{- .Path -}}">
+      {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+      <div class="grid-container grid-container-desktop" data-edit-this="{{- $path -}}">
         <div class="grid-row">
           <div class="grid-col-12">
 
@@ -29,7 +30,8 @@
     </header>
 
     <section>
-      <div class="grid-container grid-container-desktop" data-edit-this="{{- .Path -}}">
+      {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+      <div class="grid-container grid-container-desktop" data-edit-this="{{- $path -}}">
         <div class="grid-row tablet-lg:grid-gap-6">
 
           <div class="grid-col-12 tablet:grid-col-9">

--- a/themes/digital.gov/layouts/_default/single.html
+++ b/themes/digital.gov/layouts/_default/single.html
@@ -1,9 +1,8 @@
 {{- define "content" -}}
-
+{{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
 <main role="main" id="main-content">
   <article>
     <header>
-      {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
       <div class="grid-container grid-container-desktop" data-edit-this="{{- $path -}}">
         <div class="grid-row">
           <div class="grid-col-12">
@@ -30,7 +29,6 @@
     </header>
 
     <section>
-      {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
       <div class="grid-container grid-container-desktop" data-edit-this="{{- $path -}}">
         <div class="grid-row tablet-lg:grid-gap-6">
 

--- a/themes/digital.gov/layouts/_default/single.json.json
+++ b/themes/digital.gov/layouts/_default/single.json.json
@@ -93,9 +93,10 @@
 
       "branch" : {{ $.Scratch.Get "branch" | jsonify }},
       "filename" : {{- with .File -}}{{- .LogicalName | jsonify -}}{{- end -}},
-      "filepath" : {{- with .File -}}{{- .Path | jsonify -}}{{- end -}},
-      "filepathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/blob/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") .Path | jsonify -}}{{- end -}},
-      "editpathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/edit/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") .Path | jsonify -}}{{- end -}},
+      {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+      "filepath" : {{- with .File -}}{{- $path | jsonify -}}{{- end -}},
+      "filepathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/blob/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $path | jsonify -}}{{- end -}},
+      "editpathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/edit/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $path | jsonify -}}{{- end -}},
       {{- if .Params.source -}}
       "source" : "{{- .Params.source -}}",
       {{- end -}}
@@ -104,7 +105,7 @@
       {{- end -}}
 
       {{- partial "api/slug.html" . -}}
-      
+
       "url" : "{{- .Permalink -}}",
       {{- if .Params.aliases -}}
       "aliases" : {

--- a/themes/digital.gov/layouts/authors/list.html
+++ b/themes/digital.gov/layouts/authors/list.html
@@ -4,7 +4,8 @@
   <section class="author-profile">
     <div class="grid-container grid-container-desktop">
       <div class="grid-row tablet-lg:grid-gap-6">
-        <div class="grid-col-12" data-edit-this="{{- .Path -}}">
+        {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+        <div class="grid-col-12" data-edit-this="{{- $path -}}">
           <header>
 
             {{- if .Params.github -}}

--- a/themes/digital.gov/layouts/authors/list.json.json
+++ b/themes/digital.gov/layouts/authors/list.json.json
@@ -62,9 +62,10 @@
     {{- end -}}
     "branch" : {{ $.Scratch.Get "branch" | jsonify }},
     "filename" : {{- with .File -}}{{- .LogicalName | jsonify -}}{{- end -}},
-    "filepath" : {{- with .File -}}{{- .Path | jsonify -}}{{- end -}},
-    "filepathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/blob/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") .Path | jsonify -}}{{- end -}},
-    "editpathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/edit/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") .Path | jsonify -}}{{- end -}},
+    {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+    "filepath" : {{- with .File -}}{{- $path | jsonify -}}{{- end -}},
+    "filepathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/blob/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $path | jsonify -}}{{- end -}},
+    "editpathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/edit/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $path | jsonify -}}{{- end -}},
     "url" : "{{- .Permalink -}}",
     "items" : [
     {{- range $index, $element := $list -}}
@@ -126,9 +127,10 @@
 
         "branch" : {{ $.Scratch.Get "branch" | jsonify }},
         "filename" : {{- with .File -}}{{- .LogicalName | jsonify -}}{{- end -}},
-        "filepath" : {{- with .File -}}{{- .Path | jsonify -}}{{- end -}},
-        "filepathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/blob/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") .Path | jsonify -}}{{- end -}},
-        "editpathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/edit/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") .Path | jsonify -}}{{- end -}},
+        {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+        "filepath" : {{- with .File -}}{{- $path | jsonify -}}{{- end -}},
+        "filepathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/blob/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $path | jsonify -}}{{- end -}},
+        "editpathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/edit/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $path | jsonify -}}{{- end -}},
         "url" : "{{- .Permalink -}}"
     }{{- if ne (add $index 1) $length -}},{{- end -}}
     {{- end -}}

--- a/themes/digital.gov/layouts/authors/list.json.json
+++ b/themes/digital.gov/layouts/authors/list.json.json
@@ -127,7 +127,6 @@
 
         "branch" : {{ $.Scratch.Get "branch" | jsonify }},
         "filename" : {{- with .File -}}{{- .LogicalName | jsonify -}}{{- end -}},
-        {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
         "filepath" : {{- with .File -}}{{- $path | jsonify -}}{{- end -}},
         "filepathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/blob/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $path | jsonify -}}{{- end -}},
         "editpathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/edit/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $path | jsonify -}}{{- end -}},

--- a/themes/digital.gov/layouts/authors/terms.html
+++ b/themes/digital.gov/layouts/authors/terms.html
@@ -26,7 +26,8 @@
               {{- range $i, $author := $authors -}}
                 {{ if .Params.slug }}
                   {{ $link := printf "authors/%s/" .Params.slug }}
-                  <div class="author grid-row" data-edit-this="{{- .Path -}}">
+                  {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+                  <div class="author grid-row" data-edit-this="{{- $path -}}">
                     <div class="grid-col-auto">
                       <div class="photo">
                         {{- if $author.Params.github -}}

--- a/themes/digital.gov/layouts/communities/archived.html
+++ b/themes/digital.gov/layouts/communities/archived.html
@@ -6,7 +6,8 @@
     <header>
       <div class="grid-container grid-container-desktop">
         <div class="grid-row">
-          <div class="grid-col-12" data-edit-this="{{- .Path -}}">
+          {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+          <div class="grid-col-12" data-edit-this="{{- $path -}}">
 
             <p class="breadcrumb"><a href="{{ .Parent.Permalink }}" title="{{ .Parent.Title }}"><i class="fas fa-arrow-left"></i> <span>{{ .Parent.Title }}</span></a></p>
             {{/* Page Title */}}
@@ -25,7 +26,7 @@
             </div>
               <div class="community_events">
               {{- partial "core/get-upcomingevents.html" . -}}
-              {{- partial "core/get-pastevents.html" . -}}              
+              {{- partial "core/get-pastevents.html" . -}}
             </div>
             <div>
               <br/>

--- a/themes/digital.gov/layouts/communities/list.json.json
+++ b/themes/digital.gov/layouts/communities/list.json.json
@@ -101,9 +101,10 @@
 
       "branch" : {{ $.Scratch.Get "branch" | jsonify }},
       "filename" : {{- with .File -}}{{- .LogicalName | jsonify -}}{{- end -}},
-      "filepath" : {{- with .File -}}{{- .Path | jsonify -}}{{- end -}},
-      "filepathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/blob/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") .Path | jsonify -}}{{- end -}},
-      "editpathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/edit/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") .Path | jsonify -}}{{- end -}},
+      {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+      "filepath" : {{- with .File -}}{{- $path | jsonify -}}{{- end -}},
+      "filepathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/blob/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $path | jsonify -}}{{- end -}},
+      "editpathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/edit/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $path | jsonify -}}{{- end -}},
       {{- if .Params.source -}}
       "source" : "{{- .Params.source -}}",
       {{- end -}}
@@ -132,7 +133,7 @@
       {{- end -}}
 
       {{- partial "api/slug.html" . -}}
-      
+
       "url" : "{{- .Permalink -}}"
     }{{- if ne (add $index 1) $length -}},{{- end -}}
     {{- end -}}

--- a/themes/digital.gov/layouts/communities/single.html
+++ b/themes/digital.gov/layouts/communities/single.html
@@ -6,7 +6,8 @@
     <header>
       <div class="grid-container grid-container-desktop">
         <div class="grid-row">
-          <div class="grid-col-12" data-edit-this="{{- .Path -}}">
+          {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+          <div class="grid-col-12" data-edit-this="{{- $path -}}">
 
             <p class="breadcrumb"><a href="{{ .Parent.Permalink }}" title="{{ .Parent.Title }}"><i class="fas fa-arrow-left"></i> <span>{{ .Parent.Title }}</span></a></p>
             {{/* Page Title */}}
@@ -132,9 +133,9 @@
               {{- .Content -}}
             </div>
               <div class="community_events">
-              {{- partial "core/get-upcomingevents.html" . -}}         
+              {{- partial "core/get-upcomingevents.html" . -}}
             </div>
-            
+
             <div class="Community_conduct">
               <h2 id="community-conduct">Community Conduct</h2>
               {{- partial "core/community_pagefooter.html" . -}}

--- a/themes/digital.gov/layouts/communities/single.json.json
+++ b/themes/digital.gov/layouts/communities/single.json.json
@@ -96,9 +96,10 @@
 
       "branch" : {{ $.Scratch.Get "branch" | jsonify }},
       "filename" : {{- with .File -}}{{- .LogicalName | jsonify -}}{{- end -}},
-      "filepath" : {{- with .File -}}{{- .Path | jsonify -}}{{- end -}},
-      "filepathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/blob/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") .Path | jsonify -}}{{- end -}},
-      "editpathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/edit/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") .Path | jsonify -}}{{- end -}},
+      {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+      "filepath" : {{- with .File -}}{{- $path | jsonify -}}{{- end -}},
+      "filepathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/blob/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $path | jsonify -}}{{- end -}},
+      "editpathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/edit/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $path | jsonify -}}{{- end -}},
       {{- if .Params.source -}}
       "source" : "{{- .Params.source -}}",
       {{- end -}}

--- a/themes/digital.gov/layouts/events/card-event-past.html
+++ b/themes/digital.gov/layouts/events/card-event-past.html
@@ -1,4 +1,5 @@
-<div class="card card-event card-event-past card-linked" data-edit-this="{{- .Path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
+{{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+<div class="card card-event card-event-past card-linked" data-edit-this="{{- $path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
   <div class="grid-row tablet:grid-gap-4">
 
     {{- if .Params.youtube_id -}}

--- a/themes/digital.gov/layouts/events/card-event.html
+++ b/themes/digital.gov/layouts/events/card-event.html
@@ -1,5 +1,6 @@
-<div class="card card-event-promo card-linked" data-edit-this="{{- .Path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
-
+{{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+<div class="card card-event-promo card-linked" data-edit-this="{{- $path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
+  {{- print ".Path" -}}
   <div class="grid-row tablet:grid-gap-4">
 
     <div class="grid-col-9 tablet-lg:grid-col-10">

--- a/themes/digital.gov/layouts/events/card-event.html
+++ b/themes/digital.gov/layouts/events/card-event.html
@@ -1,6 +1,5 @@
 {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
 <div class="card card-event-promo card-linked" data-edit-this="{{- $path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
-  {{- print ".Path" -}}
   <div class="grid-row tablet:grid-gap-4">
 
     <div class="grid-col-9 tablet-lg:grid-col-10">

--- a/themes/digital.gov/layouts/events/list.html
+++ b/themes/digital.gov/layouts/events/list.html
@@ -4,7 +4,8 @@
   <header class="page-head page-head-{{- .Type -}}">
     <div class="grid-container grid-container-desktop">
       <div class="grid-row">
-        <div class="grid-col-12" data-edit-this="{{- .Path -}}">
+        {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+        <div class="grid-col-12" data-edit-this="{{- $path -}}">
 
           {{/* Page Title */}}
           <h1>{{- .Title | markdownify -}} </h1>

--- a/themes/digital.gov/layouts/events/list.json.json
+++ b/themes/digital.gov/layouts/events/list.json.json
@@ -136,9 +136,10 @@
 
       "branch" : {{ $.Scratch.Get "branch" | jsonify }},
       "filename" : {{- with .File -}}{{- .LogicalName | jsonify -}}{{- end -}},
-      "filepath" : {{- with .File -}}{{- .Path | jsonify -}}{{- end -}},
-      "filepathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/blob/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") .Path | jsonify -}}{{- end -}},
-      "editpathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/edit/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") .Path | jsonify -}}{{- end -}},
+      {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+      "filepath" : {{- with .File -}}{{- $path | jsonify -}}{{- end -}},
+      "filepathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/blob/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $path | jsonify -}}{{- end -}},
+      "editpathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/edit/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $path | jsonify -}}{{- end -}},
       {{- if .Params.weight -}}
       "weight" : "{{- .Params.weight -}}",
       {{- end -}}
@@ -161,7 +162,7 @@
       {{- end -}}
 
       {{- partial "api/slug.html" . -}}
-      
+
       "url" : "{{- .Permalink -}}"
     }{{- if ne (add $index 1) $length -}},{{- end -}}
     {{- end -}}

--- a/themes/digital.gov/layouts/events/single.html
+++ b/themes/digital.gov/layouts/events/single.html
@@ -9,14 +9,13 @@
 {{- $event_desc := $.Params.summary | default $.Site.Params.description | markdownify -}}
 {{- $event_description := (print $event_desc $event_url) -}}
 {{- $event_location := .Params.venue.venue_name -}}
+{{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
 
 <main role="main" id="main-content" class="event">
   <article>
-
     <header>
       <div class="grid-container grid-container-desktop">
         <div class="grid-row">
-          {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
           <div class="grid-col-12" data-edit-this="{{- $path -}}">
             <p class="breadcrumb"><a href="{{- "events/" | absURL -}}"> <i class="fas fa-arrow-left"></i> <span>All Events</span> </a></p>
             {{- if .Params.kicker -}}
@@ -60,7 +59,6 @@
           <div class="actions">
             {{/* Register */}}
             <a [attr.aria-label]="Register for {{- .Params.title -}}" class="btn btn-register" href="{{- .Params.registration_url -}}" onclick="__gaTracker('send', 'event', 'outbound-article', '{{- .Params.registration_url -}}', 'REGISTER NOW');">Register</a>
-
             <span class="addtocalendar">
               <a class="atcb-link" title="Add to calendar"><i class="far fa-calendar-plus"></i> Add to Cal</a>
               <var class="atc_event">
@@ -108,7 +106,6 @@
 
 
     <section>
-      {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
       <div class="grid-container grid-container-desktop" data-edit-this="{{- $path -}}">
         <div class="grid-row tablet-lg:grid-gap-4">
           <div class="grid-col-12 tablet:grid-col-9">

--- a/themes/digital.gov/layouts/events/single.html
+++ b/themes/digital.gov/layouts/events/single.html
@@ -16,7 +16,8 @@
     <header>
       <div class="grid-container grid-container-desktop">
         <div class="grid-row">
-          <div class="grid-col-12" data-edit-this="{{- .Path -}}">
+          {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+          <div class="grid-col-12" data-edit-this="{{- $path -}}">
             <p class="breadcrumb"><a href="{{- "events/" | absURL -}}"> <i class="fas fa-arrow-left"></i> <span>All Events</span> </a></p>
             {{- if .Params.kicker -}}
             <p class="kicker">{{- .Params.kicker -}}</p>
@@ -107,7 +108,8 @@
 
 
     <section>
-      <div class="grid-container grid-container-desktop" data-edit-this="{{- .Path -}}">
+      {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+      <div class="grid-container grid-container-desktop" data-edit-this="{{- $path -}}">
         <div class="grid-row tablet-lg:grid-gap-4">
           <div class="grid-col-12 tablet:grid-col-9">
 

--- a/themes/digital.gov/layouts/events/single.json.json
+++ b/themes/digital.gov/layouts/events/single.json.json
@@ -130,9 +130,10 @@
       "content" : {{- .Content | jsonify -}},
       "branch" : {{ $.Scratch.Get "branch" | jsonify }},
       "filename" : {{- with .File -}}{{- .LogicalName | jsonify -}}{{- end -}},
-      "filepath" : {{- with .File -}}{{- .Path | jsonify -}}{{- end -}},
-      "filepathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/blob/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") .Path | jsonify -}}{{- end -}},
-      "editpathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/edit/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") .Path | jsonify -}}{{- end -}},
+      {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+      "filepath" : {{- with .File -}}{{- $path | jsonify -}}{{- end -}},
+      "filepathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/blob/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $path | jsonify -}}{{- end -}},
+      "editpathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/edit/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $path | jsonify -}}{{- end -}},
       {{- if .Params.weight -}}
       "weight" : "{{- .Params.weight -}}",
       {{- end -}}

--- a/themes/digital.gov/layouts/events/training-card.html
+++ b/themes/digital.gov/layouts/events/training-card.html
@@ -1,4 +1,5 @@
-<article class="event card promo" data-edit-this="{{- .Path -}}">
+{{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+<article class="event card promo" data-edit-this="{{- $path -}}">
   <div class="grid-row tablet-lg:grid-gap-2">
     <div class="grid-col-12 tablet:grid-col-4">
       <div aria-label="an image from the video" class="youtube-card" data-id="{{ .Params.youtube_id }}" data-link="{{ .Permalink }}"></div>

--- a/themes/digital.gov/layouts/guides/single.html
+++ b/themes/digital.gov/layouts/guides/single.html
@@ -1,4 +1,5 @@
 {{ define "content" }}
+{{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
 
 <main role="main" id="main-content">
 
@@ -9,13 +10,11 @@
     <div class="grid-container grid-container-desktop">
       <div class="grid-row grid-gap-4">
 
-        {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
         <div class="grid-col-12 tablet-lg:grid-col-2" data-edit-this="{{- $path -}}">
           {{- partial "core/guides/guide-nav.html" . -}}
         </div>
 
         <div class="grid-col-12 tablet-lg:grid-col-8">
-          {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
           <div class="guide-content usa-layout-docs__main usa-prose" data-edit-this="{{- $path -}}">
 
             {{- partial "core/guides/guide-page-head.html" . -}}

--- a/themes/digital.gov/layouts/guides/single.html
+++ b/themes/digital.gov/layouts/guides/single.html
@@ -9,12 +9,14 @@
     <div class="grid-container grid-container-desktop">
       <div class="grid-row grid-gap-4">
 
-        <div class="grid-col-12 tablet-lg:grid-col-2" data-edit-this="{{- .Path -}}">
+        {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+        <div class="grid-col-12 tablet-lg:grid-col-2" data-edit-this="{{- $path -}}">
           {{- partial "core/guides/guide-nav.html" . -}}
         </div>
 
         <div class="grid-col-12 tablet-lg:grid-col-8">
-          <div class="guide-content usa-layout-docs__main usa-prose" data-edit-this="{{- .Path -}}">
+          {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+          <div class="guide-content usa-layout-docs__main usa-prose" data-edit-this="{{- $path -}}">
 
             {{- partial "core/guides/guide-page-head.html" . -}}
 

--- a/themes/digital.gov/layouts/news/card-article.html
+++ b/themes/digital.gov/layouts/news/card-article.html
@@ -1,4 +1,5 @@
-<div class="card card-article card-linked" data-edit-this="{{- .Path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
+{{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+<div class="card card-article card-linked" data-edit-this="{{- $path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
   <div class="grid-row tablet:grid-gap-4">
     <div class="grid-col-12 tablet:grid-col-4 tablet:order-2">
       {{- partial "core/img-featured.html" . -}}

--- a/themes/digital.gov/layouts/news/card-elsewhere.html
+++ b/themes/digital.gov/layouts/news/card-elsewhere.html
@@ -1,4 +1,5 @@
-<div class="card card-elsewhere card-linked" data-edit-this="{{- .Path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
+{{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+<div class="card card-elsewhere card-linked" data-edit-this="{{- $path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
   <div>
     <div class="icon">
       {{/* Favicon

--- a/themes/digital.gov/layouts/news/list.html
+++ b/themes/digital.gov/layouts/news/list.html
@@ -4,7 +4,8 @@
 
   <div class="grid-container grid-container-desktop">
     <div class="grid-row">
-      <div class="grid-col-12" data-edit-this="{{- .Path -}}">
+      {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+      <div class="grid-col-12" data-edit-this="{{- $path -}}">
         <header class="page-head page-head-{{- .Type -}}">
 
           {{/* Page Title */}}

--- a/themes/digital.gov/layouts/news/single.html
+++ b/themes/digital.gov/layouts/news/single.html
@@ -1,9 +1,9 @@
 {{- define "content" -}}
+{{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
 
 <main role="main" id="main-content">
   <article {{ if .Params.short_url -}}data-short_url="{{- .Params.short_url -}}"{{- end -}}>
     <header>
-      {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
       <div class="grid-container grid-container-desktop" data-edit-this="{{- $path -}}">
         <div class="grid-row">
           <div class="grid-col-12">
@@ -34,7 +34,6 @@
     </header>
 
     <section>
-      {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
       <div class="grid-container grid-container-desktop" data-edit-this="{{- $path -}}">
         <div class="grid-row tablet-lg:grid-gap-6">
 

--- a/themes/digital.gov/layouts/news/single.html
+++ b/themes/digital.gov/layouts/news/single.html
@@ -3,7 +3,8 @@
 <main role="main" id="main-content">
   <article {{ if .Params.short_url -}}data-short_url="{{- .Params.short_url -}}"{{- end -}}>
     <header>
-      <div class="grid-container grid-container-desktop" data-edit-this="{{- .Path -}}">
+      {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+      <div class="grid-container grid-container-desktop" data-edit-this="{{- $path -}}">
         <div class="grid-row">
           <div class="grid-col-12">
             <p class="breadcrumb"><a href="{{- "news" | absURL -}}"> <i class="fas fa-arrow-left"></i> <span>Latest News</span> </a></p>
@@ -33,7 +34,8 @@
     </header>
 
     <section>
-      <div class="grid-container grid-container-desktop" data-edit-this="{{- .Path -}}">
+      {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+      <div class="grid-container grid-container-desktop" data-edit-this="{{- $path -}}">
         <div class="grid-row tablet-lg:grid-gap-6">
 
           <div class="grid-col-12 tablet-lg:grid-col-9 tablet-lg:order-last">

--- a/themes/digital.gov/layouts/partials/core/collection.html
+++ b/themes/digital.gov/layouts/partials/core/collection.html
@@ -65,7 +65,8 @@
   {{- $href := .href -}}
   {{- $src := .src -}}
   {{- with .item -}}
-  <li data-edit-this="{{- .Path -}}">
+  {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+  <li data-edit-this="{{- $path -}}">
 
     {{- template "collection-icon" dict "item" . "src" $src "href" $href -}}
 

--- a/themes/digital.gov/layouts/partials/core/get_related.html
+++ b/themes/digital.gov/layouts/partials/core/get_related.html
@@ -106,7 +106,8 @@
   {{- $href := .href -}}
   {{- $src := .src -}}
   {{- with .item -}}
-    <div class="promo" data-edit-this="{{- .Path -}}">
+    {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+    <div class="promo" data-edit-this="{{- $path -}}">
       <div>
         <h4>
           <a class="external-link" href="{{- .Params.source_url -}}?=dg" title="{{ .Title | markdownify -}}"><span>{{- .Title | markdownify -}}</span></a>

--- a/themes/digital.gov/layouts/partials/core/get_sharetools.html
+++ b/themes/digital.gov/layouts/partials/core/get_sharetools.html
@@ -1,5 +1,7 @@
 {{/* Share tools */}}
 
+{{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+<!-- Test syntax -->
 <section class="share_tools">
   <div class="grid-row">
     <div class="grid-col-4">

--- a/themes/digital.gov/layouts/partials/core/get_sharetools.html
+++ b/themes/digital.gov/layouts/partials/core/get_sharetools.html
@@ -1,22 +1,23 @@
 {{/* Share tools */}}
 
 {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+
 <!-- Test syntax -->
 <section class="share_tools">
   <div class="grid-row">
     <div class="grid-col-4">
-      <a class="twitter" href="http://twitter.com/share?url=https://digital.gov{{ (urls.Parse .Permalink).Path }}&amp;text={{ .Title }}"><i class="fab fa-twitter"></i></a>
+      <a class="twitter" href="http://twitter.com/share?url=https://digital.gov{{ (urls.Parse .Permalink)}}{{$path}}&amp;text={{ .Title }}"><i class="fab fa-twitter"></i></a>
     </div>
     <div class="grid-col-4">
-      <a class="facebook" href="http://www.facebook.com/sharer.php?u=https://digital.gov{{ (urls.Parse .Permalink).Path }}&t={{ .Title | urlize }}"><i class="fab fa-facebook-f"></i></a>
+      <a class="facebook" href="http://www.facebook.com/sharer.php?u=https://digital.gov{{ (urls.Parse .Permalink)}}{{$path}}&t={{ .Title | urlize }}"><i class="fab fa-facebook-f"></i></a>
     </div>
     <div class="grid-col-4">
-      <a class="linkedin" href="https://www.linkedin.com/shareArticle?mini=true&url=https://digital.gov{{ (urls.Parse .Permalink).Path }}&title={{ .Title | urlize }}&summary={{ .Params.summary | urlize }}&source={{ "Digital.gov" | urlize }}"><i class="fab fa-linkedin-in"></i></a>
+      <a class="linkedin" href="https://www.linkedin.com/shareArticle?mini=true&url=https://digital.gov{{ (urls.Parse .Permalink)}}{{$path}}&title={{ .Title | urlize }}&summary={{ .Params.summary | urlize }}&source={{ "Digital.gov" | urlize }}"><i class="fab fa-linkedin-in"></i></a>
     </div>
   </div>
   <div class="grid-row">
     <div class="grid-col-6">
-      <a target="_blank" title="Email this page" class="email" href="mailto:?subject={{ .Title }}%20%7C%20Digital.gov&body=%20%20%0A-------%0A{{ .Title }}%0Ahttps://digital.gov{{ (urls.Parse .Permalink).Path }}%3Fem%0A-------%0A%0A&#9829; Sign-up%20for%20the%20Digital.gov%20newsletter%3A%20https%3A%2F%2Fdigital.gov%2Fsubscribe%2F" data-proofer-ignore><i class="fas fa-envelope"></i> Email</a>
+      <a target="_blank" title="Email this page" class="email" href="mailto:?subject={{ .Title }}%20%7C%20Digital.gov&body=%20%20%0A-------%0A{{ .Title }}%0Ahttps://digital.gov{{ (urls.Parse .Permalink)}}{{$path}}%3Fem%0A-------%0A%0A&#9829; Sign-up%20for%20the%20Digital.gov%20newsletter%3A%20https%3A%2F%2Fdigital.gov%2Fsubscribe%2F" data-proofer-ignore><i class="fas fa-envelope"></i> Email</a>
     </div>
     <div class="grid-col-6">
       <a class="print" href="javascript:window.print()" onclick="window.print();return false;"><i class="fas fa-print"></i> Print</a>

--- a/themes/digital.gov/layouts/partials/core/head.html
+++ b/themes/digital.gov/layouts/partials/core/head.html
@@ -174,9 +174,10 @@
     branch           = {{ $.Scratch.Get "branch" }};
     short_url        = {{ if .Params.short_url -}}{{- .Params.short_url -}}{{ else }}""{{- end -}};
     filename         = {{ with .File -}}{{- .LogicalName -}}{{- end }};
-    filepath         = {{ with .File -}}{{ .Path }}{{- end }};
-    filepathURL      = {{ with .File -}}{{ printf "https://github.com/%s/%s/blob/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $.Path -}}{{- end }};
-    editpathURL      = {{ with .File -}}{{ printf "https://github.com/%s/%s/edit/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $.Path -}}{{- end }};
+    {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+    filepath         = {{ with .File -}}{{ $path }}{{- end }};
+    filepathURL      = {{ with .File -}}{{ printf "https://github.com/%s/%s/blob/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $path -}}{{- end }};
+    editpathURL      = {{ with .File -}}{{ printf "https://github.com/%s/%s/edit/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $path -}}{{- end }};
     <!-- {{ getenv "BRANCH" }} | {{ $.Scratch.Get "branch" }} -->
   </script>
 
@@ -187,5 +188,5 @@
   {{- end -}}
 
   <script type="text/javascript" src="//script.crazyegg.com/pages/scripts/0007/9651.js" async="async" ></script>
-  
+
 </head>

--- a/themes/digital.gov/layouts/partials/core/home/topics_featured.html
+++ b/themes/digital.gov/layouts/partials/core/home/topics_featured.html
@@ -12,8 +12,9 @@
         {{- with $.Site.GetPage (printf "/topics/%s" $name) -}}
           {{- if eq .Params.weight 3 -}}
 
-            <div class="grid-col-6 tablet:grid-col-4 ">
-              <div class="topic" data-edit-this="{{- .Path -}}">
+            <div class="grid-col-6 tablet:grid-col-4">
+              {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+              <div class="topic" data-edit-this="{{- $path -}}">
                 <h3>
                   <a href="{{- .Permalink | absURL -}}" title="{{- .Title -}}">{{- .Title -}} <span>&#8594;</span></a>
                 </h3>

--- a/themes/digital.gov/layouts/partials/core/overlay.html
+++ b/themes/digital.gov/layouts/partials/core/overlay.html
@@ -3,6 +3,7 @@
     <h6>File name</h6>
     {{- with .File -}}<p>{{- .LogicalName -}}</p>{{- end -}}
     <h6>File path</h6>
+    <!-- Test before updating syntax -->
     {{- with .File -}}<p>{{- .Path }}</p>{{- end -}}
     <h6>Link Shortcode</h6>
     {{- with .File -}}<p>&#x0007B;&#x0007B;&#x0003C; link "{{- .Path }}<p>" &#x0003E;&#x0007D;&#x0007D;</p>{{- end -}}

--- a/themes/digital.gov/layouts/partials/core/overlay.html
+++ b/themes/digital.gov/layouts/partials/core/overlay.html
@@ -3,10 +3,10 @@
     <h6>File name</h6>
     {{- with .File -}}<p>{{- .LogicalName -}}</p>{{- end -}}
     <h6>File path</h6>
-    <!-- Test before updating syntax -->
-    {{- with .File -}}<p>{{- .Path }}</p>{{- end -}}
+    {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+    {{- with .File -}}<p>{{- $path }}</p>{{- end -}}
     <h6>Link Shortcode</h6>
-    {{- with .File -}}<p>&#x0007B;&#x0007B;&#x0003C; link "{{- .Path }}<p>" &#x0003E;&#x0007D;&#x0007D;</p>{{- end -}}
+    {{- with .File -}}<p>&#x0007B;&#x0007B;&#x0003C; link "{{- $path }}<p>" &#x0003E;&#x0007D;&#x0007D;</p>{{- end -}}
     <button class="close" type="button" name="button">close</button>
   </div>
 </div>

--- a/themes/digital.gov/layouts/resources/list.html
+++ b/themes/digital.gov/layouts/resources/list.html
@@ -5,7 +5,8 @@
     <header class="page-head page-head-{{- .Type -}}">
       <div class="grid-container grid-container-desktop">
         <div class="grid-row">
-          <div class="grid-col-12" data-edit-this="{{- .Path -}}">
+          {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+          <div class="grid-col-12" data-edit-this="{{- $path -}}">
 
             {{/* Page Title */}}
             <h1>{{- .Title | markdownify -}} </h1>
@@ -156,7 +157,8 @@
             {{- with $.Site.GetPage (printf "/topics/%s" $name) -}}
               {{- if or (eq .Params.weight 2) (eq .Params.weight 3) -}}
                 <div class="grid-col-12 tablet:grid-col-4">
-                  <div class="topic" data-edit-this="{{- .Path -}}">
+                  {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+                  <div class="topic" data-edit-this="{{- $path -}}">
                     <h3>
                       <a href="{{- .Permalink | absURL -}}" title="{{- .Title -}}">{{- .Title -}} <span>&#8594;</span></a>
                     </h3>

--- a/themes/digital.gov/layouts/resources/list.html
+++ b/themes/digital.gov/layouts/resources/list.html
@@ -1,11 +1,11 @@
 {{- define "content" -}}
+{{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
 
 <main role="main" id="main-content" class="main-resources">
   <article>
     <header class="page-head page-head-{{- .Type -}}">
       <div class="grid-container grid-container-desktop">
         <div class="grid-row">
-          {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
           <div class="grid-col-12" data-edit-this="{{- $path -}}">
 
             {{/* Page Title */}}
@@ -157,7 +157,6 @@
             {{- with $.Site.GetPage (printf "/topics/%s" $name) -}}
               {{- if or (eq .Params.weight 2) (eq .Params.weight 3) -}}
                 <div class="grid-col-12 tablet:grid-col-4">
-                  {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
                   <div class="topic" data-edit-this="{{- $path -}}">
                     <h3>
                       <a href="{{- .Permalink | absURL -}}" title="{{- .Title -}}">{{- .Title -}} <span>&#8594;</span></a>

--- a/themes/digital.gov/layouts/resources/single.html
+++ b/themes/digital.gov/layouts/resources/single.html
@@ -5,7 +5,8 @@
     <header>
       <div class="grid-container grid-container-desktop">
         <div class="grid-row">
-          <div class="grid-col-12" data-edit-this="{{- .Path -}}">
+          {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+          <div class="grid-col-12" data-edit-this="{{- $path -}}">
             <p class="breadcrumb"><a href="{{- "resources/" | absURL -}}"> <i class="fas fa-arrow-left"></i> <span>All Resources</span> </a></p>
             {{- if .Params.kicker -}}
             <p class="kicker">{{- .Params.kicker -}}</p>
@@ -26,7 +27,8 @@
       <div class="grid-container grid-container-desktop">
         <div class="grid-row tablet-lg:grid-gap-6">
 
-          <div class="grid-col-12 tablet:grid-col-9" data-edit-this="{{- .Path -}}">
+          {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+          <div class="grid-col-12 tablet:grid-col-9" data-edit-this="{{- $path -}}">
 
             {{/* Content */}}
             <div class="content usa-prose">
@@ -34,7 +36,7 @@
             </div>
 
             {{- partial "core/touchpoints_feedback.html" . -}}
-            
+
             {{- partial "core/page-data.html" (dict "page" . "page_type" "resource" "branch" ($.Scratch.Get "branch")) -}}
 
           </div>

--- a/themes/digital.gov/layouts/resources/single.html
+++ b/themes/digital.gov/layouts/resources/single.html
@@ -1,11 +1,11 @@
 {{- define "content" -}}
+{{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
 
 <main role="main" id="main-content">
   <article>
     <header>
       <div class="grid-container grid-container-desktop">
         <div class="grid-row">
-          {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
           <div class="grid-col-12" data-edit-this="{{- $path -}}">
             <p class="breadcrumb"><a href="{{- "resources/" | absURL -}}"> <i class="fas fa-arrow-left"></i> <span>All Resources</span> </a></p>
             {{- if .Params.kicker -}}
@@ -27,7 +27,6 @@
       <div class="grid-container grid-container-desktop">
         <div class="grid-row tablet-lg:grid-gap-6">
 
-          {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
           <div class="grid-col-12 tablet:grid-col-9" data-edit-this="{{- $path -}}">
 
             {{/* Content */}}

--- a/themes/digital.gov/layouts/services/card-service-contact.html
+++ b/themes/digital.gov/layouts/services/card-service-contact.html
@@ -57,7 +57,8 @@
   {{- $href := .href -}}
   {{- $src := .src -}}
   {{- with .item -}}
-  <div class="card card-service-contact" data-edit-this="{{- .Path -}}">
+  {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+  <div class="card card-service-contact" data-edit-this="{{- $path -}}">
 
     <div class="grid-row grid-gap-2">
       <div class="grid-col-12 tablet:grid-col-3">

--- a/themes/digital.gov/layouts/services/card-service.html
+++ b/themes/digital.gov/layouts/services/card-service.html
@@ -1,4 +1,10 @@
-<div class="card-service" data-edit-this="{{- .Path -}}">
+{{ $path := "" }}
+{{ with .File }}
+  {{ $path = .Path }}
+  {{ else }}
+  {{ $path = .Path }}
+{{ end }}
+<div class="card-service" data-edit-this="{{- .File.Path -}}">
 
   {{/* set the href as a variable */}}
   {{- $href := "" -}}

--- a/themes/digital.gov/layouts/services/card-service.html
+++ b/themes/digital.gov/layouts/services/card-service.html
@@ -1,10 +1,5 @@
-{{ $path := "" }}
-{{ with .File }}
-  {{ $path = .Path }}
-  {{ else }}
-  {{ $path = .Path }}
-{{ end }}
-<div class="card-service" data-edit-this="{{- .File.Path -}}">
+{{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+<div class="card-service" data-edit-this="{{- $path -}}">
 
   {{/* set the href as a variable */}}
   {{- $href := "" -}}

--- a/themes/digital.gov/layouts/services/directory.html
+++ b/themes/digital.gov/layouts/services/directory.html
@@ -5,7 +5,8 @@
   <div class="grid-container grid-container-desktop">
     <div class="grid-row tablet-lg:grid-gap-4">
       <div class="grid-col-12">
-        <header class="page-head page-head-{{- .Type -}}" data-edit-this="{{- .Path -}}">
+        {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+        <header class="page-head page-head-{{- .Type -}}" data-edit-this="{{- $path -}}">
 
           {{/* Page Title */}}
           <h1>{{- .Title | markdownify -}} </h1>

--- a/themes/digital.gov/layouts/shortcodes/api-authors.html
+++ b/themes/digital.gov/layouts/shortcodes/api-authors.html
@@ -43,7 +43,7 @@
         {{- end -}}
 
         {{- partial "api/bio.html" . -}}
-        
+
         {{- if .Params.bio_url -}}
         "bio_url" : "{{- .Params.bio_url -}}",
         {{- end -}}
@@ -75,9 +75,10 @@
         {{- with .File -}}
           "filename" : {{- .LogicalName | jsonify -}},
         {{- end -}}
-        "filepath" : {{ with .File -}}{{- .Path | jsonify -}}{{- end -}},
-        "filepathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/blob/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") .Path | jsonify -}}{{- end -}},
-        "editpathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/edit/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") .Path | jsonify -}}{{- end -}},
+        {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+        "filepath" : {{ with .File -}}{{- $path | jsonify -}}{{- end -}},
+        "filepathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/blob/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $path | jsonify -}}{{- end -}},
+        "editpathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/edit/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $path | jsonify -}}{{- end -}},
         {{- if .Params.aliases -}}
         "aliases" : {
           {{- $aliaslen := .Params.aliases | len -}}

--- a/themes/digital.gov/layouts/shortcodes/api-authors.html
+++ b/themes/digital.gov/layouts/shortcodes/api-authors.html
@@ -1,6 +1,6 @@
 {{- partial "core/set-env.html" . -}}
 {{- $list := where .Site.Pages "Section" "authors" -}}
-{{- $list := where $list ".Path" "ne" "authors/_index.md" -}}
+{{- $list := where $list "with .File.Path" "ne" "authors/_index.md" -}}
 {{- $length := len $list -}}
 {
   "version" : "https://jsonfeed.org/version/1",

--- a/themes/digital.gov/layouts/shortcodes/api-topics.html
+++ b/themes/digital.gov/layouts/shortcodes/api-topics.html
@@ -12,7 +12,8 @@
   {{- range $topic := $list.ByTitle -}}
     {{- with $topic -}}
       {
-        "slug" : "{{- with .File -}}{{- .Path | replaceRE "^topics/([^/]+).*" "$1" -}}{{- end -}}",
+        {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+        "slug" : "{{- with .File -}}{{- $path | replaceRE "^topics/([^/]+).*" "$1" -}}{{- end -}}",
         "title" : "{{- .Title -}}",
         "summary" : "{{- replace .Params.summary "\n" "\\n" -}}",
         {{- if .Params.aliases -}}
@@ -37,9 +38,10 @@
         {{- end -}}
         "branch" : {{- $.Scratch.Get "branch" | jsonify -}},
         "filename" : {{- with .File -}}{{- .LogicalName | jsonify -}}{{- end -}},
-        "filepath" : {{- with .File -}}{{- .Path | jsonify -}}{{- end -}},
-        "filepathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/blob/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") .Path | jsonify -}}{{- end -}},
-        "editpathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/edit/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") .Path | jsonify -}}{{- end -}},
+        {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+        "filepath" : {{- with .File -}}{{- $path | jsonify -}}{{- end -}},
+        "filepathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/blob/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $path | jsonify -}}{{- end -}},
+        "editpathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/edit/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $path | jsonify -}}{{- end -}},
         "length" : {{- $length -}},
         "iterator" : "{{- $.Scratch.Get "i" -}}"
       }

--- a/themes/digital.gov/layouts/shortcodes/api-topics.html
+++ b/themes/digital.gov/layouts/shortcodes/api-topics.html
@@ -38,7 +38,6 @@
         {{- end -}}
         "branch" : {{- $.Scratch.Get "branch" | jsonify -}},
         "filename" : {{- with .File -}}{{- .LogicalName | jsonify -}}{{- end -}},
-        {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
         "filepath" : {{- with .File -}}{{- $path | jsonify -}}{{- end -}},
         "filepathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/blob/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $path | jsonify -}}{{- end -}},
         "editpathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/edit/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $path | jsonify -}}{{- end -}},

--- a/themes/digital.gov/layouts/sources/list.json.json
+++ b/themes/digital.gov/layouts/sources/list.json.json
@@ -14,7 +14,7 @@
     {{- range $index, $element := $list -}}
     {
         {{- partial "api/slug.html" . -}}
-        
+
         {{- if (isset .Params "name") -}}
         "name" : "{{- .Params.name | markdownify -}}",
         {{- end -}}
@@ -56,9 +56,10 @@
 
         "branch" : {{ $.Scratch.Get "branch" | jsonify }},
         "filename" : {{- with .File -}}{{- .LogicalName | jsonify -}}{{- end -}},
-        "filepath" : {{- with .File -}}{{- .Path | jsonify -}}{{- end -}},
-        "filepathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/blob/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") .Path | jsonify -}}{{- end -}},
-        "editpathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/edit/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") .Path | jsonify -}}{{- end -}},
+        {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+        "filepath" : {{- with .File -}}{{- $path | jsonify -}}{{- end -}},
+        "filepathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/blob/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $path | jsonify -}}{{- end -}},
+        "editpathURL" : {{- with .File -}}{{- printf "https://github.com/%s/%s/edit/%s/content/%s" $.Site.Params.git_org $.Site.Params.git_repo ($.Scratch.Get "branch") $path | jsonify -}}{{- end -}},
         "url" : "{{- .Permalink -}}"
     }{{- if ne (add $index 1) $length -}},{{- end -}}
     {{- end -}}

--- a/themes/digital.gov/layouts/topics/list.html
+++ b/themes/digital.gov/layouts/topics/list.html
@@ -5,7 +5,8 @@
 
 <main role="main" id="main-content" class="main-topic">
   <div class="grid-container grid-container-desktop">
-    <div class="grid-row tablet-lg:grid-gap-4" data-edit-this="{{- .Path -}}">
+    {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+    <div class="grid-row tablet-lg:grid-gap-4" data-edit-this="{{- $path -}}">
       <div class="grid-col-12">
         <header class="page-header">
           <p class="breadcrumb"><a href="{{- "resources/" | absURL -}}"> <i class="fas fa-arrow-left"></i> <span>All Resources</span> </a></p>

--- a/themes/digital.gov/layouts/topics/terms.html
+++ b/themes/digital.gov/layouts/topics/terms.html
@@ -1,6 +1,7 @@
 {{/* All Tags */}}
 {{/* lists out the tags for the site */}}
 {{- define "content" -}}
+{{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
 
 <main role="main" id="main-content">
 
@@ -24,7 +25,6 @@
           {{- with $.Site.GetPage (printf "/topics/%s" $name) -}}
             {{- if eq .Params.weight 2 -}}
               <div class="grid-col-12 tablet:grid-col-4">
-                {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
                 <div class="topic" data-edit-this="{{- $path -}}">
                   <h3>
                     <a href="{{- .Permalink | absURL -}}" title="{{- .Title -}}">{{- .Title -}} <span>&#8594;</span></a>
@@ -76,7 +76,6 @@
           {{/*
           Output the topic HTML
           */}}
-          {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
           <div class="topic" data-edit-this="{{- $path -}}">
             <p>
               <a href="{{- .Permalink -}}" title="{{- $name -}}"><span>{{- .Title -}}</span></a> <span class="count">{{- $taxonomy.Count -}}</span>

--- a/themes/digital.gov/layouts/topics/terms.html
+++ b/themes/digital.gov/layouts/topics/terms.html
@@ -24,7 +24,8 @@
           {{- with $.Site.GetPage (printf "/topics/%s" $name) -}}
             {{- if eq .Params.weight 2 -}}
               <div class="grid-col-12 tablet:grid-col-4">
-                <div class="topic" data-edit-this="{{- .Path -}}">
+                {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+                <div class="topic" data-edit-this="{{- $path -}}">
                   <h3>
                     <a href="{{- .Permalink | absURL -}}" title="{{- .Title -}}">{{- .Title -}} <span>&#8594;</span></a>
                   </h3>
@@ -75,7 +76,8 @@
           {{/*
           Output the topic HTML
           */}}
-          <div class="topic" data-edit-this="{{- .Path -}}">
+          {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+          <div class="topic" data-edit-this="{{- $path -}}">
             <p>
               <a href="{{- .Permalink -}}" title="{{- $name -}}"><span>{{- .Title -}}</span></a> <span class="count">{{- $taxonomy.Count -}}</span>
             </p>

--- a/themes/digital.gov/static/workflow/js/editorComponents/tweet.js
+++ b/themes/digital.gov/static/workflow/js/editorComponents/tweet.js
@@ -1,11 +1,16 @@
 const component = {
   id: "tweet",
   label: "Tweet",
-  hint: "example: {{< tweet 877500564405444608 >}}",
+  hint: "example: {{< tweet user='username' id='10100101010101' >}}",
   fields: [
     {
       name: "id",
       label: "Tweet id",
+      widget: "string"
+    },
+    {
+      name: "user",
+      label: "User name",
       widget: "string"
     }
   ],
@@ -16,10 +21,10 @@ const component = {
     };
   },
   toBlock: function(obj) {
-    return `{{< tweet ${obj.id} >}}`;
+    return `{{< tweet user='${obj.user}' id='${obj.id}' >}}`;
   },
   toPreview: function(obj) {
-    return `{{< tweet ${obj.id} >}}`;
+    return `{{< tweet user='${obj.user}' id='${obj.id}' >}}`;
   }
 };
 


### PR DESCRIPTION
This PR implements the following **changes:**

Updates for the `tweet` shortcode and `.Path` parameter.

tweet shortcode requires username and id and [applies to 1 file](https://digital.gov/2016/09/12/the-content-corner-using-social-media-to-promote-enhance-preparedness-for-the-public-we-serve/).

`'.Path'` updates are for the edit button, when clicked and the user edits the text box, it takes them to the github file to update. New syntax will provide a path for this field.

`'.Path'` param update from:

`<div ... data-edit-this="{{- .Path -}}">`

to

```
  {{ $path := "" }}
  {{ with .File }}
        {{ $path = .Path }}
  {{ else }}
        {{ $path = .Path }}
  {{ end }}
```

See links for more further details.

- [Hugo Issue 9348](https://github.com/gohugoio/hugo/issues/9348)
- [.Path when the page is backed by a file is deprecated](https://discourse.gohugo.io/t/path-when-the-page-is-backed-by-a-file-is-deprecated/36842)](https://discourse.gohugo.io/t/path-when-the-page-is-backed-by-a-file-is-deprecated/36842)

Note:

Some files are already using the suggested convention of calling `{{- with .File -}}` before the `{{ .Path }}`.
See [themes/digital.gov/layouts/shortcodes/api-topics.html](https://github.com/GSA/digitalgov.gov/blob/d3509b532f91d2ab2ffe162262afdb4b4ede9643/themes/digital.gov/layouts/shortcodes/api-topics.html#L15)