### PR TITLE
Investigate 404 page errors

### DIFF
--- a/themes/digital.gov/layouts/404.html
+++ b/themes/digital.gov/layouts/404.html
@@ -37,16 +37,6 @@
           </div>
 
           <div class="grid-col-12 tablet:grid-col-3">
-
-            {{/* Table of contents */}}
-            {{- partial "core/toc.html" . -}}
-
-            {{/* Last updated */}}
-            {{/* {{- partial "last-updated.html" . -}}  */}}
-
-            {{/* Touchpoints Form */}}
-            {{- partial "core/touchpoints-form.html" . -}}
-
           </div>
 
         </div>


### PR DESCRIPTION
### Summary
404 page is displaying the wrong templates and github edit button functionality is broken.

See screenshot below

### Problems

1. There's an "In this page" right sidebar menu, but nothing in it. The sidebar should only appear if there are H2s on a page (non-news or non-event).
2. The Touchpoints button appears on the page twice; bottom (correct) and right sidebar (incorrect).
3. The round blue Edit button doesn't work when you click it.
4. The `Edit` button to open in GitHub - normally below main content and the `Have feedback or questions? Send us an email at digitalgov@gsa.gov` line - is missing

Example pages: 

- https://digital.gov/services/sites-usa-gov/ 
- https://digital.gov/services/open-opportunities-mobile-application-testing-program/ 

### Solutions

1. Removed sidebar template
2. Removed touchpoints form
3. Not an issue*
4. Not an issue*

*Wayback machine does not show `Edit` button below the "Have feedback or questions?" and the the round edit button does not work either. This is because github editing is disabled for this page specifically.

### Notes

**Before**
<img width="1280" alt="404" src="https://user-images.githubusercontent.com/104778659/191570459-1a5ba2ba-155f-4a45-8f8c-8f34bc8e70a9.png">

**After**
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/104778659/191571855-aa1e7c0f-7e90-47b3-ab85-4f9c59ba7da0.png">

**Wayback Machine April/22**
<img width="1679" alt="Screen Shot 2022-09-21 at 1 23 02 PM" src="https://user-images.githubusercontent.com/104778659/191571987-199325e8-38d6-43e2-9966-2aaee50cc777.png">
