### PR TITLE
Add headings to all News items

### DIFF
--- a/themes/digital.gov/layouts/news/card-elsewhere.html
+++ b/themes/digital.gov/layouts/news/card-elsewhere.html
@@ -19,6 +19,9 @@
 
     <div class="summary">
       <p>
+        <h3>
+          <a href="{{- .Permalink -}}">{{- .Title | markdownify -}}</a>
+        </h3>
         {{- if .Params.deck -}}{{- .Params.deck | markdownify | emojify -}}{{- end -}}
         {{- if $source -}}
           {{ $url := urls.Parse .Params.source_url }}

--- a/themes/digital.gov/layouts/news/list.html
+++ b/themes/digital.gov/layouts/news/list.html
@@ -13,7 +13,7 @@
 
           {{/* Deck */}}
           {{- if .Params.deck -}}
-          <div class="deck">{{- .Params.deck | markdownify -}}</div>
+          <h2 class="deck">{{- .Params.deck | markdownify -}}</h2>
           {{- end -}}
 
           <div class="join-buttons">

--- a/themes/digital.gov/layouts/partials/core/newsletter-signup.html
+++ b/themes/digital.gov/layouts/partials/core/newsletter-signup.html
@@ -3,13 +3,13 @@
   <div class="grid-container grid-container-desktop">
     <div class="grid-row tablet-lg:grid-gap-6">
       <div class="grid-col-12 tablet:grid-col-7">
-        <div class="usa-sign-up">
+        <section class="usa-sign-up">
           <p class="blurb"><strong>Join 60,000 others in government</strong> and sign-up for our newsletter — a round-up of the best digital news in government and across our field.</p>
-        </div>
+        </section>
       </div>
       <div class="grid-col-12 tablet:grid-col-5">
 
-        <div class="usa-sign-up">
+        <section class="usa-sign-up">
           <!--[if lte IE 8]>
           <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2-legacy.js"></script>
           <![endif]-->
@@ -20,7 +20,7 @@
             formId: "f8c8ff73-dbc9-4242-90e4-e8cbcee02f6a"
           });
           </script>
-        </div>
+        </section>
 
       </div>
     </div>


### PR DESCRIPTION
### Summary
News short links need to contain an `h3` header for screen readers.

### Problem
News 'short links' posts with the `card-elsewhere` class use the `deck` property with a markdown bold syntax within the deck that looks like a header but cannot be read by the screen reader. This causes the short links to be skipped as the reader navigates down the page.

@ToniBonittoGSA we will need to update markdown templates going forward if we do this. We should remove the **bold** markup in the deck to remove the title duplication. We could update just the short link posts within the past 2 months to make the home page work with this change.

https://github.com/GSA/digitalgov.gov/blob/0d04d41b467b27bee6c15408dfe7af0077c327cd/content/news/2022/09/2022-09-27-cxday.md?plain=1#L7

### Solution
Use an `h3` for an accessible heading.

### Notes

**Before**
Screen reader headings skip over short links.

<img width="1260" alt="Screen Shot 2022-09-28 at 3 25 50 PM" src="https://user-images.githubusercontent.com/104778659/192877934-a58efb32-79ad-43f2-a859-002ce887fcbb.png">

**After**

<img width="1575" alt="image" src="https://user-images.githubusercontent.com/104778659/192878301-3312e08e-3710-49fd-943c-6fc99927df15.png">
