### PR TITLE
Table fix for whitespace rules with new formatter

### DIFF
--- a/content/resources/plain-language-web-writing-tips.md
+++ b/content/resources/plain-language-web-writing-tips.md
@@ -15,103 +15,61 @@ On the web, people are in a hurry. They skim and scan, looking for fast answers 
 
 Help your readers complete their tasks with these Plain Language writing tips:
 
-<table style="width: 100%" border="1">
+<table class="resources__plain-language-table" style="width: 100%" border="1">
   <tr>
-    <td><strong>Audience</strong></td>
-
-    <td>Write for your reader. Don&#8217;t write for the experts, the lawyers, or your management, unless they are your intended audience.</td>
-
+    <td><strong>Audience</strong></td><td>Write for your reader. Don&#8217;t write for the experts, the lawyers, or your management, unless they are your intended audience.</td>
   </tr>
   
   <tr>
-    <td><strong>Length</strong></td>
-
-    <td><s>Less is more!</s> <s>Be concise.</s> Eliminate ALL unnecessary words. <s>Challenge every word = do you need it?</s></td>
-
+    <td><strong>Length</strong></td><td><s>Less is more!</s> <s>Be concise.</s> Eliminate ALL unnecessary words. <s>Challenge every word = do you need it?</s></td>
   </tr>
   
   <tr>
-    <td><strong>Tone</strong></td>
-
-    <td>Use conversational pronouns (you, us, our, we). Write as if you were talking to a colleague or friend. Use contractions (we’re instead of we are).</td>
-
+    <td><strong>Tone</strong></td><td>Use conversational pronouns (you, us, our, we). Write as if you were talking to a colleague or friend. Use contractions (we’re instead of we are).</td>
   </tr>
   
   <tr>
-    <td><strong>Voice</strong></td>
-
-    <td>Use active voice with strong verbs. Say “We mailed your form on May 1” instead of “Your form was mailed by us on May 1.”</td>
-
+    <td><strong>Voice</strong></td><td>Use active voice with strong verbs. Say “We mailed your form on May 1” instead of “Your form was mailed by us on May 1.”</td>
   </tr>
   
   <tr>
-    <td><strong>Word Choice</strong></td>
-
-    <td>Use the same words your readers use when they search for your info on the Web. Avoid acronyms and jargon.</td>
-
+    <td><strong>Word Choice</strong></td><td>Use the same words your readers use when they search for your info on the Web. Avoid acronyms and jargon.</td>
   </tr>
   
   <tr>
-    <td><strong>Simplify</strong></td>
-
-    <td>Use simple, descriptive section headings; short paragraphs; and ordinary, familiar words.</td>
-
+    <td><strong>Simplify</strong></td><td>Use simple, descriptive section headings; short paragraphs; and ordinary, familiar words.</td>
   </tr>
   
   <tr>
-    <td><strong>Links</strong></td>
-
-    <td>Never use &#8220;click here&#8221;—link language should describe what your reader will get if they click that link. Include key words to help search engines.</td>
-
+    <td><strong>Links</strong></td><td>Never use &#8220;click here&#8221;—link language should describe what your reader will get if they click that link. Include key words to help search engines.</td>
   </tr>
   
   <tr>
-    <td><strong>Organization</strong></td>
-
-    <td>Put the most important information first, followed by the details.</td>
-
+    <td><strong>Organization</strong></td><td>Put the most important information first, followed by the details.</td>
   </tr>
   
   <tr>
-    <td><strong>Improve Tasks</strong></td>
-
-    <td>Organize content around your customers’ tasks, not your organization. Highlight action items (step 1, step 2, etc.).</td>
-
+    <td><strong>Improve Tasks</strong></td><td>Organize content around your customers’ tasks, not your organization. Highlight action items (step 1, step 2, etc.).</td>
   </tr>
   
   <tr>
-    <td><strong>Scannability</strong></td>
-
-    <td>Separate content into small chunks. Use lots of white space for easy scanning. In general, write no more than 5-7 lines per paragraph. Use lists and bullets, they are easy to scan.</td>
-
+    <td><strong>Scannability</strong></td><td>Separate content into small chunks. Use lots of white space for easy scanning. In general, write no more than 5-7 lines per paragraph. Use lists and bullets, they are easy to scan.</td>
   </tr>
   
   <tr>
-    <td><strong>Separate Topics</strong></td>
-
-    <td>Present each topic separately. Keep the information on each page to three (or fewer) levels.</td>
-
+    <td><strong>Separate Topics</strong></td><td>Present each topic separately. Keep the information on each page to three (or fewer) levels.</td>
   </tr>
   
   <tr>
-    <td><strong>Context</strong></td>
-
-    <td>Don’t assume your readers already know the subject or have read related pages. Each page should stand on its own. Put everything in context.</td>
-
+    <td><strong>Context</strong></td><td>Don’t assume your readers already know the subject or have read related pages. Each page should stand on its own. Put everything in context.</td>
   </tr>
   
   <tr>
-    <td><strong>Test and Evaluate</strong></td>
-
-    <td>Test Web pages with actual customers so you can be sure real people can understand what you write.</td>
-
+    <td><strong>Test and Evaluate</strong></td><td>Test Web pages with actual customers so you can be sure real people can understand what you write.</td>
   </tr>
   
   <tr>
-    <td><strong>Train</strong></td>
-
-    <td>Encourage all your colleagues (lawyers, accountants, researchers, etc.) to use plain language—because all content is potentially Web content.</td>
-
+    <td><strong>Train</strong></td><td>Encourage all your colleagues (lawyers, accountants, researchers, etc.) to use plain language—because all content is potentially Web content.</td>
   </tr>
 </table>
 

--- a/themes/digital.gov/src/scss/new/_resources.scss
+++ b/themes/digital.gov/src/scss/new/_resources.scss
@@ -52,3 +52,14 @@
     @include u-border-top('1px', 'base-light', 'solid');
   }
 }
+
+.usa-prose table.resources__plain-language-table  tr td {
+  background-color: #fff;
+  border: 1px solid #1b1b1b;
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-color: rgb(27, 27, 27);
+  border-bottom-style: solid;
+  border-left-style: solid;
+  font-weight: 400;
+}


### PR DESCRIPTION
Formatted table markup to render as expected with new markdown engine.

**Before**
<img width="1430" alt="Screen Shot 2022-08-24 at 2 37 36 PM" src="https://user-images.githubusercontent.com/104778659/186501843-2ae552a7-d382-497b-ba97-06de438519f7.png">

**After**
<img width="1354" alt="Screen Shot 2022-08-24 at 2 52 10 PM" src="https://user-images.githubusercontent.com/104778659/186501860-0c1c4043-3561-4d3e-93d6-cbd80c264b9a.png">



