### PR TITLE
Fix bug: deck replaces summary in 4 content types

### DIFF
--- a/themes/digital.gov/layouts/partials/core/collection.html
+++ b/themes/digital.gov/layouts/partials/core/collection.html
@@ -75,7 +75,7 @@
         <a href="{{- $href -}}" title="{{- .Title | markdownify -}}">
           <span>{{- .Title | markdownify -}}</span>
         </a>
-        {{- if .Params.deck -}} — {{- .Params.deck | markdownify -}}{{- else -}} — {{- .Params.summary | markdownify | truncate 140 -}}{{- end -}}
+        {{- if .Params.summary -}} — {{- .Params.summary | markdownify | truncate 140 -}}{{- else -}} — {{- .Params.deck | markdownify -}}{{- end -}}
       </p>
     </div>
 


### PR DESCRIPTION
Refactor template to display summary instead of deck

This change displays the `summary` field first and if blank will display the `deck`.
Current behavior displays the `deck` if present, then the `summary` which explains why when both are used, we see the deck only.

https://github.com/GSA/digitalgov.gov/blob/c6e68a44eb627db3074541e9df296b0effa02a67/themes/digital.gov/layouts/partials/core/collection.html#L78
