### PR TITLE
Review text alternatives for news items

### DIFF
--- a/themes/digital.gov/layouts/partials/core/img-featured.html
+++ b/themes/digital.gov/layouts/partials/core/img-featured.html
@@ -29,7 +29,7 @@
 
   <div class="media-featured">
     <a href="{{- .Permalink -}}" title="{{- .Title | markdownify -}}">
-      <img src="{{- $imgBaseCDN -}}{{- $.Scratch.Get "imgSuffix" -}}.{{- $imgExt -}}" alt="{{- .Title | markdownify -}}" title="{{- .Title | markdownify -}}" />
+      <img src="{{- $imgBaseCDN -}}{{- $.Scratch.Get "imgSuffix" -}}.{{- $imgExt -}}" aria-hidden="true" alt="" />
     </a>
   </div>
 


### PR DESCRIPTION
### Summary

Include text alternatives that label or describe the image being used.
News post images are considered decorative and we don't need to include them for screen readers.

### Problem

News images `alt` and `title` are the same as the post title.

- `alt` text should describe the content of the image.
- `title` text is redundant, we only need alt or title and alt is preferable.

### Solution

**Removed:**

- `title` from markup
- `alt` should be empty for decorative images

**Added:**

- `aria-hidden: true` will hide from screenreaders

