### PR TITLE
AS_Challenge CoP Redirect

### DIFF
--- a/content/communities/challenges-prizes.md
+++ b/content/communities/challenges-prizes.md
@@ -22,6 +22,8 @@ topics:
 authors:
   - jarah-meador
 
+redirectto: https://www.challenge.gov/community/
+
 # Page weight: controls how this page appears across the site
 # 0 -- hidden
 # 1 -- visible


### PR DESCRIPTION
This PR implements the following **changes:**

* Redirecting Challenge CoP off Digital.gov to https://www.challenge.gov/community/ as part of streamline effort


**URL / Link to page**

https://digital.gov/communities/challenges-prizes/
