### PR TITLE
Find and fix issue with gulp watch not processing images

### DIFF
--- a/config/gulp/img-upload.js
+++ b/config/gulp/img-upload.js
@@ -1,14 +1,16 @@
+require('dotenv').config();
 const { series, src, dest } = require("gulp"),
   vinylPaths = require("vinyl-paths"),
   del = require("del"),
   s3config = {
-    accessKeyId: process.env.AWS_ACCESSKEY,
-    secretAccessKey: process.env.AWS_SECRET,
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
   },
   s3 = require("gulp-s3-upload")(s3config);
 
 function upload() {
   console.log("starting upload");
+  console.log(process.env);
   return src("content/images/_working/processed/**/*")
     .pipe(
       s3(

--- a/config/gulp/img-upload.js
+++ b/config/gulp/img-upload.js
@@ -10,7 +10,6 @@ const { series, src, dest } = require("gulp"),
 
 function upload() {
   console.log("starting upload");
-  console.log(process.env);
   return src("content/images/_working/processed/**/*")
     .pipe(
       s3(


### PR DESCRIPTION
Added `require('dotenv').config()` to load the `.env` variables for AWS uploading.

