### PR TITLE
added future & past events to /news and removed youtube filter

### DIFF
--- a/themes/digital.gov/layouts/news/list.html
+++ b/themes/digital.gov/layouts/news/list.html
@@ -34,16 +34,13 @@
           List all of the blog posts tagged with this topic */}}
 
           {{/* Gets the past events */}}
-          {{- $past_events := where (where .Site.RegularPages.ByDate.Reverse "Section" "events") ".Date.Unix" "<" now.Unix -}}
-
-          {{/* Gets the past events that have youtube_id set  */}}
-          {{- $past_events := where $past_events ".Params.youtube_id" "!=" nil -}}
+          {{- $events := where .Site.RegularPages.ByDate.Reverse "Section" "events" -}}
 
           {{/* Gets the recent blog posts */}}
           {{- $posts := where .Pages "Section" "news" -}}
 
           {{/* Merges the past events and the recent blog posts */}}
-          {{ $stream := union $posts $past_events }}
+          {{ $stream := union $posts $events }}
 
           {{/* If there are any items at all... */}}
           {{- if $stream -}}
@@ -53,7 +50,11 @@
             {{- range (.Paginate ( $stream.ByDate.Reverse )).Pages -}}
 
               {{- if eq .Type "events" -}}
-                {{- .Render "card-event-past" -}}
+                {{- if ge .Date now.Unix }}
+                  {{- .Render "card-event" -}}
+                {{- else -}}
+                  {{- .Render "card-event-past" -}}
+                {{- end -}}
               {{- end -}}
 
               {{- if eq .Type "news" -}}

--- a/themes/digital.gov/layouts/news/list.html
+++ b/themes/digital.gov/layouts/news/list.html
@@ -36,11 +36,15 @@
           {{/* Gets the past events */}}
           {{- $events := where .Site.RegularPages.ByDate.Reverse "Section" "events" -}}
 
+          {{- $past_events := where (where .Site.RegularPages.ByDate.Reverse "Section" "events") ".Date.Unix" "<" now.Unix -}}
+
+          {{ $all_events := union $past_events $events }}
+
           {{/* Gets the recent blog posts */}}
           {{- $posts := where .Pages "Section" "news" -}}
 
           {{/* Merges the past events and the recent blog posts */}}
-          {{ $stream := union $posts $events }}
+          {{ $stream := union $all_events $posts }}
 
           {{/* If there are any items at all... */}}
           {{- if $stream -}}

--- a/themes/digital.gov/layouts/partials/core/home/news_featured.html
+++ b/themes/digital.gov/layouts/partials/core/home/news_featured.html
@@ -24,7 +24,7 @@
           <section class="stream">
 
             {{/* Future Events ===========================  */}}
-            {{- $events := where .Site.RegularPages.Reverse  "Section" "events" -}}
+            {{- $events := where .Site.RegularPages.Reverse "Section" "events" -}}
 
             {{/* gets the # of news items to display from the config.yml */}}
             {{- $events_count := .Site.Params.events_count -}}
@@ -32,11 +32,7 @@
             {{- $events := $events | intersect (where $events "Date" "ge" (now.AddDate 0 0 0)) | first 2 -}}
 
             {{/* Past Events =========================== */}}
-            {{/* only the ones with videos */}}
             {{- $past_events := where (where .Site.RegularPages.ByDate.Reverse "Section" "events") ".Date.Unix" "<" now.Unix -}}
-
-            {{/* Gets the past events that have youtube_id set  */}}
-            {{- $past_events := where $past_events ".Params.youtube_id" "!=" nil -}}
 
             {{/* News Posts =========================== */}}
             {{/* Gets the recent blog posts */}}
@@ -48,7 +44,7 @@
 
             {{/* Sorting all the items by date and reverse chron */}}
             {{ $stream := $stream.ByDate.Reverse }}
-            {{ $stream := $stream.ByWeight }}
+            {{/* $stream := $stream.ByWeight */}}
 
             {{/* gets the # of news items to display from the config.yml */}}
             {{ $stream_count := .Site.Params.stream_count }}
@@ -56,7 +52,6 @@
             {{/* Gets the first X items for the news stream */}}
             {{/* The # is defined in the config.yml file */}}
             {{- range $i, $el := first $stream_count $stream -}}
-
 
               {{- with $events -}}
                 {{- if eq $i 2 -}}
@@ -71,7 +66,6 @@
                   {{- end -}}
                 {{- end -}}
               {{- end -}}
-
 
               {{- if eq .Type "events" -}}
                 {{- if .Date.Before now -}}


### PR DESCRIPTION
Resolves [trello card](https://trello.com/c/rGYcNFNk) for movings future & past events to `/news` page.