### PR TITLE
Find and fix issue with gulp watch not processing images

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,12 +11,16 @@ const fa = require("./config/gulp/fontawesome"),
   scripts = require("./config/gulp/scripts"),
   styles = require("./config/gulp/styles");
 
+function watchImages() {
+  return series(img.prep.do, img.process.do, img.upload.do);
+}
+
 function gulpWatch() {
   const THEME_DIR = "./themes/digital.gov/src";
   watch(`${THEME_DIR}/scss/uswds/**/*.scss`, styles.buildSass);
   watch(`${THEME_DIR}/scss/new/**/*.scss`, styles.buildSass);
   watch(`${THEME_DIR}/js/**/*.js`, scripts.compile);
-  watch("./content/images/_inbox/*.*", img);
+  watch("./content/images/_inbox/*.*", watchImages());
 }
 
 // Define public tasks


### PR DESCRIPTION
Adds a function to be called in the `gulpWatch` function to process images while `npm start` is running.

