### PR TITLE
Contact page template errors

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -56,7 +56,7 @@ markup:
   tableOfContents:
     endLevel: 3
     ordered: false
-    startLevel: 2
+    startLevel: 1
 
 
 

--- a/config.yml
+++ b/config.yml
@@ -56,7 +56,7 @@ markup:
   tableOfContents:
     endLevel: 3
     ordered: false
-    startLevel: 1
+    startLevel: 2
 
 
 

--- a/content/about/contact.md
+++ b/content/about/contact.md
@@ -2,20 +2,14 @@
 title: "Contact Us"
 deck: "We are human, we promise."
 summary: "How to contact the Digital.gov team."
+
 ---
 
 **Digital.gov** is made up of a cross-functional team of writers, editors, strategists, technologists, and designers who all work at the Technology Transformation Services (TTS) at the General Services Administration (GSA).
 
-- **Digital.gov:** Toni Bonitto
-- **Communities:**  Alexander Schulte
-- **Events:** Gabrielle Fratanduono, Jeannie Yoon
-
 For a wider list of contacts, see our [**Directory of services, tools, and teams**]({{< ref "/services/directory.md" >}}) »
 
 :envelope: **Questions or feedback?** send an email to us at [digitalgov@gsa.gov](mailto:digitalgov@gsa.gov).
-
-:envelope: **For questions or feedback about a specific page**: At the end of any page, please use the email link that says, `Have feedback or questions? Send us an email at digitalgov@gsa.gov`. The link is coded to automatically include the URL of that specific page in your email message to us&mdash;so that we can find it quickly.
-
 
 :video_camera: For all media or speaker inquiries, please [email GSA’s Office of Strategic Communication](mailto:press@gsa.gov) (OSC).
 

--- a/content/about/contact.md
+++ b/content/about/contact.md
@@ -2,7 +2,6 @@
 title: "Contact Us"
 deck: "We are human, we promise."
 summary: "How to contact the Digital.gov team."
-
 ---
 
 **Digital.gov** is made up of a cross-functional team of writers, editors, strategists, technologists, and designers who all work at the Technology Transformation Services (TTS) at the General Services Administration (GSA).
@@ -13,7 +12,10 @@ summary: "How to contact the Digital.gov team."
 
 For a wider list of contacts, see our [**Directory of services, tools, and teams**]({{< ref "/services/directory.md" >}}) »
 
-:envelope: Questions or feedback? send an email to us at [digitalgov@gsa.gov](mailto:digitalgov@gsa.gov).
+:envelope: **Questions or feedback?** send an email to us at [digitalgov@gsa.gov](mailto:digitalgov@gsa.gov).
+
+:envelope: **For questions or feedback about a specific page**: At the end of any page, please use the email link that says, `Have feedback or questions? Send us an email at digitalgov@gsa.gov`. The link is coded to automatically include the URL of that specific page in your email message to us&mdash;so that we can find it quickly.
+
 
 :video_camera: For all media or speaker inquiries, please [email GSA’s Office of Strategic Communication](mailto:press@gsa.gov) (OSC).
 

--- a/themes/digital.gov/layouts/_default/single.html
+++ b/themes/digital.gov/layouts/_default/single.html
@@ -35,7 +35,7 @@
           <div class="grid-col-12 tablet:grid-col-9">
 
             {{/* Content */}}
-            <div class="content">
+            <div class="content usa-prose">
               {{- .Content -}}
             </div>
 

--- a/themes/digital.gov/layouts/partials/core/toc.html
+++ b/themes/digital.gov/layouts/partials/core/toc.html
@@ -1,5 +1,6 @@
 {{/* Check if there no headers in the list to hide the "In this page" sidebar */}}
 {{/* https://discourse.gohugo.io/t/check-for-empty-tableofcontents/29737 */}}
+
 {{- if eq .TableOfContents "<nav id=\"TableOfContents\"></nav>" -}}
 {{- else -}}
 <div class="toc">

--- a/themes/digital.gov/layouts/partials/core/toc.html
+++ b/themes/digital.gov/layouts/partials/core/toc.html
@@ -1,5 +1,5 @@
-// prevents displaying an empty table of contents aka "In this page"
-// See https://discourse.gohugo.io/t/check-for-empty-tableofcontents/29737/2
+{{/* Check if there no headers in the list to hide the "In this page" sidebar */}}
+{{/* https://discourse.gohugo.io/t/check-for-empty-tableofcontents/29737 */}}
 {{- if eq .TableOfContents "<nav id=\"TableOfContents\"></nav>" -}}
 {{- else -}}
 <div class="toc">

--- a/themes/digital.gov/layouts/partials/core/toc.html
+++ b/themes/digital.gov/layouts/partials/core/toc.html
@@ -1,4 +1,7 @@
-{{- if .TableOfContents -}}
+// prevents displaying an empty table of contents aka "In this page"
+// See https://discourse.gohugo.io/t/check-for-empty-tableofcontents/29737/2
+{{- if eq .TableOfContents "<nav id=\"TableOfContents\"></nav>" -}}
+{{- else -}}
 <div class="toc">
   <h4>In this page</h4>
   {{- .TableOfContents -}}


### PR DESCRIPTION
### Summary
Contact page was not rendering short code formatting and displayed empty 'In this page' sidebar.

### Problem
Contact page and any page with no `h2`'s will display an empty "In this page" sidebar.
Shortcode styles were not rendering, 'usa-prose' was missing from a template.

### Solution
Added logic to `layouts/partials/core/toc.html` to check if `.TableOfContents` is empty to hide the sidebar when no `h2`'s on the page.
Added `usa-prose` to `layouts/_default/single.html` to render short codes as expected.

### Notes

**Before**
<img width="1376" alt="Screen Shot 2022-10-05 at 9 50 34 AM" src="https://user-images.githubusercontent.com/104778659/194077071-1ee31c36-02c2-4251-b29e-f3017247036b.png">

**After**

Short code formatting is just an example in the image below, page content has not been updated.

<img width="1680" alt="Screen Shot 2022-10-05 at 9 51 59 AM" src="https://user-images.githubusercontent.com/104778659/194077410-0aae99d1-78b7-46e7-b99d-da13768954f3.png">
