### PR TITLE
Hide bullet icons from screen readers on home page

### DIFF
--- a/themes/digital.gov/layouts/partials/core/collection.html
+++ b/themes/digital.gov/layouts/partials/core/collection.html
@@ -90,7 +90,7 @@
   {{- $src := .src -}}
   {{- with .item -}}
     <div class="icon">
-      <a href="{{- $href -}}" title="{{- .Title | markdownify -}}">
+      <a href="{{- $href -}}" title="{{- .Title | markdownify -}}" aria-hidden="true">
         <img src="{{ $src | relURL }}" alt="{{- .Params.name }} icon"/>
       </a>
     </div>

--- a/themes/digital.gov/layouts/partials/core/collection.html
+++ b/themes/digital.gov/layouts/partials/core/collection.html
@@ -90,7 +90,7 @@
   {{- $src := .src -}}
   {{- with .item -}}
     <div class="icon">
-      <img src="{{ $src | relURL }}" alt="{{- .Params.name }} icon" aria-hidden="true"/>
+      <img src="{{ $src | relURL }}" alt="" aria-hidden="true"/>
     </div>
   {{- end -}}
 {{- end -}}

--- a/themes/digital.gov/layouts/partials/core/collection.html
+++ b/themes/digital.gov/layouts/partials/core/collection.html
@@ -90,9 +90,7 @@
   {{- $src := .src -}}
   {{- with .item -}}
     <div class="icon">
-      <a href="{{- $href -}}" title="{{- .Title | markdownify -}}" aria-hidden="true">
-        <img src="{{ $src | relURL }}" alt="{{- .Params.name }} icon"/>
-      </a>
+      <img src="{{ $src | relURL }}" alt="{{- .Params.name }} icon" aria-hidden="true"/>
     </div>
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
### Summary
Update bullet icons to be decorative to remove from screen readers.

### Problem
Bullet icons on "Popular Guides and Resources" section are reading out "Link image icon" on screen readers when these images should be decorative.

### Solution
Set link wrapper to `aria-hidden: true` to hide from screen readers.

### Notes
<img width="1078" alt="Screen Shot 2022-09-28 at 11 08 27 AM" src="https://user-images.githubusercontent.com/104778659/192815867-f05b49fa-300f-431b-8544-4e6f604832b9.png">
