### PR TITLE
Adding BLS to Jean's author info

### DIFF
--- a/content/authors/jean-fox/_index.md
+++ b/content/authors/jean-fox/_index.md
@@ -26,10 +26,10 @@ bio: "Jean Fox is a Research Psychologist at the Bureau of Labor Statistics."
 bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "Bureau of Labor Statistics"
 
 # Agency Acronym [e.g., GSA]
-agency: ""
+agency: "BLS"
 
 # Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
 location: ""

--- a/content/authors/jean-fox/_index.md
+++ b/content/authors/jean-fox/_index.md
@@ -20,13 +20,13 @@ slug: jean-fox
 email: "fox.jean@bls.gov"
 
 # Bio — keep it under 50 words
-bio: "Jean Fox is a Research Psychologist at the Bureau of Labor Statistics."
+bio: "Jean Fox is a research psychologist in the Bureau of Labor Statistics (BLS) at the U.S. Department of Labor."
 
 # Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
 bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: "Bureau of Labor Statistics"
+agency_full_name: "U.S. Department of Labor"
 
 # Agency Acronym [e.g., GSA]
 agency: "BLS"


### PR DESCRIPTION
This is to show BLS under her name (without having to click on her author page to see it)

See this page as an example of where BLS doesn't show up under her name: https://digital.gov/communities/user-experience/ 