### PR TITLE
Fix 4 new AMP issues for Digital.gov score

### DIFF
--- a/themes/digital.gov/layouts/events/card-event-past.html
+++ b/themes/digital.gov/layouts/events/card-event-past.html
@@ -10,7 +10,7 @@
     <div class="non-youtube-event-card grid-col-12 tablet:grid-col-4 tablet:order-last grid-row">
       <div aria-role="img" class="grid-row flex-align-self-center" data-link="{{ .Permalink }}">
         <svg xmlns="http://www.w3.org/2000/svg" role="img" height="150" width="150" viewBox="0 0 25 25">
-          <title>Non Youtube Event</title>
+          <title>Non-Youtube Event</title>
           <path d="M0 0h24v24H0z" fill="none"/>
           <path fill="#005ea2" d="M17 12h-5v5h5v-5zM16 1v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2h-1V1h-2zm3 18H5V8h14v11z"/>
         </svg>

--- a/themes/digital.gov/layouts/events/card-event-past.html
+++ b/themes/digital.gov/layouts/events/card-event-past.html
@@ -9,11 +9,8 @@
     {{- else -}}
     <div class="non-youtube-event-card grid-col-12 tablet:grid-col-4 tablet:order-last grid-row">
       <div aria-role="img" class="grid-row flex-align-self-center" data-link="{{ .Permalink }}">
-        <!-- <svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="calendar-alt" class="svg-inline--fa fa-calendar-alt fa-w-14" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 512">
-          <path fill="#005ea2" d="M0 464c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V192H0v272zm320-196c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12v-40zm0 128c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12v-40zM192 268c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12v-40zm0 128c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12v-40zM64 268c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12H76c-6.6 0-12-5.4-12-12v-40zm0 128c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12H76c-6.6 0-12-5.4-12-12v-40zM400 64h-48V16c0-8.8-7.2-16-16-16h-32c-8.8 0-16 7.2-16 16v48H160V16c0-8.8-7.2-16-16-16h-32c-8.8 0-16 7.2-16 16v48H48C21.5 64 0 85.5 0 112v48h448v-48c0-26.5-21.5-48-48-48z">
-          </path>
-        </svg> -->
-        <svg xmlns="http://www.w3.org/2000/svg" height="150" width="150" viewBox="0 0 25 25">
+        <svg xmlns="http://www.w3.org/2000/svg" role="img" height="150" width="150" viewBox="0 0 25 25">
+          <title>Non Youtube Event</title>
           <path d="M0 0h24v24H0z" fill="none"/>
           <path fill="#005ea2" d="M17 12h-5v5h5v-5zM16 1v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2h-1V1h-2zm3 18H5V8h14v11z"/>
         </svg>


### PR DESCRIPTION
### Summary
AMP report show 4 issues with `digital.gov`

### Problem
Inline `svg` is missing several elements for accessibility.

### Solution
Added `role="img"` and a `title` element within the `svg` markup, referenced other inline svg code from other pages.

### Notes
