### PR TITLE
Use new cloud pages name for preview_context

### DIFF
--- a/themes/digital.gov/static/workflow/config.yml
+++ b/themes/digital.gov/static/workflow/config.yml
@@ -11,7 +11,7 @@ backend:
   repo: GSA/digitalgov.gov
   base_url: https://federalistapp.18f.gov
   auth_endpoint: external/auth/github
-  preview_context: federalist/build
+  preview_context: pages/build
   use_graphql: true
   branch: main
   open_authoring: true


### PR DESCRIPTION
This updates the workflow config to point to the new `pages/build` endpoint instead of federalist. Closes #5418.

See trello ticket: https://trello.com/c/0zdtz69r/1353-migrate-to-cloudgov-pages