### PR TITLE
Review <div>'s to if they need aria-role="complementary"

### DIFF
--- a/themes/digital.gov/layouts/partials/core/usa-identifier.html
+++ b/themes/digital.gov/layouts/partials/core/usa-identifier.html
@@ -11,13 +11,13 @@
           <img class="usa-identifier__logo-img" src="{{ .parent_agency.logo | relURL }}" alt="{{ .parent_agency.acronym }} logo" role="img">
         </a>
       </div>
-      <div class="usa-identifier__identity" aria-label="Agency description" role="complementary">
+      <section class="usa-identifier__identity" aria-label="Agency description">
         <p class="usa-identifier__identity-domain">{{ .domain }}</p>
         <p class="usa-identifier__identity-disclaimer">
           An official website of the
           <a href="{{ .parent_agency.url }}">{{ .parent_agency.name }}</a>
         </p>
-      </div>
+      </section>
     </div>
   </section>
   <nav class="usa-identifier__section usa-identifier__section--required-links" aria-label="Important links">

--- a/themes/digital.gov/layouts/partials/core/usa-identifier.html
+++ b/themes/digital.gov/layouts/partials/core/usa-identifier.html
@@ -11,7 +11,7 @@
           <img class="usa-identifier__logo-img" src="{{ .parent_agency.logo | relURL }}" alt="{{ .parent_agency.acronym }} logo" role="img">
         </a>
       </div>
-      <div class="usa-identifier__identity" aria-label="Agency description">
+      <div class="usa-identifier__identity" aria-label="Agency description" role="complementary">
         <p class="usa-identifier__identity-domain">{{ .domain }}</p>
         <p class="usa-identifier__identity-disclaimer">
           An official website of the


### PR DESCRIPTION
### Summary

Adding `aria-role=”complementary”` to `div`'s with a `aria-label="Agency description"` will improve accessibilty for screen readers.

### Problem

ARIA Labels don’t always work well on certain elements like `div`'s where there is no role `<div class="usa-identifier__identity" aria-label="Agency description">`

### Solution

Add `role="complementary"` to `div`'s
