### PR TITLE
Update 2022-08-11-uswds-monthly-call-august-2022.md

### DIFF
--- a/content/events/2022/08/2022-08-11-uswds-monthly-call-august-2022.md
+++ b/content/events/2022/08/2022-08-11-uswds-monthly-call-august-2022.md
@@ -23,6 +23,9 @@ slug: uswds-monthly-call-august-2022
 event_platform: zoom
 primary_image: uswds-august-2022-monthly-call-title-card
 ---
+
+[View the slides (PowerPoint, 7.8 MB, 83 pages)](https://digital.gov/files/uswds-monthly-call-august-2022.pptx)
+
 What are design patterns and how do they fit into the design system? Join us to learn more about USWDS Inclusive Design Patterns — upcoming guidance that will help connect components to common service interactions. We’ll preview this upcoming guidance and discuss the process we used to develop it.
 
 *This event is part of a monthly series that takes place on the third Thursday of each month. Don’t forget to set a placeholder on your personal calendar for our future events this year.*


### PR DESCRIPTION
Add slides to event page for USWDS Monthly Call - August 2022

This PR implements the following **changes:**
Add slides https://digital.gov/files/uswds-monthly-call-august-2022.pptx to event page for USWDS Monthly Call - August 2022


**URL / Link to page**
https://digital.gov/event/2022/08/18/uswds-monthly-call-august-2022/
Preview link: https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/jdotyoon-patch-9/event/2022/08/18/uswds-monthly-call-august-2022/

