### PR TITLE
Remove "Have feedback or questions? ..." from the page template

### DIFF
--- a/themes/digital.gov/layouts/partials/core/page-data.html
+++ b/themes/digital.gov/layouts/partials/core/page-data.html
@@ -13,25 +13,6 @@ Here are values that are passed in through the partial:
 {{- $email_copy := (print "We value your feedback and open questions. Thank you for helping to make our pages better.") -}}
 
 <div id="page-data" class="branch-{{- .branch -}}" name="page-data">
-  <p class="feedback-copy">
-    <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-      <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#help_outline"></use>
-    </svg>
-    {{ if .prompt -}}{{- .prompt -}}{{- else -}}
-      Have feedback or questions?
-    {{- end }}
-    <a target="new" href="mailto:{{- if .email -}}{{- .email -}}{{- else -}}digitalgov@gsa.gov{{- end -}}
-        ?subject=Feedback%3A%20{{- htmlUnescape .page.Title | safeHTML -}}
-        &amp;body=%0D%0A---enter%20your%20feedback%2Fquestions%20here---%0D%0A%0D%0A%0D%0A-%20-%20-%20-%20-%20%0D%0APage%3A%20
-        {{- htmlUnescape .page.Title | safeHTML -}}%0D%0AURL%3A%20https%3A%2F%2Fwww.digital.gov{{- .page.Permalink | markdownify -}}
-        %0D%0A-%20-%20-%20-%20-%0D%0A%0D%0A%0D%0A
-        {{- $email_copy -}}
-        %0D%0A%0D%0Ahttps%3A%2F%2Fwww.digital.gov%0D%0A%40digital_gov%20on%20Twitter
-        {{- if .cc -}}&amp;cc={{- .cc -}}{{- end -}}">
-        Send us an email at digitalgov@gsa.gov
-    </a>
-    </p>
-
   <!-- Edit file on GitHub -->
   <div class="edit_file hidden"></div>
 </div>


### PR DESCRIPTION
### Summary

Removed "Have feedback or questions? [Send us an email at digitalgov@gsa.gov](mailto:digitalgov@gsa.gov?subject=Feedback%3A%20Federal%20Communicators%20Network&body=%0D%0A---enter%20your%20feedback%2Fquestions%20here---%0D%0A%0D%0A%0D%0A-%20-%20-%20-%20-%20%0D%0APage%3A%20Federal%20Communicators%20Network%0D%0AURL%3A%20https%3A%2F%2Fwww.digital.gov%2fcommunities%2ffederal-communicators-network%2f%0D%0A-%20-%20-%20-%20-%0D%0A%0D%0A%0D%0AWe%20value%20your%20feedback%20and%20open%20questions.%20Thank%20you%20for%20helping%20to%20make%20our%20pages%20better.%0D%0A%0D%0Ahttps%3A%2F%2Fwww.digital.gov%0D%0A%40digital_gov%20on%20Twitter)" from page template.

<img width="783" alt="have-feedback" src="https://user-images.githubusercontent.com/104778659/195107209-5b0ac4d3-2e47-436b-8c15-638834438437.png">


