### PR TITLE
Removing Speaker Nadia Hansen from UX Summit Agenda

### DIFF
--- a/content/events/2022/05/2022-05-24-2022-government-ux-summit.md
+++ b/content/events/2022/05/2022-05-24-2022-government-ux-summit.md
@@ -122,7 +122,6 @@ Misalignment of the customer-driven recommendations of human-centered design (HC
 In this session you will hear from the following speakers:
 
 * **Mike Catania** &mdash; Innovation Specialist, Department of Veterans Affairs
-* **Nadia Hansen** &mdash; Former county government CIO
 
 ## 12:30 pm - 12:50 pm, ET<br />Designing Digital Products for Adults With Low Literacy
 


### PR DESCRIPTION

This PR implements the following **changes:**

Speaker unable to present due to schedule change

**URL / Link to page**

https://digital.gov/event/2022/06/07/2022-government-ux-summit/

