### PR TITLE
Adding resource link to event page

### DIFF
--- a/content/events/2021/11/2021-11-16-results-of-the-2021-federal-report-card.md
+++ b/content/events/2021/11/2021-11-16-results-of-the-2021-federal-report-card.md
@@ -30,11 +30,13 @@ primary_image: december-plain-language-report-card-title-card
 
 ---
 
-[Read the Event Recap](https://digital.gov/resources/lessons-from-the-2021-federal-plain-language-report-card/?dg)
+[View the slides (PowerPoint, 1.4 MB, 9 pages)](https://digital.gov/files/results-of-the-fplrc.pptx)
+
+[Read the Lessons Learned](https://digital.gov/resources/lessons-from-the-2021-federal-plain-language-report-card/)
 
 ## Event Details
 
-For a decade, the Center for Plain Language has issued a yearly Report Card evaluating how well agencies follow the [Plain Writing Act.](https://www.plainlanguage.gov/law/) These agencies were judged on organizational compliance and writing quality.
+For a decade, the Center for Plain Language has issued a yearly Report Card evaluating how well agencies follow the [Plain Writing Act](https://www.plainlanguage.gov/law/). These agencies were judged on organizational compliance and writing quality.
 
 This year, the judges focused on the main Freedom of Information Act (FOIA) request page and the main Coronavirus page of 21 executive branch agencies, including all 15 cabinet-level departments.
 
@@ -46,8 +48,6 @@ This year, the judges focused on the main Freedom of Information Act (FOIA) requ
 
 * **Katherine Spivey** — U.S. General Services Administration (GSA)
 * **Katina Stapleton** — U.S. Department of Education (ED)
-
-[View the slides (PowerPoint, 1.4 MB, 9 pages)](https://digital.gov/files/results-of-the-fplrc.pptx)
 
 ## Related Resources
 

--- a/content/events/2021/11/2021-11-16-results-of-the-2021-federal-report-card.md
+++ b/content/events/2021/11/2021-11-16-results-of-the-2021-federal-report-card.md
@@ -32,6 +32,8 @@ primary_image: december-plain-language-report-card-title-card
 
 ---
 
+[Read the Event Recap](https://digital.gov/resources/lessons-from-the-2021-federal-plain-language-report-card/?dg)
+
 ## Event Details
 
 For a decade, the Center for Plain Language has issued a yearly Report Card evaluating how well agencies follow the [Plain Writing Act.](https://www.plainlanguage.gov/law/) These agencies were judged on organizational compliance and writing quality.

--- a/content/events/2021/11/2021-11-16-results-of-the-2021-federal-report-card.md
+++ b/content/events/2021/11/2021-11-16-results-of-the-2021-federal-report-card.md
@@ -1,10 +1,8 @@
 ---
 title: Results of the 2021 Federal Report Card
-deck: This month, we get the inside story on the Center for Plain Language’s
-  Federal Report Card.
+deck: This month, we get the inside story on the Center for Plain Language’s Federal Report Card.
 kicker: Plain Language
-summary: David Lipscomb from the Center for PL will review the results of this
-  year’s Federal Plain Language Report Card and answer questions.
+summary: David Lipscomb from the Center for PL will review the results of this year’s Federal Plain Language Report Card and answer questions.
 host: Plain Language Community of Practice
 event_organizer: Digital.gov
 registration_url: "https://www.eventbrite.com/e/results-of-the-2021-federal-report-card-tickets-211733910827"
@@ -49,9 +47,9 @@ This year, the judges focused on the main Freedom of Information Act (FOIA) requ
 * **Katherine Spivey** — U.S. General Services Administration (GSA)
 * **Katina Stapleton** — U.S. Department of Education (ED)
 
-[View the slides](https://digital.gov/files/results-of-the-fplrc.pptx) (PowerPoint, 1.4 MB, 9 pages)
+[View the slides (PowerPoint, 1.4 MB, 9 pages)](https://digital.gov/files/results-of-the-fplrc.pptx)
 
-### Related Resources
+## Related Resources
 
 * [2021 Federal Plain Language Report Card](https://centerforplainlanguage.org/2021-federal-plain-language-report-card/) 
 * [PlainLanguage.gov](https://www.plainlanguage.gov/) 


### PR DESCRIPTION
Adding resource link to event page

This PR implements the following **changes:**
Resource link: https://digital.gov/resources/lessons-from-the-2021-federal-plain-language-report-card/?dg

Event page: https://digital.gov/event/2021/12/08/results-of-the-2021-federal-report-card/

Preview link: https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/jdotyoon-patch-9/event/2021/12/08/results-of-the-2021-federal-report-card/
