### PR TITLE
Update 2022-07-29-2022-federal-plain-language-summit.md

### DIFF
--- a/content/events/2022/07/2022-07-29-2022-federal-plain-language-summit.md
+++ b/content/events/2022/07/2022-07-29-2022-federal-plain-language-summit.md
@@ -66,6 +66,8 @@ In this session you will hear from the following speakers:
 * **Shuly Babitz** &mdash; Health Communications Strategist, Health Resources and Services Administration (HRSA)
 * **Katy Karnell** &mdash; Communications Team Lead, Health Resources and Services Administration (HRSA)
 
+{{< youtube 9U2wzbWpCso >}}
+
 ---
 
 ## 11:15 am - 11:45 am, ET<br />A Happy Compromise: Applying People-First Standards with Plain Language in Mind


### PR DESCRIPTION
Preview Link: https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/Gabr1elleKING-patch-29/event/2022/08/24/2022-federal-plain-language-summit/

This PR implements the following **changes:**

*Adding Youtube video for Debunking the Oversimplification Myth: Making the Case for Plain Language in Health Communications


**[URL / Link to page](https://digital.gov/event/2022/08/24/2022-federal-plain-language-summit/)**
