### PR TITLE
removed go.usa.gov & federal crowdsource mobile program from /services & /services/directory

### DIFF
--- a/content/services/service_mobile-testing-program.md
+++ b/content/services/service_mobile-testing-program.md
@@ -23,7 +23,7 @@ contact: digitalgov@gsa.gov
 # 2 == will appear as related service (ADs) on blog posts and event pages
 # 1 == will appear on the tools and services page, and all related topic pages
 # 0 == hides this service from all pages, but URL is still public
-weight: 2
+weight: 0
 
 # Topics that best describe this product or service
 topics:

--- a/content/services/service_usagov-short-urls.md
+++ b/content/services/service_usagov-short-urls.md
@@ -24,7 +24,7 @@ contact: go.usa.gov@gsa.gov
 # 2 == will appear as related service (ADs) on blog posts and event pages
 # 1 == will appear on the tools and services page, and all related topic pages
 # 0 == hides this service from all pages, but URL is still public
-weight: 0
+weight: 2
 
 # see all authors at https://digital.gov/authors
 authors:

--- a/content/services/service_usagov-short-urls.md
+++ b/content/services/service_usagov-short-urls.md
@@ -24,7 +24,7 @@ contact: go.usa.gov@gsa.gov
 # 2 == will appear as related service (ADs) on blog posts and event pages
 # 1 == will appear on the tools and services page, and all related topic pages
 # 0 == hides this service from all pages, but URL is still public
-weight: 2
+weight: 0
 
 # see all authors at https://digital.gov/authors
 authors:


### PR DESCRIPTION
Resolves **trello card**: [Update the directory of tools & services on Digital.gov](https://trello.com/c/vdhjUs05)

Removed:

- [https://go.usa.gov/](https://go.usa.gov/)
- [Federal Crowdsource Mobile Testing Program](https://digital.gov/services/mobile-application-testing-program/)

from `/services` and `/services/directory`

Previews:
https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/nl-update-tools-services/services/ 

https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/nl-update-tools-services/services/directory/ 