### PR TITLE
Updating baseurl for workflow

### DIFF
--- a/themes/digital.gov/static/workflow/config.yml
+++ b/themes/digital.gov/static/workflow/config.yml
@@ -9,7 +9,7 @@ backend:
   # Federalist
   name: github
   repo: GSA/digitalgov.gov
-  base_url: https://federalistapp.18f.gov
+  base_url: https://pages.cloud.gov
   auth_endpoint: external/auth/github
   preview_context: pages/build
   use_graphql: true


### PR DESCRIPTION
This PR implements the following **changes:**

Points workflow login to new Cloud.gov pages (previously Federalist). Closes #5444.

**URL / Link to page**

Go to [Workflow login](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/jm-update-workflow-baseurl/workflow)

You should be able to login successfully.