### PR TITLE
Update 2022-07-01-white-house-and-gsa-open-innovation-forum-building-…

### DIFF
--- a/content/events/2022/07/2022-07-01-white-house-and-gsa-open-innovation-forum-building-equitable-partnerships.md
+++ b/content/events/2022/07/2022-07-01-white-house-and-gsa-open-innovation-forum-building-equitable-partnerships.md
@@ -27,6 +27,11 @@ topics:
 authors:
   - jarah-meador
   - administrator-robin-carnahan
+  - ariel-gold
+  - chaitra-shenoy
+  - hunter-jones
+  - matthew-biggerstaff
+  - liam-r-ofallon
   - v-david-zvenyach
   - dr-alondra-nelson
   - dr-jedidah-isler


### PR DESCRIPTION
…equitable-partnerships.md

Adding the panelists - new author pages

This PR implements the following **changes:**

* Updating the event page to include the new author adds

**[URL / Link to page](https://digital.gov/event/2022/07/20/white-house-and-gsa-open-innovation-forum-building-equitable-partnerships/)**