### PR TITLE
Improve color contrast for 3 community cards

### DIFF
--- a/themes/digital.gov/src/scss/new/home/_communities.scss
+++ b/themes/digital.gov/src/scss/new/home/_communities.scss
@@ -18,11 +18,11 @@
 }
 
 $communities-of-practice: (
-  'FCN': #FA9441,
+  'FCN': #c84281,
   'ML': #D73A33,
   'PL': #06648D,
-  'SM': #F2938C,
-  'UX': #73B2E7,
+  'SM': #2672de,
+  'UX': #40807e,
   'WAO': #775540,
   'WCM': #4A50C4
 );


### PR DESCRIPTION
### Summary
Border colors for `communicators`, `social media`, and `user experience` don't meet color contrast best practices.

### Solution
Replaced colors with alternate USWDS colors with at least 4.5 ratio with https://app.contrast-finder.org.

### Notes
**Before**
<img width="1010" alt="Screen Shot 2022-09-21 at 3 41 48 PM" src="https://user-images.githubusercontent.com/104778659/191596684-b69555dd-86dd-4394-ba10-7619a5a983da.png">

**After**
<img width="918" alt="Screen Shot 2022-09-21 at 3 43 49 PM" src="https://user-images.githubusercontent.com/104778659/191596703-f3f36e70-1e21-4215-b94b-f27a158630ef.png">
