### PR TITLE
refactored hosted field, verbiage and community names

### DIFF
--- a/content/events/2022/02/2022-02-11-language-connections-tips-to-create-maintain-and-present-non-english-digital-content.md
+++ b/content/events/2022/02/2022-02-11-language-connections-tips-to-create-maintain-and-present-non-english-digital-content.md
@@ -2,7 +2,8 @@
 title: "Language Connections: Tips to Create, Maintain, and Present Non-English Digital Content"
 kicker: Multilingual & Web Content
 summary: Tips to help you improve access to your non-English digital content.
-host: Multilingual Community of Practice, and the Web Managers Community of Practice
+host: Digital.gov
+communities: Multilingual Community of Practice, and the Web Managers Community of Practice
 event_organizer: Digital.gov
 registration_url: https://www.eventbrite.com/e/language-connections-tips-to-create-maintain-present-non-english-content-tickets-266324191827
 date: 2022-02-24 14:00:00 -0500

--- a/content/events/2022/02/2022-02-11-language-connections-tips-to-create-maintain-and-present-non-english-digital-content.md
+++ b/content/events/2022/02/2022-02-11-language-connections-tips-to-create-maintain-and-present-non-english-digital-content.md
@@ -2,7 +2,7 @@
 title: "Language Connections: Tips to Create, Maintain, and Present Non-English Digital Content"
 kicker: Multilingual & Web Content
 summary: Tips to help you improve access to your non-English digital content.
-host: Multilingual Community of Practice & Web Managers Community of Practice
+host: Multilingual Community of Practice, and the Web Managers Community of Practice
 event_organizer: Digital.gov
 registration_url: https://www.eventbrite.com/e/language-connections-tips-to-create-maintain-present-non-english-content-tickets-266324191827
 date: 2022-02-24 14:00:00 -0500

--- a/content/events/2022/02/2022-02-11-language-connections-tips-to-create-maintain-and-present-non-english-digital-content.md
+++ b/content/events/2022/02/2022-02-11-language-connections-tips-to-create-maintain-and-present-non-english-digital-content.md
@@ -2,8 +2,7 @@
 title: "Language Connections: Tips to Create, Maintain, and Present Non-English Digital Content"
 kicker: Multilingual & Web Content
 summary: Tips to help you improve access to your non-English digital content.
-host: Digital.gov
-communities: Multilingual Community of Practice, and the Web Managers Community of Practice
+host: Multilingual Community of Practice, and the Web Managers Community of Practice
 event_organizer: Digital.gov
 registration_url: https://www.eventbrite.com/e/language-connections-tips-to-create-maintain-present-non-english-content-tickets-266324191827
 date: 2022-02-24 14:00:00 -0500

--- a/content/resources/21st-century-integrated-digital-experience-act.md
+++ b/content/resources/21st-century-integrated-digital-experience-act.md
@@ -183,5 +183,5 @@ Refer to [Public Law 115–336](https://www.congress.gov/115/plaws/publ336/PLAW-
 - Visit our topic page for [21st Century IDEA-related resources, news, and training events](https://digital.gov/topics/21st-century-idea/).
 - Learn about the [Go-Live Checklist for Federal Websites](https://digital.gov/2022/01/13/go-live-checklist-for-federal-websites/)
 - Resource pages:
-  - [Checklist of Requirements for Federal Websites and Digital Services](https://digital.gov/resources/checklist-of-requirements-for-federal-digital-services/)&mdash;The relevant laws, policies, and regulations for federal agencies.
-  - [Required Web Content and Links](https://digital.gov/resources/required-web-content-and-links/)&mdash;A list of required links that all federal websites need to have.
+    - [Checklist of Requirements for Federal Websites and Digital Services](https://digital.gov/resources/checklist-of-requirements-for-federal-digital-services/)&mdash;The relevant laws, policies, and regulations for federal agencies.
+    - [Required Web Content and Links](https://digital.gov/resources/required-web-content-and-links/)&mdash;A list of required links that all federal websites need to have.

--- a/themes/digital.gov/layouts/events/card-event.html
+++ b/themes/digital.gov/layouts/events/card-event.html
@@ -16,9 +16,9 @@
       {{- end -}}
 
       {{- if .Params.community_name -}}
-        <p class="host">Hosted by Digital.gov's {{ .Params.community_name }} Community</p>
-        {{- else -}}
-        <p class="host">Hosted by Digital.gov and the {{ .Params.host }} Community</p>
+      <p class="host">Hosted by Digital.gov's {{ .Params.community_name }} Community</p>
+      {{- else -}}
+      <p class="host">Hosted by Digital.gov and the {{ .Params.host }} Community</p>
       {{- end -}}
 
       <a [attr.aria-label]="Register for {{- .Params.title -}}" class="btn btn-register" href="{{- .Params.registration_url -}}" onclick="__gaTracker('send', 'event', 'outbound-article', '{{- .Params.registration_url -}}', 'REGISTER NOW');">Register</a>

--- a/themes/digital.gov/layouts/events/card-event.html
+++ b/themes/digital.gov/layouts/events/card-event.html
@@ -15,15 +15,7 @@
       <div class="summary">{{ .Params.summary | markdownify }}</div>
       {{- end -}}
 
-      {{- if .Params.communities -}}
-      {{- $communities := split .Params.communities ", " -}}
-      {{- $length := len $communities -}}
-        {{- if gt $length 1 -}}
-          <p class="host">Hosted by Digital.gov, the {{ .Params.communities }}</p>
-          {{- else if gt $length 0 -}}
-          <p class="host">Hosted by Digital.gov and the {{ .Params.communities }}</p>
-        {{- end -}}
-      {{- else -}}
+      {{- if .Params.host -}}
       <p class="host">Hosted by Digital.gov and the {{ .Params.host }}</p>
       {{- end -}}
 

--- a/themes/digital.gov/layouts/events/card-event.html
+++ b/themes/digital.gov/layouts/events/card-event.html
@@ -24,7 +24,7 @@
           <p class="host">Hosted by Digital.gov and the {{ .Params.communities }}</p>
         {{- end -}}
       {{- else -}}
-      <p class="host">Hosted by Digital.gov and the {{ .Params.host }} Community of Practice</p>
+      <p class="host">Hosted by Digital.gov and the {{ .Params.host }}</p>
       {{- end -}}
 
       <a [attr.aria-label]="Register for {{- .Params.title -}}" class="btn btn-register" href="{{- .Params.registration_url -}}" onclick="__gaTracker('send', 'event', 'outbound-article', '{{- .Params.registration_url -}}', 'REGISTER NOW');">Register</a>

--- a/themes/digital.gov/layouts/events/card-event.html
+++ b/themes/digital.gov/layouts/events/card-event.html
@@ -15,10 +15,16 @@
       <div class="summary">{{ .Params.summary | markdownify }}</div>
       {{- end -}}
 
-      {{- if .Params.community_name -}}
-      <p class="host">Hosted by Digital.gov's {{ .Params.community_name }} Community</p>
+      {{- if .Params.communities -}}
+      {{- $communities := split .Params.communities ", " -}}
+      {{- $length := len $communities -}}
+        {{- if gt $length 1 -}}
+          <p class="host">Hosted by Digital.gov, the {{ .Params.communities }}</p>
+          {{- else if gt $length 0 -}}
+          <p class="host">Hosted by Digital.gov and the {{ .Params.communities }}</p>
+        {{- end -}}
       {{- else -}}
-      <p class="host">Hosted by Digital.gov and the {{ .Params.host }} Community</p>
+      <p class="host">Hosted by Digital.gov and the {{ .Params.host }} Community of Practice</p>
       {{- end -}}
 
       <a [attr.aria-label]="Register for {{- .Params.title -}}" class="btn btn-register" href="{{- .Params.registration_url -}}" onclick="__gaTracker('send', 'event', 'outbound-article', '{{- .Params.registration_url -}}', 'REGISTER NOW');">Register</a>

--- a/themes/digital.gov/layouts/events/card-event.html
+++ b/themes/digital.gov/layouts/events/card-event.html
@@ -15,8 +15,10 @@
       <div class="summary">{{ .Params.summary | markdownify }}</div>
       {{- end -}}
 
-      {{- if .Params.host -}}
-      <div class="host">Hosted by {{ .Params.host | markdownify }}</div>
+      {{- if .Params.community_name -}}
+        <p class="host">Hosted by Digital.gov's {{ .Params.community_name }} Community</p>
+        {{- else -}}
+        <p class="host">Hosted by Digital.gov and the {{ .Params.host }} Community</p>
       {{- end -}}
 
       <a [attr.aria-label]="Register for {{- .Params.title -}}" class="btn btn-register" href="{{- .Params.registration_url -}}" onclick="__gaTracker('send', 'event', 'outbound-article', '{{- .Params.registration_url -}}', 'REGISTER NOW');">Register</a>

--- a/themes/digital.gov/layouts/events/single.html
+++ b/themes/digital.gov/layouts/events/single.html
@@ -26,7 +26,6 @@
             {{- if .Params.deck -}}
             <div class="deck">{{- .Params.deck | markdownify -}}</div>
             {{- end -}}
-            {{- if .Params.host -}}
 
             <p class="datetime"><i class="far fa-calendar"></i>
               {{ with .Date }}
@@ -42,19 +41,10 @@
               </span>
             </p>
 
-            {{- if .Params.communities -}}
-            {{- $communities := split .Params.communities ", " -}}
-            {{- $length := len $communities -}}
-              {{- if gt $length 1 -}}
-                <p class="host">Hosted by Digital.gov, the {{ .Params.communities }}</p>
-                {{- else if gt $length 0 -}}
-                <p class="host">Hosted by Digital.gov and the {{ .Params.communities }}</p>
-              {{- end -}}
-            {{- else -}}
+            {{- if .Params.host -}}
             <p class="host">Hosted by Digital.gov and the {{ .Params.host }}</p>
             {{- end -}}
-
-            {{- end -}}
+            
           </div>
         </div>
       </div>

--- a/themes/digital.gov/layouts/events/single.html
+++ b/themes/digital.gov/layouts/events/single.html
@@ -42,11 +42,12 @@
               </span>
             </p>
 
-              {{- if .Params.community_name -}}
-                <p class="host">Hosted by Digital.gov's {{ .Params.community_name }} Community</p>
-                {{- else -}}
-                <p class="host">Hosted by Digital.gov and the {{ .Params.host }} Community</p>
-              {{- end -}}
+            {{- if .Params.community_name -}}
+            <p class="host">Hosted by Digital.gov's {{ .Params.community_name }} Community</p>
+            {{- else -}}
+            <p class="host">Hosted by Digital.gov and the {{ .Params.host }} Community</p>
+            {{- end -}}
+
             {{- end -}}
           </div>
         </div>

--- a/themes/digital.gov/layouts/events/single.html
+++ b/themes/digital.gov/layouts/events/single.html
@@ -42,10 +42,16 @@
               </span>
             </p>
 
-            {{- if .Params.community_name -}}
-            <p class="host">Hosted by Digital.gov's {{ .Params.community_name }} Community</p>
+            {{- if .Params.communities -}}
+            {{- $communities := split .Params.communities ", " -}}
+            {{- $length := len $communities -}}
+              {{- if gt $length 1 -}}
+                <p class="host">Hosted by Digital.gov, the {{ .Params.communities }}</p>
+                {{- else if gt $length 0 -}}
+                <p class="host">Hosted by Digital.gov and the {{ .Params.communities }}</p>
+              {{- end -}}
             {{- else -}}
-            <p class="host">Hosted by Digital.gov and the {{ .Params.host }} Community</p>
+            <p class="host">Hosted by Digital.gov and the {{ .Params.host }} Community of Practice</p>
             {{- end -}}
 
             {{- end -}}

--- a/themes/digital.gov/layouts/events/single.html
+++ b/themes/digital.gov/layouts/events/single.html
@@ -51,7 +51,7 @@
                 <p class="host">Hosted by Digital.gov and the {{ .Params.communities }}</p>
               {{- end -}}
             {{- else -}}
-            <p class="host">Hosted by Digital.gov and the {{ .Params.host }} Community of Practice</p>
+            <p class="host">Hosted by Digital.gov and the {{ .Params.host }}</p>
             {{- end -}}
 
             {{- end -}}

--- a/themes/digital.gov/layouts/events/single.html
+++ b/themes/digital.gov/layouts/events/single.html
@@ -42,7 +42,11 @@
               </span>
             </p>
 
-            <p class="host">Hosted by {{ .Params.host }} and {{ .Params.event_organizer }}</p>
+              {{- if .Params.community_name -}}
+                <p class="host">Hosted by Digital.gov's {{ .Params.community_name }} Community</p>
+                {{- else -}}
+                <p class="host">Hosted by Digital.gov and the {{ .Params.host }} Community</p>
+              {{- end -}}
             {{- end -}}
           </div>
         </div>
@@ -50,7 +54,7 @@
     </header>
 
 
-    {{/* EVENT Actions — REGISTER and Add to Calendar */}}
+    {{/* EVENT Actions — REGISTER and Add to Calendar */}}
     {{/* If is a Future Event */}}
     {{- if eq $future_event true -}}
     <div class="grid-container grid-container-desktop">


### PR DESCRIPTION
Resolves trello task [https://trello.com/c/uR6l0up3](https://trello.com/c/uR6l0up3).

This change adds a new field `community_name:` to the event page to highlight the community of practice in the "Hosted by..." line. 

<img width="761" alt="Screen Shot 2022-06-14 at 2 59 38 PM" src="https://user-images.githubusercontent.com/104778659/173669423-1eef6e36-6257-439f-92e4-c33a3a1de4bf.png">
<img width="755" alt="Screen Shot 2022-06-14 at 2 59 47 PM" src="https://user-images.githubusercontent.com/104778659/173669426-46de68a6-0c58-4bb5-ac3a-a00c11ad9b15.png">

