### PR TITLE
Fix extra padding on headers

### DIFF
--- a/content/_archived/common-questions-about-dap-faq.md
+++ b/content/_archived/common-questions-about-dap-faq.md
@@ -21,7 +21,7 @@ Below are the questions we hear most often about the [Digital Analytics Program 
 * [Reporting](#part-5) "Common Questions about DAP (FAQ): Reporting"
 * [Customer Satisfaction Tool Implementation](#part-6) "Common Questions about DAP (FAQ): Customer Satisfaction Tool Implementation"
 
-<h2 id="part-7" style="padding-top: 50px">
+<h2 id="part-7">
   User Agreement
 </h2>
 
@@ -36,7 +36,7 @@ By logging in and accessing data within the tools of the Digital Analytics Progr
 * For questions regarding these and other scenarios on the use of the DAP data, agencies should contact the Office of Management and Budget by emailing <eGov@omb.eop.gov>.
 * The Google Analytics code is designed to collect data in a consistent way across all .gov websites. Any modifications to the code without DAP authorization is prohibited. DAP requires oversight of the code in order to ensure the data is reported accurately for agency sites. Agencies can continue to run their own metrics tools in addition to DAP.
 
-<h2 id="part-1" style="padding-top: 50px">
+<h2 id="part-1">
   Implementation
 </h2>
 
@@ -99,7 +99,7 @@ DAP staff is responsible for creating all agency profiles, as well as maintainin
 
 To zoom into the specific website’s traffic, each DAP user can create up to 100 advanced custom segments and/or custom reports. Each user also can create up to 25 dashboards for high-level, executive-type reporting. All of the user-based reports, segments, and dashboards can be shared with other GA DAP users, if requested. Additionally, a user can create various alerts to monitor their website performance and traffic, as well as campaigns and campaign-related reports. Watch the <a href="https://www.youtube.com/watch?v=CKMTK77PrJE&list=PLd9b-GuOJ3nFwlyvLFUtmDpYFKezhot8P&index=4" target="_blank">DAP 101 recorded training</a> (Youtube), to learn more about profiles, segments and dashboards.
 
-<h2 id="part-2" style="padding-top: 50px">
+<h2 id="part-2">
   <a name="customization-access"></a>Customization and Access
 </h2>
 
@@ -119,7 +119,7 @@ A Google account is required, but a Gmail email address is not—any email addre
 
 No. The gov-wide Google Analytics code is designed to collect data in a consistent way across all .gov websites. Any modifications to the code without DAP authorization is prohibited. DAP requires oversight of the code in order to ensure the data is reported accurately for agency sites. Agencies can continue to run their own metrics in addition to DAP.
 
-<h2 id="part-3" style="padding-top: 50px">
+<h2 id="part-3">
   Google Universal Analytics
 </h2>
 
@@ -135,7 +135,7 @@ Compared to the classic GA (ga.js), UA gives GA users more control over tracking
 
 If your agency is still using a ga.js DAP code, an upgrade to Universal Analytics is essential for data integrity. More information on implementing the most recent code can be found on our [Implementation Instructions]({{< link "analytics-tool-instructions.md" >}}) page and our <a href="https://github.com/digital-analytics-program/gov-wide-code" target="_blank">Github repo</a>.
 
-<h2 id="part-4" style="padding-top: 50px">
+<h2 id="part-4">
   <a name="data-access-retention-privacy"></a>Data Access, Retention and Privacy
 </h2>
 
@@ -191,7 +191,7 @@ We recommend adding the following language:
 
 See [this notice]({{< link "policies.md" >}}) on our Site Policies page.
 
-<h2 id="part-5" style="padding-top: 50px">
+<h2 id="part-5">
   <a name="reporting"></a>Reporting
 </h2>
 
@@ -231,7 +231,7 @@ Most common Bounce Rate scenarios:
 
 Bounce rate is the % of visits that only had one page view. A click is tied to a specific action, like a new page, search box, an offsite/outbound/external link, a sign-up form etc., so, it is considered to be interaction/engagement with that page, and hence, would not be considered a bounce.
 
-<h2 id="part-6" style="padding-top: 50px">
+<h2 id="part-6">
   <a name="customer-satisfaction-tool-implementation"></a>Customer Satisfaction Tool Implementation
 </h2>
 

--- a/content/_archived/dap-digital-metrics-guidance-and-best-practices.md
+++ b/content/_archived/dap-digital-metrics-guidance-and-best-practices.md
@@ -15,7 +15,7 @@ Digital metrics are critical for measuring, analyzing, and reporting on the effe
 * [Part 3: Rationale and Framework for Common Metrics and Measures](#part-3 "DAP: Digital Metrics Guidance and Best Practices, Part 3")
 * [Part 4: Case Studies, Training, and Additional Resources](#part-4 "DAP: Digital Metrics Guidance and Best Practices, Part 4")
 
-<h2 id="part-1" style="padding-top: 50px">
+<h2 id="part-1">
   Part 1: Common Metrics—Guidance, Best Practices, and Tools
 </h2>
 
@@ -722,7 +722,7 @@ Analysis of this social data is critical not just for agency communication offic
 
 Here are a set of [recommended, baseline social media metrics]({{< link "2013-04-19-social-media-metrics-for-federal-agencies.md" >}}), developed and maintained by an interagency working group of the [Federal Social Media Community of Practice]({{< link "social-media.md" >}}). The purpose is to establish a common, yet customizable approach to analyzing social data using the most cost-effective methods available. It provides a framework for agencies to measure the value and impact of social media in addressing agency mission and program goals. The aim is to move beyond obscure results of social media activities towards more sophisticated and more accurate assessments, leading to better informed decision-making.
 
-<h2 id="part-2" style="padding-top: 50px">
+<h2 id="part-2">
   Part 2: Reporting Requirements and Common Tools
 </h2>
 
@@ -785,7 +785,7 @@ You can use one of the free customer satisfaction survey tools that has a [feder
 
 If you’re collecting feedback from more than nine people (via an online survey, focus group, form, or another method), you must get prior OMB approval, per the [Paperwork Reduction Act](http://www.gpo.gov/fdsys/pkg/PLAW-104publ13/html/PLAW-104publ13.htm) (PRA). The [Fast Track PRA]({{< link "paperwork-reduction-act-fast-track-process.md" >}}) process can significantly speed up the approval process. Some tools, such as ACSI, have current PRA clearance, and your agency may have existing approval for other tools.
 
-<h2 id="part-3" style="padding-top: 50px">
+<h2 id="part-3">
   Part 3: Rationale and Framework for Common Metrics
 </h2>
 
@@ -838,7 +838,7 @@ To support this common framework, agencies should collect performance and custom
 * **Performance**—It is now an industry standard to use page tagging to collect real-time performance metrics, so this framework calls for the use of a common tool to collect agency performance metrics.
 * **Customer Satisfaction**—Until an industry standard becomes apparent for collecting customer satisfaction metrics, we’re asking agencies to collect a set of four common reporting metrics, based on extensive industry research and and a review of existing agency systems.  These are considered in &#8220;beta&#8221; mode while we test their usefulness during implementation.
 
-<h2 id="part-4" style="padding-top: 50px">
+<h2 id="part-4">
   Part 4: Case Studies, Resources, and Training
 </h2>
 

--- a/content/news/2013/11/2013-11-06-software-and-apps-challenges.md
+++ b/content/news/2013/11/2013-11-06-software-and-apps-challenges.md
@@ -18,7 +18,7 @@ Here you’ll find tips on running a software/apps challenge, resources, example
 
 A software/apps challenge is when an organization asks the public to create software that may use a particular data set or have a set of functionalities outlined by the seeker, in order to solve an existing problem or draw attention to open and available datasets.
 
-<h2 id="tips-for-running-a-software-apps-challenge" style="padding-top: 50px;">
+<h2 id="tips-for-running-a-software-apps-challenge">
   Tips for Running a Software/Apps Challenge
 </h2>
 
@@ -32,7 +32,7 @@ A software/apps challenge is when an organization asks the public to create soft
   * Determine from the beginning and state in the challenge rules details about technology ownership, parameters for submissions, who qualifies to enter, how the entries will be judged and how the prizes will be awarded.
   * Please see the multiple resources listed below. There are so many ways to run apps challenges, that experts have created pages of plans and details that will further your understanding and goals. Choose what is best for your agency needs and goals.
 
-<h2 id="resources" style="padding-top: 50px;">
+<h2 id="resources">
   Resources
 </h2>
 
@@ -48,7 +48,7 @@ A software/apps challenge is when an organization asks the public to create soft
 
 [ChallengePost: App Contest Best Practices](http://post.challengepost.com/app_contest_resources)
 
-<h2 id="examples" style="padding-top: 50px;">
+<h2 id="examples">
   Examples
 </h2>
 
@@ -76,7 +76,7 @@ The FCC challenged the developers to use hyper-local government and public data 
 
 Challenge.gov contains [more examples](https://challenge.gov/) of software/apps challenges.
 
-<h2 id="criteria-for-choosing-a-platform" style="padding-top: 50px;">
+<h2 id="criteria-for-choosing-a-platform">
   Criteria for Choosing a Platform
 </h2>
 
@@ -112,7 +112,7 @@ Federal agencies can:
   * Have a public voting component
   * Offer a prize at the end for best app and publicize
 
-<h2 id="online-platforms-and-tools" style="padding-top: 50px;">
+<h2 id="online-platforms-and-tools">
   Online Platforms and Tools
 </h2>
 

--- a/content/news/2014/09/2014-09-11-prepareathon-2014-disaster-preparedness-in-the-palm-of-your-hand.md
+++ b/content/news/2014/09/2014-09-11-prepareathon-2014-disaster-preparedness-in-the-palm-of-your-hand.md
@@ -29,7 +29,7 @@ What better way to show your patriotism this Patriot Day than to commit to be pr
   4. &#8220;Put help in your hand&#8221; by downloading [apps from the American Red Cross](http://www.redcross.org/prepare/mobile-apps) for instant access to a range of topics including [first aid tips for you](http://www.redcross.org/mobile-apps/first-aid-app) and [your furry friends,](http://www.redcross.org/mobile-apps/pet-first-aid-app) a handy locator for [emergency shelters](http://www.redcross.org/mobile-apps/shelter-finder-app) and [a shiny new app for blood donations](http://www.redcross.org/mobile-apps/blood-app).
   5. [School yourself in preparedness tips and lists](http://www.ready.gov/prepare) and then spread the word to your social network! To keep up with breaking weather-related updates, bookmark [mobile.weather.gov](http://mobile.weather.gov) and [hurricanes.gov/mobile](http://www.hurricanes.gov/mobile) on your smartphone and tablets and make use of that Twitter app!
 
-<p style="padding-left: 60px;">
+<p>
   Follow accounts like:
 </p>
 
@@ -41,6 +41,6 @@ What better way to show your patriotism this Patriot Day than to commit to be pr
   * [@NHC_Pacific](https://twitter.com/NHC_pacific)
   * [@RedCross](https://twitter.com/RedCross)
 
-<p style="padding-left: 60px;">
+<p>
   And don&#8217;t forget to follow <a href="https://twitter.com/NWS/lists/noaa-nws-offices/members">your local NOAA National Weather Service Forecast Office</a>, community emergency management authorities and local media outlets on on your mobile device, too.
 </p>_So:_ _Be smart. Take part. Prepare today. And don&#8217;t forget: You can download more helpful government mobile apps from the [USA.gov Apps Gallery](http://www.usa.gov/mobileapps.shtml)._

--- a/content/news/2015/06/2015-06-05-using-section-508-guidance-to-improve-the-accessibility-of-government-services.md
+++ b/content/news/2015/06/2015-06-05-using-section-508-guidance-to-improve-the-accessibility-of-government-services.md
@@ -119,7 +119,7 @@ This resource list presents a compilation of links to accessibility guidance, or
   </tr>
 </table>
 
-<h2 id="Resources" style="padding-top: 50px">
+<h2 id="Resources">
   Accessibility Glossaries, FAQs and Resource Portals
 </h2>
 
@@ -132,7 +132,7 @@ This resource list presents a compilation of links to accessibility guidance, or
   <a title="Back to top" href="#toc">Top ↑</a>
 </p>
 
-<h2 id="Computers" style="padding-top: 50px">
+<h2 id="Computers">
   Desktop and Portable Computers
 </h2>
 
@@ -142,7 +142,7 @@ This resource list presents a compilation of links to accessibility guidance, or
   <a title="Back to top" href="#toc">Top ↑</a>
 </p>
 
-<h2 id="Criteria" style="padding-top: 50px">
+<h2 id="Criteria">
   Functional Performance Criteria
 </h2>
 
@@ -152,7 +152,7 @@ This resource list presents a compilation of links to accessibility guidance, or
   <a title="Back to top" href="#toc">Top ↑</a>
 </p>
 
-<h2 id="Support" style="padding-top: 50px">
+<h2 id="Support">
   Information, Documentation, and Support
 </h2>
 
@@ -209,7 +209,7 @@ This resource list presents a compilation of links to accessibility guidance, or
   <a title="Back to top" href="#toc">Top ↑</a>
 </p>
 
-<h2 id="Etiquette" style="padding-top: 50px">
+<h2 id="Etiquette">
   Meetings, Conferences, and General Etiquette
 </h2>
 
@@ -222,7 +222,7 @@ This resource list presents a compilation of links to accessibility guidance, or
   <a title="Back to top" href="#toc">Top ↑</a>
 </p>
 
-<h2 id="Procurement" style="padding-top: 50px">
+<h2 id="Procurement">
   Procurement
 </h2>
 
@@ -235,7 +235,7 @@ This resource list presents a compilation of links to accessibility guidance, or
   <a title="Back to top" href="#toc">Top ↑</a>
 </p>
 
-<h2 id="Prototyping" style="padding-top: 50px">
+<h2 id="Prototyping">
   Prototyping
 </h2>
 
@@ -245,7 +245,7 @@ This resource list presents a compilation of links to accessibility guidance, or
   <a title="Back to top" href="#toc">Top ↑</a>
 </p>
 
-<h2 id="ClosedProducts" style="padding-top: 50px">
+<h2 id="ClosedProducts">
   Self-Contained, Closed Products
 </h2>
 
@@ -255,7 +255,7 @@ This resource list presents a compilation of links to accessibility guidance, or
   <a title="Back to top" href="#toc">Top ↑</a>
 </p>
 
-<h2 id="SocialMedia" style="padding-top: 50px">
+<h2 id="SocialMedia">
   Social Media
 </h2>
 
@@ -267,7 +267,7 @@ This resource list presents a compilation of links to accessibility guidance, or
   <a title="Back to top" href="#toc">Top ↑</a>
 </p>
 
-<h2 id="AppsOS" style="padding-top: 50px">
+<h2 id="AppsOS">
   <b>Software Applications and Operating Systems</b>
 </h2>
 
@@ -281,7 +281,7 @@ This resource list presents a compilation of links to accessibility guidance, or
   <a title="Back to top" href="#toc">Top ↑</a>
 </p>
 
-<h2 id="Planning" style="padding-top: 50px">
+<h2 id="Planning">
   Strategic Planning, Reporting, and Policy
 </h2>
 
@@ -295,7 +295,7 @@ This resource list presents a compilation of links to accessibility guidance, or
   <a title="Back to top" href="#toc">Top ↑</a>
 </p>
 
-<h2 id="Telecommunications" style="padding-top: 50px">
+<h2 id="Telecommunications">
   Telecommunications Products
 </h2>
 
@@ -305,7 +305,7 @@ This resource list presents a compilation of links to accessibility guidance, or
   <a title="Back to top" href="#toc">Top ↑</a>
 </p>
 
-<h2 id="Multimedia" style="padding-top: 50px">
+<h2 id="Multimedia">
   Video and Multimedia Products
 </h2>
 
@@ -322,7 +322,7 @@ This resource list presents a compilation of links to accessibility guidance, or
   <a title="Back to top" href="#toc">Top ↑</a>
 </p>
 
-<h2 id="Web" style="padding-top: 50px">
+<h2 id="Web">
   Web-based Internet Information and Applications
 </h2>
 
@@ -339,7 +339,7 @@ This resource list presents a compilation of links to accessibility guidance, or
 
 <hr style="color: white;border-style: none" />
 
-<em id="abbreviations" style="padding-top: 50px">Agency abbreviations are defined as follows:</em>
+<em id="abbreviations">Agency abbreviations are defined as follows:</em>
 
   * CDC = Centers for Disease Control and Prevention
   * CMS = Centers for Medicare and Medicaid Services

--- a/content/news/2015/12/2015-12-29-18f-reflects-on-their-most-meaningful-projects-in-2015.md
+++ b/content/news/2015/12/2015-12-29-18f-reflects-on-their-most-meaningful-projects-in-2015.md
@@ -50,7 +50,7 @@ To mark the end of the year, we reached out to everyone at 18F and asked them to
   * [Process and Documentation](#Process-Documentation "Process and Documentation")
   * [Growing our Team](#Growing-Our-Team "Growing our Team")
 
-<h2 id="Accessibility" style="padding-top: 50px">
+<h2 id="Accessibility">
   Accessibility
 </h2>
 
@@ -62,7 +62,7 @@ _[The White House Office of Science and Technology Policy](https://www.whitehous
 
 {{< legacy-img src="2015/12/600-x-205-allytweet2.jpg" alt="A tweet by Rebecca Williams using the a-1-1-y hack hashtag" >}}
 
-<h2 id="Blog" style="padding-top: 50px">
+<h2 id="Blog">
   Blog
 </h2>_We published over 130 posts this year on our [blog](https://18f.gsa.gov/blog) and featured 70 team members and 10 guests as authors._
 
@@ -70,7 +70,7 @@ _[The White House Office of Science and Technology Policy](https://www.whitehous
 >
 > “I’m very proud of all the work that went into the blog this year including the wide range of posts we’ve published, the improved editing process, and all the new authors and voices we were able to represent.”—**Andre Francisco**
 
-<h2 id="HTTPS" style="padding-top: 50px">
+<h2 id="HTTPS">
   HTTPS
 </h2>_18F worked with government teams to help submit a number of government domains to be hardcoded as HTTPS-only. Eric Mill wrote blog posts [explaining that effort](https://18f.gsa.gov/2015/02/09/the-first-gov-domains-hardcoded-into-your-browser-as-all-https/) and the [importance of HTTPS](https://18f.gsa.gov/2014/11/13/why-we-use-https-in-every-gov-website-we-make/). Unsurprisingly, he chose the HTTPS work as the most enjoyable project he worked on this year._
 
@@ -78,7 +78,7 @@ _[The White House Office of Science and Technology Policy](https://www.whitehous
 
 {{< legacy-img src="2015/12/600-x-123-hsts-preload-list.jpg" alt="Code" >}}
 
-<h2 id="Diversity-Working-Group" style="padding-top: 50px">
+<h2 id="Diversity-Working-Group">
   Diversity Working Group
 </h2>_18F is home to many [working groups](https://pages.18f.gov/grouplet-playbook/working-groups/) that spin up to collectively address an issue or solve a problem. Several of our colleagues cited their work with the Diversity Working Group as their most meaningful project this year. The Diversity Working Group helps make 18F a great place to work for people of all backgrounds, and is working to address inequalities that exist in the tech sector._
 
@@ -88,7 +88,7 @@ _[The White House Office of Science and Technology Policy](https://www.whitehous
 >
 > “I’ve really enjoyed being part of the Diversity Working Group this year. I’ve mainly learned a lot more detail about how big the problem is of diversity in tech. I’m very hopeful that we will do all that we can here to address it.”—**Jacob Harris**
 
-<h2 id="Products-Shipped" style="padding-top: 50px">
+<h2 id="Products-Shipped">
   Products We Shipped
 </h2>
 
@@ -190,7 +190,7 @@ _[The White House Office of Science and Technology Policy](https://www.whitehous
 
 {{< legacy-img src="2015/12/600-x-450-screen-shot-of-the-my-dot-U-S-C-I-S-dot-gov-mobile-website-on-an-Android-smart-phone.jpg" alt="A screenshot of the my dot U S C I S dot gov mobile website on an Android smartphone." >}}
 
-<h2 id="Guides-Resources-Tools" style="padding-top: 50px">
+<h2 id="Guides-Resources-Tools">
   Guides, Resources, and Tools
 </h2>
 
@@ -230,7 +230,7 @@ _[The White House Office of Science and Technology Policy](https://www.whitehous
 
 {{< legacy-img src="2015/12/600-x-281-sba-execs-legos-2.jpg" alt="Small Business Administration executives collaborate with using LEGOs during a meeting." >}}
 
-<h2 id="Process-Documentation" style="padding-top: 50px">
+<h2 id="Process-Documentation">
   Process and Documentation
 </h2>_It’s not something that often gets public attention, but we worked really hard to improve 18F’s internal processes and documentation this year. Ensuring that our daily standups run smoothly and our documentation is complete will ensure that we have the capacity to continue to learn and grow._
 
@@ -248,7 +248,7 @@ _[The White House Office of Science and Technology Policy](https://www.whitehous
 
 {{< legacy-img src="2015/12/600-x-182-API-Team-onboarding-bot-Dolores.jpg" alt="Screencapture of interaction with Mrs Dolores Landingham, an onboarding bot developed by the A P I team." >}}
 
-<h2 id="Growing-Our-Team" style="padding-top: 50px">
+<h2 id="Growing-Our-Team">
   Growing Our Team
 </h2>_This year, our Talent team streamlined their processes and almost doubled our workforce. They started working in agile cycles and [launched a new website about applying to 18F](https://pages.18f.gov/joining-18f/). Several people from across 18F reflected on the work the Talent team has completed._
 

--- a/content/news/2016/06/2016-06-02-open-data-democratizes-innovation.md
+++ b/content/news/2016/06/2016-06-02-open-data-democratizes-innovation.md
@@ -55,7 +55,7 @@ It has also opened new possibilities for the government. With open and available
 
 These are technological tools created by the people, for the people. {{< legacy-img src="2015/12/600-x-414-Crowdsourcing-nevarpp-iStock-Thinkstock-467787670.jpg" alt="Various teams contribute to a solution" caption="" >}}
 
-<h3 id="spotlight-crowdsourcing" style="padding-top: 50px;padding-left: 30px">
+<h3 id="spotlight-crowdsourcing">
   Spotlight: Citizens Innovate Technology for Food Resilience in a Changing Climate
 </h3>
 
@@ -63,7 +63,7 @@ One way that federal agencies have asked citizens to innovate solutions is throu
 
 This innovation challenge spurred competitors to create more than 30 free apps and tools for farmers and policy makers. The grand prize winner released [FarmPlenty Local Crop Trends](http://farmplenty.com/croptrends/), an interactive website that helps farmers to identify the best crops by browsing nearby crops, trends and prices.
 
-<h3 id="spotlight-earth-day" style="padding-top: 50px;padding-left: 30px">
+<h3 id="spotlight-earth-day">
   Spotlight: Tech Savvy Americans Hack New Tools for Earth Day
 </h3>
 
@@ -71,7 +71,7 @@ Federal agencies also harness the creativity and technical ability of American c
 
 The winning team developed an ultraviolet (UV) radiation widget for weather apps. By integrating open data from the Environmental Protection Agency into existing mobile apps, beach-goers are alerted when they are exposed to high amounts of ultraviolet (UV) radiation, a major risk factor for most skin cancers.
 
-<h3 id="spotlight-collaborations" style="padding-top: 50px;padding-left: 30px">
+<h3 id="spotlight-collaborations">
   Spotlight: New Collaborations Reveal Trends in Big Datasets
 </h3>
 

--- a/content/news/2016/08/2016-08-18-the-right-tools-for-the-job-re-hosting-digitalgov-search-to-a-dynamic-infrastructure-environment.md
+++ b/content/news/2016/08/2016-08-18-the-right-tools-for-the-job-re-hosting-digitalgov-search-to-a-dynamic-infrastructure-environment.md
@@ -41,7 +41,7 @@ While this series of posts will discuss the requirements above separately, the b
 
 If you have questions or would like to discuss particulars, [we would love to hear from you](mailto:search@support.digitalgov.gov).
 
-<h3 id="series" style="padding-top: 50px">
+<h3 id="series">
   <em>This is the first post in a five part series. Stay tuned for the following posts:</em>
 </h3>
 

--- a/content/news/2016/09/2016-09-02-quality-speed-and-lower-costs-yes-you-can-have-it-all.md
+++ b/content/news/2016/09/2016-09-02-quality-speed-and-lower-costs-yes-you-can-have-it-all.md
@@ -102,7 +102,7 @@ We worked with GSA security personnel to modify the Assessment & Accreditation p
 
 By applying some very commonly-understood modern operations practices — role-based deployment, server redundancy and pooling — to our application, we were able to achieve substantial cost savings while making the <tt>search.usa.gov</tt> service more resilient to failure. While some government security practices are still evolving to incorporate dynamic server environments, the success of our migration bodes well for the future of cost-effective and reliable cloud computing in government applications.
 
-<h3 id="series" style="padding-top: 50px">
+<h3 id="series">
   <em>Read more of this 5-part series:</em>
 </h3>
 

--- a/content/news/2016/09/2016-09-06-a-domain-by-any-other-name-cnames-wildcard-records-and-another-level-of-indirection.md
+++ b/content/news/2016/09/2016-09-06-a-domain-by-any-other-name-cnames-wildcard-records-and-another-level-of-indirection.md
@@ -48,7 +48,7 @@ The snippet above is a bit of a simplification, however. We used [wildcard DNS r
 
 At any step in this process, we were always able to go back to our zone file and add a customer-specific CNAME to direct traffic as needed for that customer, but eventually the DNS migration came to an end and we were left with just the single wildcard record <tt>*.sites.infr.search.usa.gov</tt> pointing to our AWS infrastructure.
 
-<h3 id="series" style="padding-top: 50px">
+<h3 id="series">
   <em>Read more of this 5-part series:</em>
 </h3>
 

--- a/content/news/2016/09/2016-09-07-lets-encrypt-those-cnames-shall-we.md
+++ b/content/news/2016/09/2016-09-07-lets-encrypt-those-cnames-shall-we.md
@@ -103,7 +103,7 @@ This allows us to use the following Certbot command no matter how many customer 
 
 Our HTTP Domain Validation request proxy design ensures we can quickly and easily generate a new SAN SSL certificate that is valid for all of our customers’ domains. It currently takes us only a few minutes to respond to customer requests for HTTPS support as long as they have their DNS set up properly. This combined with the free cost of the Let&#8217;s Encrypt service makes it a great solution for us.
 
-<h3 id="series" style="padding-top: 50px">
+<h3 id="series">
   <em>Read more of this 5-part series:</em>
 </h3>
 

--- a/content/news/2016/09/2016-09-12-dnssec-vs-elastic-load-balancers-the-zone-apex-problem.md
+++ b/content/news/2016/09/2016-09-12-dnssec-vs-elastic-load-balancers-the-zone-apex-problem.md
@@ -103,7 +103,7 @@ So, thanks to some tricky multi-tier design, our solution now works as follows:
 
 For DigitalGov Search agency customers with DNSSEC-signed zones of their own, this setup allows them to select their own customer-specific CNAME, delegate it to <tt>search.usa.gov</tt>, and operate with confidence that the entire chain of DNS resolution is signed with DNSSEC and safe from cache poisoning or man-in-the-middle attacks.
 
-<h3 id="series" style="padding-top: 50px">
+<h3 id="series">
   <em>Read more of this 5 part series:</em>
 </h3>
 

--- a/content/resources/improving-the-accessibility-of-social-media-in-government.md
+++ b/content/resources/improving-the-accessibility-of-social-media-in-government.md
@@ -17,10 +17,12 @@ This Toolkit is your guide to **_Improving the Accessibility of Social Media in 
 To begin exploring the Toolkit, simply select from this table of contents:
 
 - [Who Developed This Toolkit?](#who-developed-this-toolkit)
-- [Why Is The Accessibility of Social Media So Important?](#why-is-the-accessibility-of-social-media-so-important)
-  - [5 Things Every Social Media Content Manager Needs to Know](#5-things-every-social-media-content-manager-needs-to-know)
-  - [Trainings](#trainings)
-  - [Other Web resources](#other-web-resources)
+- [Why Is The Accessibility Of Social Media So Important?](#why-is-the-accessibility-of-social-media-so-important)
+- [What You Will And Won&#8217;t Find In This Toolkit](#find)
+- [General Social Media Accessibility Tips](#general)
+- [Platform-Specific Social Media Accessibility Tips – e.g., Facebook, Twitter, YouTube, Vine, Blogs, etc.](#specific)
+- [Additional Resources](#additional)
+- [How To Provide Feedback or Contribute Content To This Toolkit](#provide)
 
 ## Who Developed This Toolkit?
 

--- a/content/resources/improving-the-accessibility-of-social-media-in-government.md
+++ b/content/resources/improving-the-accessibility-of-social-media-in-government.md
@@ -17,12 +17,10 @@ This Toolkit is your guide to **_Improving the Accessibility of Social Media in 
 To begin exploring the Toolkit, simply select from this table of contents:
 
 - [Who Developed This Toolkit?](#who-developed-this-toolkit)
-- [Why Is The Accessibility Of Social Media So Important?](#why-is-the-accessibility-of-social-media-so-important)
-- [What You Will And Won&#8217;t Find In This Toolkit](#find)
-- [General Social Media Accessibility Tips](#general)
-- [Platform-Specific Social Media Accessibility Tips – e.g., Facebook, Twitter, YouTube, Vine, Blogs, etc.](#specific)
-- [Additional Resources](#additional)
-- [How To Provide Feedback or Contribute Content To This Toolkit](#provide)
+- [Why Is The Accessibility of Social Media So Important?](#why-is-the-accessibility-of-social-media-so-important)
+  - [5 Things Every Social Media Content Manager Needs to Know](#5-things-every-social-media-content-manager-needs-to-know)
+  - [Trainings](#trainings)
+  - [Other Web resources](#other-web-resources)
 
 ## Who Developed This Toolkit?
 
@@ -40,7 +38,7 @@ This same logic applies to social media. More and more organizations are using s
 
 So put simply, the accessibility of social media—or any product or IT offering—is everyone&#8217;s responsibility. And it is vital that the federal government promote accessibility in all of its technology efforts. After all, an effective and responsive government depends on citizen engagement as well as a diverse, well-prepared workforce. And both of these require access to information and technology.
 
-<h2 id="find" style="padding-top: 50px">
+<h2 id="find">
   What You Will And Won&#8217;t Find in this Toolkit
 </h2>
 
@@ -48,7 +46,7 @@ Below are tips on how to increase the accessibility of social media. These tips 
 
 In addition, there are many ways users access and participate in social media. Though this toolkit is not meant to address the needs of social media users, we encourage users to be part of the conversation in order to provide guidance to those who are trying to effectively reach them.
 
-<h2 id="general" style="padding-top: 50px">
+<h2 id="general">
   General Social Media Accessibility Tips
 </h2>
 
@@ -62,7 +60,7 @@ Below are a set of recommended, baseline strategies to improve the accessibility
 4. Keep it simple. Good design and good content more often than not leads to accessible content. When possible, write in plain language, use camel case when appropriate (i.e., capitalize the first letters of compound words as in #SocialGov), and limit your use of hashtags, abbreviations and acronyms. The use of camel case is not only a common practice, but a helpful one as it makes multi-word hashtags easier to read, including for those using a screen reader.
 5. Learn the accessibility requirements and periodically test your content for accessibility. Read the [Section 508 Standards](http://www.access-board.gov/guidelines-and-standards/communications-and-it/about-the-section-508-standards/section-508-standards) and the [Web Content Accessibility Guidelines (WCAG)](http://www.w3.org/TR/WCAG20/) 2.0 and other key resources that discuss them. Then test your social media content with a screen reader or other type of assistive technology.
 
-<h2 id="specific" style="padding-top: 50px">
+<h2 id="specific">
   Platform-Specific Social Media Accessibility Tips
 </h2>
 
@@ -73,7 +71,7 @@ Below are a set of recommended, baseline strategies to improve the accessibility
 - [Tips for Making Blogs Accessible](#blogs)
 - [Tips for Making Other Social Media Platforms Accessible](#platforms)
 
-<h3 id="facebook" style="padding-top: 50px">
+<h3 id="facebook">
   Tips for Making Facebook Updates Accessible
 </h3>
 
@@ -84,7 +82,7 @@ Below are a set of recommended, baseline strategies to improve the accessibility
     - Facebook’s Accessibility Team’s Facebook Page &#8211; <http://www.facebook.com/help/141636465971794>
     - Facebook’s Accessibility Team’s Twitter Account &#8211; <https://twitter.com/fbaccess>
 
-<h3 id="tweets" style="padding-top: 50px">
+<h3 id="tweets">
   Tips for Making Tweets Accessible
 </h3>
 
@@ -102,7 +100,7 @@ Below are a set of recommended, baseline strategies to improve the accessibility
 > Did you know #a11y is short for accessibility? “a11y” is a numeronym (number-based abbreviation) for “accessibility.” The 11 is a stand-in for the 11 characters that would normally be seen between the “a” and the “y”. For those of you with computer-science/IT backgrounds, you might recognize other numeronyms such as “i18n” for “internationalization” or “l10n” for “localization.” Source: http://www.a11ylab.com/what-exactly-does-a11y-stand-for/
 > Remember that infographics are, by their very nature, pictures. If you decide to link to an infographic, make sure that you adequately describe all of the content with text. Just remember to use plain language and be concise in your descriptions. Also make sure that the infographic itself is easy for readers, including those with cognitive disabilities, to interpret. In other words, make sure that the infographic is not overly complicated to understand and navigate. Avoid: complex layout and flow that require the reader to follow too many lines or arrows connecting one piece of content to another; excessive images and text; and wide variation and insufficient contrast in the color scheme.
 
-<h3 id="youtube" style="padding-top: 50px">
+<h3 id="youtube">
   Tips for Making YouTube Videos Accessible
 </h3>
 
@@ -122,7 +120,7 @@ Below are a set of recommended, baseline strategies to improve the accessibility
 - Note that good captions are not just a transcript of what is said in the video. It is also important to describe sounds, particularly sounds for which there is no visual equivalent (e.g., if someone in a video is giving a talk, and the viewer can&#8217;t see that the audience is laughing, the captions should say that people are laughing). Tone of voice is also important to note, particularly if not obvious from a person&#8217;s facial expression (or if the person&#8217;s face can&#8217;t be seen). A lot of meaning and information can get lost by certain viewers with hearing or cognitive impairments if they are not made aware of sounds, tone of voice, etc.; the way the meaning of spoken content is interpreted can completely change based on this information. Knowing that the background music is cheery, for example, helps signal that the producers mean for the scene to be viewed in a light way and can help shape viewers’ expectations for the kinds of things that will follow. Someone saying &#8220;I&#8217;m doing great&#8221; in a sarcastic tone clearly means something very different from someone saying it in a casual or light tone.
 - The YouTube player on the YouTube site is not fully keyboard accessible (e.g., it can be impossible or very difficult for a user with a motor disability to turn on captions without a mouse). Therefore, if possible, it is beneficial to also embed any YouTube videos on a site that uses an accessible YouTube player wrapper and have captions enabled by default.
 
-<h3 id="vine" style="padding-top: 50px">
+<h3 id="vine">
   Tips for Making Vine Posts Accessible
 </h3>
 
@@ -130,7 +128,7 @@ Below are a set of recommended, baseline strategies to improve the accessibility
 - Upon uploading a video clip, add a transcript to cover spoken and visual action to Vine&#8217;s “description” field.
 - Alternatively, Vine videos can be embedded in a website where they can be captioned and described. Closed-caption can be embedded Vine video on your website using a tool like the [JW Player](http://www.longtailvideo.com/support/forums/jw-player/feature-suggestions/32592/support-for-vine-videos#comment-182152).
 
-<h3 id="blogs" style="padding-top: 50px">
+<h3 id="blogs">
   Tips for Making Blogs Accessible
 </h3>
 
@@ -145,7 +143,7 @@ Below are a set of recommended, baseline strategies to improve the accessibility
 - Keep your writing simple. Use plain language and write in the active voice. Break up long paragraphs into smaller chunks of text.
 - Although [Tumblr](http://tumblr.com/) is considered a popular micro-blogging and social media tool, many users with disabilities find it difficult to navigate, but there are some ways to help make this easier. Tumblr is image-heavy, so as with all Web content, alternative text should be used. Many users suggest posting images using the text post option, rather than the image post option. In the image option, any text entered as a caption is read twice by screen readers. The use of GIFs on the site can also be difficult for individuals with sensitivities to flashes. Either limit their use or make sure than any visual element that blinks or flashes at a rate more than three flashes per second is small enough to only cover a quarter of an individual’s field of vision.
 
-<h3 id="platforms" style="padding-top: 50px">
+<h3 id="platforms">
   Tips for Making Other Social Media Platforms Accessible
 </h3>
 
@@ -156,7 +154,7 @@ Below are a set of recommended, baseline strategies to improve the accessibility
 - Instagram is a mobile photo- and video-sharing service where users take images or videos, apply digital filters and have the ability to share them on the application itself and on a wide variety of social networking services. Although Instagram does not allow images and videos to have alternative text, users should provide a detailed caption explaining the image. Use Camel Case for multiple words within a hashtag.
 - As with Vine videos, Instagram videos should have captions and a transcript. For more information on video accessibility, read the Tips for Making YouTube Videos Accessible and Tips for Making Vine Posts Accessible.
 
-<h3 id="additional" style="padding-top: 50px">
+<h3 id="additional">
   Additional Resources
 </h3>
 
@@ -191,7 +189,7 @@ Digital Government University (DGU) offers a series of trainings based on these 
 - [WAVE Accessibility Testing](http://wave.webaim.org/)
 - [W3 Web Accessibility Initiative](http://www.w3.org/WAI/)
 
-<h2 id="provide" style="padding-top: 50px">
+<h2 id="provide">
   How To Provide Feedback Or Contribute Content To This Toolkit
 </h2>
 

--- a/content/resources/mobile-user-experience-guidelines-and-recommendations.md
+++ b/content/resources/mobile-user-experience-guidelines-and-recommendations.md
@@ -34,7 +34,7 @@ As more agencies develop mobile apps and websites, they need quick guidance on m
 
 Below we have added specific resources to each guideline.
 
-<h2 id="guideline1" style="padding-top: 50px">
+<h2 id="guideline1">
   Guideline 1: Make sure your content is structured and chunked appropriately for multiple devices
 </h2>
 
@@ -59,7 +59,7 @@ Below we have added specific resources to each guideline.
 - Guidelines to [making Mobile Websites]({{< ref "2015-04-15-mobilegeddon-government-edition.md" >}}) mobile search friendly &#8211; A how-to guide written by the Search.gov _(formerly DigitalGov Search)_ team
 - [How to Use Open Source CMS to Implement Responsive Web Design]({{< ref "2014-09-03-mobile-web-templates-how-to-use-open-source-cms-to-implement-responsive-web-design-webinar-recap.md" >}})
 
-<h2 id="guideline2" style="padding-top: 50px">
+<h2 id="guideline2">
   Guideline 2: Follow industry user interface guidelines and government regulations (like 508) in the development of your mobile product
 </h2>
 
@@ -82,7 +82,7 @@ Below we have added specific resources to each guideline.
 - [Google Mobile Friendly PDF](http://services.google.com/fh/files/misc/mobile-friendly-starter-guide.pdf) &#8211; Basic one sheeter for webmasters.
 - [Google Principles of Mobile Site Design](http://static.googleusercontent.com/media/www.google.com/en//intl/ALL_ALL/think/multiscreen/pdf/multi-screen-moblie-whitepaper_research-studies.pdf) &#8211; Tips for delighting mobile users and increasing mobile conversions.
 
-<h2 id="guideline3" style="padding-top: 50px">
+<h2 id="guideline3">
   Guideline 3: Leverage the device’s features for usability and accessibility
 </h2>
 
@@ -98,7 +98,7 @@ Below we have added specific resources to each guideline.
 - [A Checklist for Designing Mobile Input Fields](http://www.nngroup.com/articles/mobile-input-checklist/)
 - [Accordions on Mobile](http://www.nngroup.com/articles/mobile-accordions/)
 
-<h2 id="guideline4" style="padding-top: 50px">
+<h2 id="guideline4">
   Guideline 4: Test at multiple points in the design/development process
 </h2>
 
@@ -119,7 +119,7 @@ Below we have added specific resources to each guideline.
 - [W3C Mobile OK Checker](https://validator.w3.org/mobile/)
 - [Why Mobile Testing is Tough](http://www.softwaretestinghelp.com/why-mobile-testing-is-tough/)
 
-<h2 id="guideline5" style="padding-top: 50px">
+<h2 id="guideline5">
   Guideline 5: Collect and use data (quantitative and qualitative) to determine what content your users want and where
 </h2>
 
@@ -139,7 +139,7 @@ Below we have added specific resources to each guideline.
 - [Multi-armed Bandit Approach to Testing](http://stevehanov.ca/blog/index.php?id=132)
 - [The Ultimate Guide to A/B Testing](http://www.smashingmagazine.com/2010/06/24/the-ultimate-guide-to-a-b-testing/)
 
-<h2 id="guideline6" style="padding-top: 50px">
+<h2 id="guideline6">
   Guideline 6: Develop security and privacy guidelines with regard to what the app does/how it protects user data and government systems
 </h2>
 


### PR DESCRIPTION
### Summary
Some old pages have inline padding top styles that break the vertical rhythm with too much spacing.

<img width="1073" alt="Screen Shot 2022-10-13 at 12 34 29 PM" src="https://user-images.githubusercontent.com/104778659/195654295-e1167e8a-183f-4698-b525-b004751f33de.png">


### Solution
Search and replace on `styles="padding-top: 50px;"`

### Links

Example pages:

- https://digital.gov/resources/improving-the-accessibility-of-social-media-in-government/
- https://digital.gov/2016/09/12/dnssec-vs-elastic-load-balancers-the-zone-apex-problem/
- https://digital.gov/2015/12/29/18f-reflects-on-their-most-meaningful-projects-in-2015/

### Federalist Preview

- https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/nl-remove-header-padding/resources/improving-the-accessibility-of-social-media-in-government/
- https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/nl-remove-header-padding/2016/09/12/dnssec-vs-elastic-load-balancers-the-zone-apex-problem/
-  https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/nl-remove-header-padding/2015/12/29/18f-reflects-on-their-most-meaningful-projects-in-2015/