### PR TITLE
Update federal-social-media-accessibility-toolkit-hackpad.md

### DIFF
--- a/content/resources/federal-social-media-accessibility-toolkit-hackpad.md
+++ b/content/resources/federal-social-media-accessibility-toolkit-hackpad.md
@@ -80,7 +80,7 @@ Below is a set of recommended, baseline strategies to improve the accessibility 
 
         Active Voice: 100 people submitted applications for the job.
   2. Use this [Document Checklist for Plain Language on the Web](http://www.plainlanguage.gov/howto/quickreference/weblist.cfm) from [PlainLanguage.gov](http://www.plainlanguage.gov/index.cfm) when writing social media posts.
-  3. Follow this [5-step checklist provided by the Center for Plain Language](http://centerforplainlanguage.org/5-steps-to-plain-language/) to ensure that your social media posts communicate your message effectively.
+  3. Follow this [5-step checklist provided by the Center for Plain Language](https://www.centerforplainlanguage.org/learning-training/five-steps-plain-language/) to ensure that your social media posts communicate your message effectively.
   4. For before and after examples of plain language, visit [PlainLanguage.gov’s list of Before-and-After Comparisons](http://www.plainlanguage.gov/examples/before_after/index.cfm).
 
 ### Tips for Making Facebook Updates Accessible


### PR DESCRIPTION
update 5 Steps link

This PR implements the following **changes:**

Broken link identified in https://github.com/GSA/digitalgov.gov/pull/4974 

Change http://centerforplainlanguage.org/5-steps-to-plain-language/ 
to https://centerforplainlanguage.org/learning-training/five-steps-plain-language/ 

**URL / Link to page**
https://digital.gov/resources/federal-social-media-accessibility-toolkit-hackpad/ 

Preview: 

