### PR TITLE
Investigate why deck is replacing summary again

### DIFF
--- a/themes/digital.gov/layouts/events/card-event-past.html
+++ b/themes/digital.gov/layouts/events/card-event-past.html
@@ -34,10 +34,10 @@
       <h3>
         <a href="{{ .Permalink }}" title="{{ .Title | markdownify }}" rel="bookmark">{{ .Title | markdownify }}</a>
       </h3>
-      {{- if .Params.deck -}}
-        <div class="deck">{{ .Params.deck | markdownify -}}</div>
-      {{- else -}}
+      {{- if .Params.summary -}}
         <div class="deck">{{ .Params.summary | markdownify -}}</div>
+      {{- else -}}
+        <div class="deck">{{ .Params.deck | markdownify -}}</div>
       {{- end -}}
 
       {{- partial "core/get_authors_short.html" . -}}

--- a/themes/digital.gov/layouts/events/card-event.html
+++ b/themes/digital.gov/layouts/events/card-event.html
@@ -9,10 +9,11 @@
       <h3>
         <a href="{{ .Permalink }}" title="{{ .Title | markdownify }}" rel="bookmark">{{ .Title | markdownify }}</a>
       </h3>
-      {{- if .Params.deck -}}
-      <div class="deck">{{ .Params.deck | markdownify }}</div>
-      {{- else -}}
+
+      {{- if .Params.summary -}}
       <div class="summary">{{ .Params.summary | markdownify }}</div>
+      {{- else -}}
+      <div class="deck">{{ .Params.deck | markdownify }}</div>
       {{- end -}}
 
       {{- if .Params.host -}}

--- a/themes/digital.gov/layouts/news/card-article.html
+++ b/themes/digital.gov/layouts/news/card-article.html
@@ -13,10 +13,10 @@
         <a href="{{- .Permalink -}}">{{- .Title | markdownify -}}</a>
       </h3>
 
-      {{- if .Params.deck -}}
-      <div class="deck">{{ .Params.deck | markdownify }}</div>
+      {{- if .Params.summary -}}
+      <div class="deck">{{ .Params.summary | markdownify }}</div>
       {{- else -}}
-      <div class="summary">{{ .Params.summary | markdownify }}</div>
+      <div class="summary">{{ .Params.deck | markdownify }}</div>
       {{- end -}}
 
       {{- partial "core/get_authors_short.html" . -}}


### PR DESCRIPTION
**Problem**
`deck` field displays instead of the `summary` field on news, events, resources and communities pages which requires deletion of the `deck` contents to show the summary.

Current code does the opposite which is why users would have to remove the deck contents.

https://github.com/GSA/digitalgov.gov/blob/0059b153e637d090db72b2d3293328a70834059a/themes/digital.gov/layouts/news/card-article.html#L16-L20

**Fix**
New code reverses this logic: display the `summary` first then the `deck` if `summary` is empty.

