### PR TITLE
Update alt text for SVG calendar icon on past events

### DIFF
--- a/themes/digital.gov/layouts/events/card-event-past.html
+++ b/themes/digital.gov/layouts/events/card-event-past.html
@@ -8,9 +8,9 @@
     </div>
     {{- else -}}
     <div class="non-youtube-event-card grid-col-12 tablet:grid-col-4 tablet:order-last grid-row">
-      <div aria-role="img" class="grid-row flex-align-self-center" data-link="{{ .Permalink }}">
-        <svg xmlns="http://www.w3.org/2000/svg" role="img" height="150" width="150" viewBox="0 0 25 25">
-          <title>Non-Youtube Event</title>
+      <div class="grid-row flex-align-self-center" data-link="{{ .Permalink }}">
+        <svg xmlns="http://www.w3.org/2000/svg" role="img" alt="" aria-hidden="true" height="150" width="150" viewBox="0 0 25 25">
+          <title id="calendar-title">Calendar Event</title>
           <path d="M0 0h24v24H0z" fill="none"/>
           <path fill="#005ea2" d="M17 12h-5v5h5v-5zM16 1v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2h-1V1h-2zm3 18H5V8h14v11z"/>
         </svg>

--- a/themes/digital.gov/layouts/events/card-event-past.html
+++ b/themes/digital.gov/layouts/events/card-event-past.html
@@ -10,7 +10,7 @@
     <div class="non-youtube-event-card grid-col-12 tablet:grid-col-4 tablet:order-last grid-row">
       <div class="grid-row flex-align-self-center" data-link="{{ .Permalink }}">
         <svg xmlns="http://www.w3.org/2000/svg" role="img" alt="" aria-hidden="true" height="150" width="150" viewBox="0 0 25 25">
-          <title id="calendar-title">Calendar Event</title>
+          <title>Calendar Event</title>
           <path d="M0 0h24v24H0z" fill="none"/>
           <path fill="#005ea2" d="M17 12h-5v5h5v-5zM16 1v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2h-1V1h-2zm3 18H5V8h14v11z"/>
         </svg>


### PR DESCRIPTION
### Summary
Added proper alt text for calendar svg icon

### Problem
Calendar icon for past events does not contain an alternative text or label.

<img width="1379" alt="image" src="https://user-images.githubusercontent.com/104778659/193895330-db971936-6e8c-459d-8899-d84e2f5b826f.png">


### Solution
Added an `id` to the `title` attribute of the svg and a `aria-labelledby` to the `svg`.

<img width="1345" alt="image" src="https://user-images.githubusercontent.com/104778659/193895525-7896e801-72f1-40ea-a5dd-7036a65817d2.png">
