### PR TITLE
Update alt text for icons in news & events section

### DIFF
--- a/themes/digital.gov/layouts/authors/list.html
+++ b/themes/digital.gov/layouts/authors/list.html
@@ -9,9 +9,9 @@
           <header>
 
             {{- if .Params.github -}}
-              <img class="profile" src="https://github.com/{{- .Params.github -}}.png?size=100" srcset="https://www.github.com/{{-  .Params.github -}}.png?size=200" alt="Profile image for&nbsp;{{- .Params.display_name -}}">
+              <img class="profile" src="https://github.com/{{- .Params.github -}}.png?size=100" srcset="https://www.github.com/{{-  .Params.github -}}.png?size=200" alt="Profile image for {{- .Params.display_name -}}">
             {{- else -}}
-              <img class="profile" src="{{- "img/digit-light.png" | absURL -}}" alt="Profile image for&nbsp;{{- .Params.display_name -}}">
+              <img class="profile" src="{{- "img/digit-light.png" | absURL -}}" alt="Profile image for {{- .Params.display_name -}}">
             {{- end -}}
 
             <div>

--- a/themes/digital.gov/layouts/authors/list.html
+++ b/themes/digital.gov/layouts/authors/list.html
@@ -9,9 +9,9 @@
           <header>
 
             {{- if .Params.github -}}
-              <img class="profile" src="https://github.com/{{- .Params.github -}}.png?size=100" srcset="https://www.github.com/{{-  .Params.github -}}.png?size=200" alt="Photo: {{- .Params.display_name -}}">
+              <img class="profile" src="https://github.com/{{- .Params.github -}}.png?size=100" srcset="https://www.github.com/{{-  .Params.github -}}.png?size=200" alt="Profile image for&nbsp;{{- .Params.display_name -}}">
             {{- else -}}
-              <img class="profile" src="{{- "img/digit-light.png" | absURL -}}" alt="Photo: {{- .Params.display_name -}}">
+              <img class="profile" src="{{- "img/digit-light.png" | absURL -}}" alt="Profile image for&nbsp;{{- .Params.display_name -}}">
             {{- end -}}
 
             <div>

--- a/themes/digital.gov/layouts/partials/core/get_authors_short.html
+++ b/themes/digital.gov/layouts/partials/core/get_authors_short.html
@@ -26,7 +26,7 @@
       {{/* Lets look up the author data, based on the UID. Should equal the filename */}}
       {{- with $.Site.GetPage (printf "/%s/%s" $taxonomy $uid) -}}
 
-      <a class="author" href="{{- (printf "authors/%s/" $uid) | absURL -}} " title="Posts by {{- .Params.display_name | default $uid -}} " rel="author">
+      <a class="author" href="{{- (printf "authors/%s/" $uid) | absURL -}} " title="Posts by&nbsp;{{- .Params.display_name | default $uid -}} " rel="author">
 
         {{- partial "core/get_author_image.html" (dict "author" . ) -}}
 

--- a/themes/digital.gov/layouts/partials/core/get_authors_short.html
+++ b/themes/digital.gov/layouts/partials/core/get_authors_short.html
@@ -26,7 +26,7 @@
       {{/* Lets look up the author data, based on the UID. Should equal the filename */}}
       {{- with $.Site.GetPage (printf "/%s/%s" $taxonomy $uid) -}}
 
-      <a class="author" href="{{- (printf "authors/%s/" $uid) | absURL -}} " title="Posts by&nbsp;{{- .Params.display_name | default $uid -}} " rel="author">
+      <a class="author" href="{{- (printf "authors/%s/" $uid) | absURL -}}" rel="author">
 
         {{- partial "core/get_author_image.html" (dict "author" . ) -}}
         <span class="usa-sr-only">Posts by</span>

--- a/themes/digital.gov/layouts/partials/core/get_authors_short.html
+++ b/themes/digital.gov/layouts/partials/core/get_authors_short.html
@@ -29,7 +29,7 @@
       <a class="author" href="{{- (printf "authors/%s/" $uid) | absURL -}} " title="Posts by&nbsp;{{- .Params.display_name | default $uid -}} " rel="author">
 
         {{- partial "core/get_author_image.html" (dict "author" . ) -}}
-
+        <span class="usa-sr-only">Posts by</span>
         <span>{{- .Params.display_name | default $uid | markdownify -}}</span>
       </a>{{ if lt (add $i 1) $length }}<!--,--> {{ end }}
 


### PR DESCRIPTION
### Summary
Made several accessibility updates for author images on several pages.

### Problem
[Home](https://digital.gov) and [News](https://digital.gov/news/) pages have author images that aren't accessible with their `title` attributes. This approach is not consistent across all AT devices.

[Author](https://digital.gov/authors/katina-stapleton/) bio pages need better plain language text to accompany the image.

### Solution
Added a `span` with `usa-sr-only` within the link to ensure screen readers read "Posts by author name".
Updated verbiage for author bio image to read "Profile image for author name". Previously was "Photo:author name"

### Notes
Fixed a typo in the `title` which was missing a space between the name and "Posts by".
