### PR TITLE
Update svg paths to use relURL

### DIFF
--- a/themes/digital.gov/layouts/_default/baseof.html
+++ b/themes/digital.gov/layouts/_default/baseof.html
@@ -40,12 +40,12 @@
   <div class="edit_tools">
     <button class="edit edit-open" aria-label="edit" type="button">
       <svg class="usa-icon dg-icon dg-icon--large margin-bottom-05" aria-hidden="true" focusable="false">
-        <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#edit"></use>
+        <use xlink:href="{{ "uswds/img/sprite.svg#edit" | relURL }}"></use>
       </svg>
     </button>
     <a class="edit edit-issue" role="button" target="_blank" href="https://github.com/GSA/digitalgov.gov/issues/new?body=%0D%0A%2A%2A{{- .Title -}}%2A%2A%0D%0Ahttps%3A%2F%2Fdigital.gov%2F{{- .Permalink -}}%0D%0A%0D%0A---%0D%0A%0D%0A%2A%2APlease+describe+the+issue+clearly.+Include+a+screenshot+if+needed%2A%2A%0D%0A">
       <svg class="usa-icon dg-icon dg-icon--large margin-bottom-05" aria-hidden="true" focusable="false">
-        <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#bug_report"></use>
+        <use xlink:href="{{ "uswds/img/sprite.svg#bug_report" | relURL }}"></use>
       </svg>
       <span class="usa-sr-only">Report an issue</span>
     </a>

--- a/themes/digital.gov/layouts/_default/images.html
+++ b/themes/digital.gov/layouts/_default/images.html
@@ -8,7 +8,7 @@
           <div class="grid-col-12" data-edit-this="{{- $path -}}">
             <p class="breadcrumb"><a href="{{- "/" | absURL -}}">
               <svg class="usa-icon dg-icon dg-icon--large margin-bottom-05" aria-hidden="true" focusable="false">
-                <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#arrow_back"></use>
+                <use xlink:href="{{ "uswds/img/sprite.svg#arrow_back" | relURL }}"></use>
               </svg>
               <span>Home</span> </a>
             </p>

--- a/themes/digital.gov/layouts/_default/list.html
+++ b/themes/digital.gov/layouts/_default/list.html
@@ -9,7 +9,7 @@
             <p class="breadcrumb">
               <a href="{{- "resources/" | absURL -}}">
                 <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                  <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#arrow_back"></use>
+                  <use xlink:href="{{ "uswds/img/sprite.svg#arrow_back" | relURL }}"></use>
                 </svg>
                 <span>Home</span>
               </a>

--- a/themes/digital.gov/layouts/_default/single.html
+++ b/themes/digital.gov/layouts/_default/single.html
@@ -12,7 +12,7 @@
             <p class="breadcrumb">
               <a href="{{ .Parent.Permalink }}" title="{{ .Parent.Title }}">
                 <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                  <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#arrow_back"></use>
+                  <use xlink:href="{{ "uswds/img/sprite.svg#arrow_back" | relURL }}"></use>
                 </svg>
                 <span>{{ .Parent.Title }}</span>
               </a>

--- a/themes/digital.gov/layouts/authors/list.html
+++ b/themes/digital.gov/layouts/authors/list.html
@@ -46,7 +46,7 @@
                     <li>
                       <a class="facebook" rel="external" title="{{- .Params.display_name }} on Facebook" href="http://www.facebook.com/{{- .Params.facebook -}}/">
                         <svg class="usa-icon dg-icon dg-icon--extra-large margin-bottom-05" aria-hidden="true" focusable="false">
-                          <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#facebook"></use>
+                          <use xlink:href="{{ "uswds/img/sprite.svg#facebook" | relURL }}"></use>
                         </svg>
                       </a>
                     </li>
@@ -55,7 +55,7 @@
                     <li>
                       <a class="twitter" rel="external" title="{{- .Params.display_name -}} on Twitter" href="http://www.twitter.com/{{- .Params.twitter -}}/">
                         <svg class="usa-icon dg-icon dg-icon--extra-large margin-bottom-05" aria-hidden="true" focusable="false">
-                          <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#twitter"></use>
+                          <use xlink:href="{{ "uswds/img/sprite.svg#twitter" | relURL }}"></use>
                         </svg>
                       </a>
                     </li>
@@ -64,7 +64,7 @@
                     <li>
                       <a class="linkedin" rel="external" title="{{- .Params.display_name -}} on LinkedIn" href="http://www.linkedin.com/in/{{- .Params.linkedin -}}/">
                         <svg class="usa-icon dg-icon dg-icon--extra-large margin-bottom-05" aria-hidden="true" focusable="false">
-                          <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#linkedin"></use>
+                          <use xlink:href="{{ "uswds/img/sprite.svg#linkedin" | relURL }}"></use>
                         </svg>
                       </a>
                     </li>
@@ -73,7 +73,7 @@
                     <li>
                       <a class="youtube" rel="external" title="{{- .Params.display_name -}} on YouTube" href="http://www.youtube.com/user/{{- .Params.youtube -}}">
                         <svg class="usa-icon dg-icon dg-icon--extra-large margin-bottom-05" aria-hidden="true" focusable="false">
-                          <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#youtube"></use>
+                          <use xlink:href="{{ "uswds/img/sprite.svg#youtube" | relURL }}"></use>
                         </svg>
                       </a>
                     </li>
@@ -82,7 +82,7 @@
                     <li>
                       <a class="github" rel="external" title="{{- .Params.display_name }} on GitHub" href="http://www.github.com/{{- .Params.github -}}">
                         <svg class="usa-icon dg-icon dg-icon--extra-large margin-bottom-05" aria-hidden="true" focusable="false">
-                          <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#github"></use>
+                          <use xlink:href="{{ "uswds/img/sprite.svg#github" | relURL }}"></use>
                         </svg>
                       </a>
                     </li>
@@ -91,7 +91,7 @@
                   <li>
                     <a class="rss" title="RSS Feed for {{ .Params.display_name -}}" href="{{- .RelPermalink -}}">
                       <svg class="usa-icon dg-icon dg-icon--extra-large margin-bottom-05" aria-hidden="true" focusable="false">
-                        <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#rss_feed"></use>
+                        <use xlink:href="{{ "uswds/img/sprite.svg#rss_feed" | relURL }}"></use>
                       </svg>
                     </a>
                   </li>
@@ -99,7 +99,7 @@
                   <li>
                     <a class="json" title="API for {{ .Params.display_name -}}" href="{{- .Permalink -}}index.json">
                       <svg class="usa-icon dg-icon dg-icon--extra-large" aria-hidden="true" focusable="false">
-                        <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#code"></use>
+                        <use xlink:href="{{ "uswds/img/sprite.svg#code" | relURL }}"></use>
                       </svg>
                     </a>
                   </li>
@@ -180,7 +180,7 @@
             <a class="btn" href="{{ "news" | absURL }}" title="">
               <span>See all News</span>
               <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#arrow_forward"></use>
+                <use xlink:href="{{ "uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
               </svg>
             </a>
             <p>Have a case study to share? Did your team recently launch something?<br/><a href="mailto:digitalgov@gsa.gov" title=""><strong>Send us an email</strong></a></p>

--- a/themes/digital.gov/layouts/communities/archived.html
+++ b/themes/digital.gov/layouts/communities/archived.html
@@ -12,7 +12,7 @@
             <p class="breadcrumb">
               <a href="{{ .Parent.Permalink }}" title="{{ .Parent.Title }}">
                 <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                  <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#arrow_back"></use>
+                  <use xlink:href="{{ "uswds/img/sprite.svg#arrow_back" | relURL }}"></use>
                 </svg>
                 <span>{{ .Parent.Title }}</span>
               </a>

--- a/themes/digital.gov/layouts/communities/single.html
+++ b/themes/digital.gov/layouts/communities/single.html
@@ -111,12 +111,12 @@
                     {{- if $e.members -}}
                       <p class="members">
                         <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                          <use xlink:href="{{- $.Site.BaseURL -}}uswds/img/sprite.svg#person"></use>
+                          <use xlink:href="{{ "uswds/img/sprite.svg#person" | relURL }}"></use>
                         </svg>
                         {{ $e.members }} members
                         {{- if $e.emails_per_week }}
                         <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                          <use xlink:href="{{- $.Site.BaseURL -}}uswds/img/sprite.svg#mail"></use>
+                          <use xlink:href="{{ "uswds/img/sprite.svg#mail" | relURL }}"></use>
                         </svg>
                         Avg. {{ $e.emails_per_week }} emails per week{{- end -}}
                       </p>

--- a/themes/digital.gov/layouts/communities/single.html
+++ b/themes/digital.gov/layouts/communities/single.html
@@ -12,7 +12,7 @@
             <p class="breadcrumb">
               <a href="{{ .Parent.Permalink }}" title="{{ .Parent.Title }}">
                 <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                  <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#arrow_back"></use>
+                  <use xlink:href="{{ "uswds/img/sprite.svg#arrow_back" | relURL }}"></use>
                 </svg>
                 <span>{{ .Parent.Title }}</span>
               </a>

--- a/themes/digital.gov/layouts/events/single.html
+++ b/themes/digital.gov/layouts/events/single.html
@@ -19,7 +19,7 @@
           <div class="grid-col-12" data-edit-this="{{- $path -}}">
             <p class="breadcrumb"><a href="{{- "events/" | absURL -}}">
               <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#arrow_back"></use>
+                <use xlink:href="{{ "uswds/img/sprite.svg#arrow_back" | relURL }}"></use>
               </svg>
               <span>All Events</span> </a>
             </p>
@@ -34,7 +34,7 @@
 
             <p class="datetime">
               <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#calendar_today"></use>
+                <use xlink:href="{{ "uswds/img/sprite.svg#calendar_today" | relURL }}"></use>
               </svg>
               {{ with .Date }}
               {{ . | dateFormat "Monday, January 02, 2006" }}
@@ -71,7 +71,7 @@
             <span class="addtocalendar">
               <a class="atcb-link" title="Add to calendar">
                 <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                  <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#event"></use>
+                  <use xlink:href="{{ "uswds/img/sprite.svg#event" | relURL }}"></use>
                 </svg> Add to Cal
               </a>
               <var class="atc_event">
@@ -174,7 +174,7 @@
                 <span class="addtocalendar">
                   <a class="atcb-link" title="Add to calendar">
                     <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                      <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#event"></use>
+                      <use xlink:href="{{ "uswds/img/sprite.svg#event" | relURL }}"></use>
                     </svg> Add to Cal
                   </a>
                   <var class="atc_event">

--- a/themes/digital.gov/layouts/events/stage-adobe_connect.html
+++ b/themes/digital.gov/layouts/events/stage-adobe_connect.html
@@ -2,7 +2,7 @@
   <div class="icon">
     <p>
       <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false" role="img">
-        <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#keyboard"></use>
+        <use xlink:href="{{ "uswds/img/sprite.svg#keyboard" | relURL }}"></use>
       </svg>
     </p>
   </div>
@@ -13,7 +13,7 @@
     <p>
       <a class="captions" href="{{- .Params.captions -}}" title="Captions for the {{ .Title -}}"><strong>
         <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-          <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#closed_caption"></use>
+          <use xlink:href="{{ "uswds/img/sprite.svg#closed_caption" | relURL }}"></use>
         </svg>
         <span>View captions</span></strong>
       </a>

--- a/themes/digital.gov/layouts/events/stage-google.html
+++ b/themes/digital.gov/layouts/events/stage-google.html
@@ -2,7 +2,7 @@
   <div class="icon">
     <p>
       <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false" role="img">
-        <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#keyboard"></use>
+        <use xlink:href="{{ "uswds/img/sprite.svg#keyboard" | relURL }}"></use>
       </svg>
     </p>
   </div>
@@ -14,7 +14,7 @@
       <a class="captions" href="{{- .Params.captions -}}" title="Captions for the {{ .Title -}}">
         <strong>
           <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-            <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#closed_caption"></use>
+            <use xlink:href="{{ "uswds/img/sprite.svg#closed_caption" | relURL }}"></use>
           </svg>
           <span>View captions</span>
         </strong>

--- a/themes/digital.gov/layouts/events/stage-youtube-live.html
+++ b/themes/digital.gov/layouts/events/stage-youtube-live.html
@@ -20,7 +20,7 @@
           <a class="youtube" href="https://www.youtube.com/watch?v={{- .Params.youtube_id -}}" title="Watch on YouTube">
             <strong>
               <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false" role="img">
-                <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#youtube"></use>
+                <use xlink:href="{{ "uswds/img/sprite.svg#youtube" | relURL }}"></use>
               </svg>
               <span>Watch on YouTube</span>
             </strong>
@@ -30,7 +30,7 @@
           <a class="captions" href="{{- .Params.captions -}}" title="Captions for the {{ .Title -}}">
             <strong>
               <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false" role="img">
-                <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#closed_caption"></use>
+                <use xlink:href="{{ "uswds/img/sprite.svg#closed_caption" | relURL }}"></use>
               </svg>
               <span>View captions</span>
             </strong>
@@ -42,7 +42,7 @@
         <div class="event-tools">
           <p class="notice">
             <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-              <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#flag"></use>
+              <use xlink:href="{{ "uswds/img/sprite.svg#flag" | relURL }}"></use>
             </svg>
             You'll need to sign in to Google to chat. All chats will be archived alongside the video.
           </p>

--- a/themes/digital.gov/layouts/events/stage-zoom.html
+++ b/themes/digital.gov/layouts/events/stage-zoom.html
@@ -2,7 +2,7 @@
   <div class="icon">
     <p>
       <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false" role="img">
-        <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#keyboard"></use>
+        <use xlink:href="{{ "uswds/img/sprite.svg#keyboard" | relURL }}"></use>
       </svg>
     </p>
   </div>
@@ -14,7 +14,7 @@
     <p>
       <a class="captions" href="{{- .Params.captions -}}" title="Captions for the {{ .Title -}}"><strong>
         <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-          <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#closed_caption"></use>
+          <use xlink:href="{{ "uswds/img/sprite.svg#closed_caption" | relURL }}"></use>
         </svg>
         <span>View captions</span></strong>
       </a>

--- a/themes/digital.gov/layouts/home.html
+++ b/themes/digital.gov/layouts/home.html
@@ -30,7 +30,7 @@
                   <p class="more">
                     <a href="/resources"><span>See all guides and resources</span>
                       <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                        <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#arrow_forward"></use>
+                        <use xlink:href="{{ "uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
                       </svg>
                     </a>
                   </p>

--- a/themes/digital.gov/layouts/news/single.html
+++ b/themes/digital.gov/layouts/news/single.html
@@ -10,7 +10,7 @@
             <p class="breadcrumb">
               <a href="{{- "news" | absURL -}}">
                 <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                  <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#arrow_back"></use>
+                  <use xlink:href="{{ "uswds/img/sprite.svg#arrow_back" | relURL }}"></use>
                 </svg>
                 <span>Latest News</span>
               </a>

--- a/themes/digital.gov/layouts/partials/core/community-join-with-form.html
+++ b/themes/digital.gov/layouts/partials/core/community-join-with-form.html
@@ -2,7 +2,7 @@
 
 <a href="{{ .e.subscribe_form }}" class="join type-{{- .e.platform -}}" title="Join the {{ .Title | markdownify }} Community">
   <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-    <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#mail"></use>
+    <use xlink:href="{{ "uswds/img/sprite.svg#mail" | relURL }}"></use>
   </svg>
   Join via our form
 </a>

--- a/themes/digital.gov/layouts/partials/core/community-join-without-form.html
+++ b/themes/digital.gov/layouts/partials/core/community-join-without-form.html
@@ -12,7 +12,7 @@
   {{- end -}}
 {{- end -}}" class="join type-{{- .e.platform -}}">
   <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-    <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#mail"></use>
+    <use xlink:href="{{ "uswds/img/sprite.svg#mail" | relURL }}"></use>
   </svg>
   Join by email
 </a>

--- a/themes/digital.gov/layouts/partials/core/footer.html
+++ b/themes/digital.gov/layouts/partials/core/footer.html
@@ -5,7 +5,7 @@
         <a href="#">
           <span>Return to top</span>
           <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-            <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#arrow_upward"></use>
+            <use xlink:href="{{ "uswds/img/sprite.svg#arrow_upward" | relURL }}"></use>
           </svg>
         </a>
       </div>
@@ -55,31 +55,31 @@
               <ul class="usa-list usa-list--unstyled social-links">
                 <li class="usa-footer__secondary-link">
                   <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                    <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#twitter"></use>
+                    <use xlink:href="{{ "uswds/img/sprite.svg#twitter" | relURL }}"></use>
                   </svg>
                   <a class="text-ink hover:text-ink text-no-underline hover:text-underline" href="https://twitter.com/digital_gov">Twitter</a>
                 </li>
                 <li class="usa-footer__secondary-link">
                   <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                    <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#facebook"></use>
+                    <use xlink:href="{{ "uswds/img/sprite.svg#facebook" | relURL }}"></use>
                   </svg>
                   <a class="text-ink hover:text-ink text-no-underline hover:text-underline" href="https://www.facebook.com/digitalgov/">Facebook</a>
                 </li>
                 <li class="usa-footer__secondary-link">
                   <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                    <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#youtube"></use>
+                    <use xlink:href="{{ "uswds/img/sprite.svg#youtube" | relURL }}"></use>
                   </svg>
                   <a class="text-ink hover:text-ink text-no-underline hover:text-underline" href="https://youtube.com/digitalgov">YouTube</a>
                 </li>
                 <li class="usa-footer__secondary-link">
                   <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                    <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#rss_feed"></use>
+                    <use xlink:href="{{ "uswds/img/sprite.svg#rss_feed" | relURL }}"></use>
                   </svg>
                   <a class="text-ink hover:text-ink text-no-underline hover:text-underline" href="{{- "/" | relURL -}}index.xml">RSS</a>
                 </li>
                 <li class="usa-footer__secondary-link">
                   <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                    <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#mail_outline"></use>
+                    <use xlink:href="{{ "uswds/img/sprite.svg#mail_outline" | relURL }}"></use>
                   </svg>
                   <a class="text-ink hover:text-ink text-no-underline hover:text-underline" href="mailto:digitalgov@gsa.gov">Email us</a>
                 </li>

--- a/themes/digital.gov/layouts/partials/core/get_related.html
+++ b/themes/digital.gov/layouts/partials/core/get_related.html
@@ -39,7 +39,7 @@
     <p class="more">
       <a href="{{ "/communities/" | absURL }}"><span>See all {{ len (where $.Site.RegularPages "Section" "communities") }} communities</span>
         <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-          <use xlink:href="{{- $.Site.BaseURL -}}uswds/img/sprite.svg#arrow_forward"></use>
+          <use xlink:href="{{ "uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
         </svg>
       </a>
     </p>
@@ -105,7 +105,7 @@
     <p class="more">
       <a href="{{ "/services/" | absURL }}"><span>See all {{ len (where $.Site.RegularPages "Section" "services") }} services</span>
         <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-          <use xlink:href="{{- $.Site.BaseURL -}}uswds/img/sprite.svg#arrow_forward"></use>
+          <use xlink:href="{{ "uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
         </svg>
       </a>
     </p>

--- a/themes/digital.gov/layouts/partials/core/get_sharetools.html
+++ b/themes/digital.gov/layouts/partials/core/get_sharetools.html
@@ -8,21 +8,21 @@
     <div class="grid-col-4">
       <a class="twitter" aria-label="Share on Twitter" href="http://twitter.com/share?url=https://digital.gov{{ (urls.Parse .Permalink)}}{{$path}}&amp;text={{ .Title }}">
         <svg class="usa-icon dg-icon dg-icon--large margin-bottom-05" aria-hidden="true" focusable="false">
-          <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#twitter"></use>
+          <use xlink:href="{{ "uswds/img/sprite.svg#twitter" | relURL }}"></use>
         </svg>
       </a>
     </div>
     <div class="grid-col-4">
       <a class="facebook" aria-label="Share on Facebook" href="http://www.facebook.com/sharer.php?u=https://digital.gov{{ (urls.Parse .Permalink)}}{{$path}}&t={{ .Title | urlize }}">
         <svg class="usa-icon dg-icon dg-icon--large margin-bottom-05" aria-hidden="true" focusable="false">
-          <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#facebook"></use>
+          <use xlink:href="{{ "uswds/img/sprite.svg#facebook" | relURL }}"></use>
         </svg>
       </a>
     </div>
     <div class="grid-col-4">
       <a class="linkedin" aria-label="Share on LinkedIn" href="https://www.linkedin.com/shareArticle?mini=true&url=https://digital.gov{{ (urls.Parse .Permalink)}}{{$path}}&title={{ .Title | urlize }}&summary={{ .Params.summary | urlize }}&source={{ "Digital.gov" | urlize }}">
         <svg class="usa-icon dg-icon dg-icon--large margin-bottom-05" aria-hidden="true" focusable="false">
-          <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#linkedin"></use>
+          <use xlink:href="{{ "uswds/img/sprite.svg#linkedin" | relURL }}"></use>
         </svg>
       </a>
     </div>
@@ -31,14 +31,14 @@
     <div class="grid-col-6">
       <a target="_blank" title="Email this page" class="email" href="mailto:?subject={{ .Title }}%20%7C%20Digital.gov&body=%20%20%0A-------%0A{{ .Title }}%0Ahttps://digital.gov{{ (urls.Parse .Permalink)}}{{$path}}%3Fem%0A-------%0A%0A&#9829; Sign-up%20for%20the%20Digital.gov%20newsletter%3A%20https%3A%2F%2Fdigital.gov%2Fsubscribe%2F" data-proofer-ignore>
         <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-          <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#mail"></use>
+          <use xlink:href="{{ "uswds/img/sprite.svg#mail" | relURL }}"></use>
         </svg>
         Email</a>
     </div>
     <div class="grid-col-6">
       <a class="print" href="javascript:window.print()" onclick="window.print();return false;">
         <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-          <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#print"></use>
+          <use xlink:href="{{ "uswds/img/sprite.svg#print" | relURL }}"></use>
         </svg>
         Print
       </a>

--- a/themes/digital.gov/layouts/partials/core/header.html
+++ b/themes/digital.gov/layouts/partials/core/header.html
@@ -13,7 +13,7 @@
 
     <button class="usa-menu-btn">
       <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-2px" aria-hidden="true" focusable="false" role="img">
-        <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#menu"></use>
+        <use xlink:href="{{ "uswds/img/sprite.svg#menu" | relURL }}"></use>
       </svg> Menu
     </button>
   </div>

--- a/themes/digital.gov/layouts/partials/core/home/events_featured.html
+++ b/themes/digital.gov/layouts/partials/core/home/events_featured.html
@@ -57,7 +57,7 @@
             <a class="btn" href="{{ "news" | absURL }}" title="">
               <span>See all News</span>
               <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false" role="img">
-                <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#arrow_forward"></use>
+                <use xlink:href="{{ "uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
               </svg>
               </a>
             <p>Have a case study to share? Did your team recently launch something?<br/><a href="mailto:digitalgov@gsa.gov" title=""><strong>Send us an email</strong></a></p>

--- a/themes/digital.gov/layouts/partials/core/home/news_featured.html
+++ b/themes/digital.gov/layouts/partials/core/home/news_featured.html
@@ -102,7 +102,7 @@
             <a class="btn" href="{{- "news" | absURL -}}" title="">
               <span>See all News</span>
               <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false" role="img">
-                <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#arrow_forward"></use>
+                <use xlink:href="{{ "uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
               </svg>
             </a>
             <p>Have a case study to share? Did your team recently launch something?<br/><a href="{{- "contribute" | absURL -}}" title="Learn how you can contribute"><strong>Learn how you can contribute</strong></a></p>

--- a/themes/digital.gov/layouts/partials/core/home/topics_featured.html
+++ b/themes/digital.gov/layouts/partials/core/home/topics_featured.html
@@ -32,7 +32,7 @@
           <p class="more">
             <a href="/topics"><span>See all topics</span>
               <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false" role="img">
-                <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#arrow_forward"></use>
+                <use xlink:href="{{ "uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
               </svg>
             </a>
           </p>

--- a/themes/digital.gov/layouts/resources/list.html
+++ b/themes/digital.gov/layouts/resources/list.html
@@ -105,7 +105,7 @@
                           <a href="{{- .Permalink -}}">
                             <span>More on {{ .Title -}}</span>
                             <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                              <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#arrow_forward"></use>
+                              <use xlink:href="{{ "uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
                             </svg>
                           </a>
                         </p>
@@ -146,7 +146,7 @@
               <a href="{{- "/topics" | absURL -}}">
                 <span>See all topics</span>
                 <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                  <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#arrow_forward"></use>
+                  <use xlink:href="{{ "uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
                 </svg>
               </a>
             </p>
@@ -188,7 +188,7 @@
                 <a href="/topics">
                   <span>See all topics</span>
                   <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                    <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#arrow_forward"></use>
+                    <use xlink:href="{{ "uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
                   </svg>
                 </a>
               </p>

--- a/themes/digital.gov/layouts/resources/single.html
+++ b/themes/digital.gov/layouts/resources/single.html
@@ -10,7 +10,7 @@
             <p class="breadcrumb">
               <a href="{{- "resources/" | absURL -}}">
                 <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                  <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#arrow_back"></use>
+                  <use xlink:href="{{ "uswds/img/sprite.svg#arrow_back" | relURL }}"></use>
                 </svg>
                 <span>All Resources</span>
               </a>

--- a/themes/digital.gov/layouts/services/card-service-contact.html
+++ b/themes/digital.gov/layouts/services/card-service-contact.html
@@ -89,7 +89,7 @@
             <a class="contact" href="mailto:{{- .Params.contact -}}" title="Contact">
               <span>
                 <svg class="usa-icon dg-icon dg-icon--small margin-bottom-05" aria-hidden="true" focusable="false">
-                  <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#mail"></use>
+                  <use xlink:href="{{ "uswds/img/sprite.svg#mail" | relURL }}"></use>
                 </svg>
                 Contact</span>
             </a>

--- a/themes/digital.gov/layouts/services/list.html
+++ b/themes/digital.gov/layouts/services/list.html
@@ -50,7 +50,7 @@
             <a class="btn" href="{{- "services/directory" | absURL -}}" title="">
               <span>See the full directory</span>
               <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#arrow_forward"></use>
+                <use xlink:href="{{ "uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
               </svg>
             </a>
           </footer>

--- a/themes/digital.gov/layouts/services/single.html
+++ b/themes/digital.gov/layouts/services/single.html
@@ -10,7 +10,7 @@
             <p class="breadcrumb">
               <a href="{{- "services/" | absURL -}}">
                 <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                  <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#arrow_back"></use>
+                  <use xlink:href="{{ "uswds/img/sprite.svg#arrow_back" | relURL }}"></use>
                 </svg>
                 <span>All Services</span>
               </a>

--- a/themes/digital.gov/layouts/shortcodes/accordion.html
+++ b/themes/digital.gov/layouts/shortcodes/accordion.html
@@ -10,13 +10,13 @@
         {{ if (.Get "icon") -}}
           <span class="icon">
             <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-              <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#{{- .Get "icon" -}}"></use>
+              <use xlink:href="{{ "uswds/img/sprite.svg#{{- .Get 'icon' -}}" | relURL }}"></use>
             </svg>
           </span>
         {{- else -}}
           <span class="icon">
             <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false" role="img">
-              <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#unfold_more"></use>
+              <use xlink:href="{{ "uswds/img/sprite.svg#unfold_more" | relURL }}"></use>
             </svg>
           </span>
         {{- end -}}

--- a/themes/digital.gov/layouts/shortcodes/asset-img.html
+++ b/themes/digital.gov/layouts/shortcodes/asset-img.html
@@ -10,7 +10,7 @@
     <strong class="ext">{{- path.Ext $path }}</strong> {{- path.Base $path }}
     <a class="download" href="{{- $path | relURL -}}">
       <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-        <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#file_download"></use>
+        <use xlink:href="{{ "uswds/img/sprite.svg#file_download" | relURL }}"></use>
       </svg>
       <span>download</span>
     </a>

--- a/themes/digital.gov/layouts/shortcodes/card-policy.html
+++ b/themes/digital.gov/layouts/shortcodes/card-policy.html
@@ -9,7 +9,7 @@
       aria-controls="card-policy-{{- .Page.Scratch.Get "count" -}}">
       <span class="scroll">
         <svg class="usa-icon dg-icon dg-icon--large margin-bottom-05" aria-hidden="true" focusable="false">
-          <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#unfold_more"></use>
+          <use xlink:href="{{ "uswds/img/sprite.svg#unfold_more" | relURL }}"></use>
         </svg>
       </span>
       <span class="src">
@@ -26,7 +26,7 @@
     <a class="src" href="{{- .Get "src" }}" title="View {{ .Get "name" | plainify -}}">
       View the full legislation 
       <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-        <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#arrow_forward"></use>
+        <use xlink:href="{{ "uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
       </svg>
     </a>
   </div>

--- a/themes/digital.gov/layouts/shortcodes/card-prompt.html
+++ b/themes/digital.gov/layouts/shortcodes/card-prompt.html
@@ -47,7 +47,7 @@ If not, it will not render the shortcode.
     <div class="intro">
       <div class="icon">
         <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-          <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#comment"></use>
+          <use xlink:href="{{ "uswds/img/sprite.svg#comment" | relURL }}"></use>
         </svg>
       </div>
       {{/* output the intro with markdownify */}}

--- a/themes/digital.gov/layouts/shortcodes/list-resources.html
+++ b/themes/digital.gov/layouts/shortcodes/list-resources.html
@@ -32,7 +32,7 @@
             <a href="{{- $topic.Permalink -}}">
               <span>More on {{ $topic.Title -}}</span>
               <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#arrow_forward"></use>
+                <use xlink:href="{{ "uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
               </svg>
             </a>
           </p>

--- a/themes/digital.gov/layouts/shortcodes/note.html
+++ b/themes/digital.gov/layouts/shortcodes/note.html
@@ -35,31 +35,31 @@ additional text goes here...
   {{- if and (.Get 0) (eq (.Get 0) "activity") -}}
     <h4>
       <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-        <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#assessment"></use>
+        <use xlink:href="{{ "uswds/img/sprite.svg#assessment" | relURL }}"></use>
       </svg> Activity
     </h4>
   {{- else if and (.Get 0) (eq (.Get 0) "action") -}}
     <h4>
       <svg class="usa-icon dg-icon dg-icon--large margin-bottom-05" aria-hidden="true" focusable="false">
-        <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#campaign"></use>
+        <use xlink:href="{{ "uswds/img/sprite.svg#campaign" | relURL }}"></use>
       </svg> Action
     </h4>
   {{- else if and (.Get 0) (eq (.Get 0) "alert") -}}
     <h4>
       <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-        <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#report"></use>
+        <use xlink:href="{{ "uswds/img/sprite.svg#report" | relURL }}"></use>
       </svg> Alert
     </h4>
   {{- else if and (.Get 0) (eq (.Get 0) "comment") -}}
     <h4>
       <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-        <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#comment"></use>
+        <use xlink:href="{{ "uswds/img/sprite.svg#comment" | relURL }}"></use>
       </svg> Comment
     </h4>
   {{- else -}}
     <h4>
       <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-        <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#notifications"></use>
+        <use xlink:href="{{ "uswds/img/sprite.svg#notifications" | relURL }}"></use>
       </svg> Note
     </h4>
   {{- end -}}

--- a/themes/digital.gov/layouts/shortcodes/theme-img.html
+++ b/themes/digital.gov/layouts/shortcodes/theme-img.html
@@ -10,7 +10,7 @@
     <strong class="ext">{{- path.Ext $path }}</strong> {{- path.Base $path }} 
     <a class="download" href="{{- path.Base $path | relURL -}}">
       <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-        <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#file_download"></use>
+        <use xlink:href="{{ "uswds/img/sprite.svg#file_unload" | relURL }}"></use>
       </svg>
       <span>download</span>
     </a>

--- a/themes/digital.gov/layouts/topics/list.html
+++ b/themes/digital.gov/layouts/topics/list.html
@@ -11,7 +11,7 @@
         <header class="page-header">
           <p class="breadcrumb"><a href="{{- "resources/" | absURL -}}">
             <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-              <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#arrow_back"></use>
+              <use xlink:href="{{ "uswds/img/sprite.svg#arrow_back" | relURL }}"></use>
             </svg>
             <span>All Resources</span>
           </a></p>


### PR DESCRIPTION
Update svg paths to use `relURL`. This is the preferred hugo syntax and will fix icon display issues in Federalist and production.

**Old Markup**

```
  <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
    <use xlink:href="{{- .Site.BaseURL -}}uswds/img/sprite.svg#arrow_back"></use>
  </svg>
```

**New Markup**

```
  <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
    <use xlink:href="{{ "uswds/img/sprite.svg#mail" | relURL }}"></use>
  </svg>
```