### PR TITLE
Fix redirect for mobile testing program

### DIFF
--- a/content/resources/_index.md
+++ b/content/resources/_index.md
@@ -75,7 +75,6 @@ aliases:
 
 - [Connected Government Act](https://digital.gov/resources/connected-government-act/), January 2018
 - [Eight Principles of Mobile-Friendliness](https://digital.gov/resources/mobile/principles/)
-- [Federal CrowdSource Mobile Testing Program]({{< ref "service_mobile-testing-program.md" >}})
 - [A Guide to Creating Mobile-Friendly Websites](https://digital.gov/resources/guide-create-mobile-friendly-websites/)
 - [Mobile Application Development Program]({{< ref "mobile-application-development-program.md" >}})
     - [Mobile Code Sharing Catalog]({{< ref "2013-05-13-federal-mobile-code-sharing-catalog-is-here.md" >}})

--- a/content/services/service_mobile-testing-program.md
+++ b/content/services/service_mobile-testing-program.md
@@ -1,0 +1,62 @@
+---
+# What is the name of the product or service?
+title: "Federal Crowdsource Mobile Testing Program"
+
+# Keep it short — should be no longer than 10 words.
+summary: "Compatibility testing service that agencies can use to test the mobile-friendliness of their websites."
+
+# Will this point to an external source URL?
+# Note: We'll add a ?dg to the end of the URL in the code for tracking purposes
+# source_url: ''
+
+# Images need to be 200x200px with a transparent background
+# Upload new images to Github in the /static/logos/ folder
+# https://github.com/GSA/digitalgov.gov/tree/master/static/promos/
+# The filename should reflect the name of the product or service (e.g., challenge-gov.png)
+logo: 'digitalgov'
+
+contact: digitalgov@gsa.gov
+
+# Weight — controls how services appear across the site
+# 2 == will appear as related service (ADs) on blog posts and event pages
+# 1 == will appear on the tools and services page, and all related topic pages
+# 0 == hides this service from all pages, but URL is still public
+weight: 0
+
+# see all authors at https://digital.gov/authors
+authors:
+  - jparcell
+
+---
+
+{{< note "alert" >}}
+**The Federal Crowdsource Mobile Testing Program** at the U.S. General Services Administration (GSA) is no longer active. This page will be archived.
+{{< /note >}}
+
+Does your mobile site function properly on all devices your users have? Are you able to test your mobile site on all devices that access it? Do you have the time and money to maintain a mobile test lab?
+
+We&#8217;re guessing not.
+
+Our Crowdsource Mobile Testing program is a FREE service provided for federal agencies by federal employees. We do compatibility testing (determining how mobile websites display on the multiple makes and models of devices, operating systems, and mobile browsers), for mobile websites that agencies think are mobile-friendly.
+
+## Here&#8217;s How It Works
+
+You tell us your top tasks for your mobile website &#8211;
+
+We help you create a script for our testers!
+
+We recruit an army of Testers (all federal employees) to evaluate your application on a wide variety of mobile devices and provide you with a results report you can immediately use to enhance your application.
+
+**It works, take our customers&#8217; word for it!**
+
+{{< box >}}**American Battle Monuments Commission on testing Normandy App:** _Your feedback and input was critical to our testing process. In fact, you’ll notice a big difference on the home screen that stemmed directly from your comments. Instead of the scrolling left to right navigation from the home screen, we redesigned the home screen so the five main subpages are all right there._{{< /box >}}
+
+{{< box >}}**TSA on testing TSA.gov responsive site**: _The entire process of the Federal Mobile Crowdsource Testing Program and test cycle was helpful and extremely valuable. The testers explaining the exact issues and the steps they took to get to that specific problem will help us redesign and update the site to best disseminate pertinent security information the traveling public._{{< /box >}}
+
+Whether you have a site ready for testing or want to join our cadre of volunteer mobile testers, send us an email and indicate in the message whether you have a site you're interested in having tested, or if you want to become a tester.
+
+**But Wait! Do You Test Native Apps?!?!**
+
+Our program has tested a native app or two, but there have been some challenges to doing so. If your app is already in the app stores, then we won’t have a problem. Just send us an email and let us know how we might be able to help.
+
+_Want to learn more about what we've learned in the Federal Crowdsource Mobile Testing program? [Check out our lessons learned blog posts]({{< ref "/topics/mobile-testing" >}})!_


### PR DESCRIPTION
### Summary
https://digital.gov/services/mobile-application-testing-program/ is not redirected to https://digital.gov/topics/mobile/

### Problem
`aliases` is not redirecting to https://digital.gov/topics/mobile/

### Solution
Removed `url` on old page to allow internal redirecting.

The same alias was used twice, removed it from the 2nd link.
- `content/topics/mobile/_index.md `
- `content/guides/mobile-principles/_index.md`

### Preview
https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/nl-alias-mobile-testing-program/services/mobile-application-testing-program/