### PR TITLE
Adjust heading structure on News pages

### DIFF
--- a/content/services/directory.md
+++ b/content/services/directory.md
@@ -2,6 +2,7 @@
 # What is the name of the product or service?
 title: "Directory of services, tools, and teams"
 deck: "Shared services and tools offered by the GSA and other agencies."
+source_url: /services
 
 # Keep it short — should be no longer than 10 words.
 summary: "Free and low-cost shared services and tools offered by the GSA and other agencies."

--- a/content/services/directory.md
+++ b/content/services/directory.md
@@ -2,7 +2,6 @@
 # What is the name of the product or service?
 title: "Directory of services, tools, and teams"
 deck: "Shared services and tools offered by the GSA and other agencies."
-source_url: /services
 
 # Keep it short — should be no longer than 10 words.
 summary: "Free and low-cost shared services and tools offered by the GSA and other agencies."

--- a/themes/digital.gov/layouts/news/single.html
+++ b/themes/digital.gov/layouts/news/single.html
@@ -30,7 +30,7 @@
 
             <div class="meta">
               <div class="date">
-                <a href="{{- .Permalink -}} " rel="nofollow" title="{{- .Title | markdownify -}} ">{{- .Date.Format "Jan _2, 2006" -}}</a>
+                <span title="{{- .Title | markdownify -}} ">{{- .Date.Format "Jan _2, 2006" -}}</span>
               </div>
             </div>
 
@@ -63,7 +63,7 @@
 
               {{/* Date */}}
               <div class="date">
-                <a href="{{- .Permalink -}} " rel="nofollow" title="{{- .Title | markdownify -}} ">{{- .Date.Format "Jan _2, 2006" -}} </a>
+                <span title="{{- .Title | markdownify -}} ">{{- .Date.Format "Jan _2, 2006" -}} </span>
               </div>
 
 

--- a/themes/digital.gov/layouts/partials/core/get_authors.html
+++ b/themes/digital.gov/layouts/partials/core/get_authors.html
@@ -35,7 +35,7 @@
           <div class="grid-col-9">
             <div class="details">
               <h5>
-                <span class="usa-sr-only">Orginally posted by {{ $author.Params.display_name | default $uid }} on {{ $.Date.Format "Jan 2, 2006" }}</span>
+                <span class="usa-sr-only">Originally posted by {{ $author.Params.display_name | default $uid }} on {{ $.Date.Format "Jan 2, 2006" }}</span>
                 <a href="{{ (printf "authors/%s/" $uid) | absURL }} " title="Posts by {{ $author.Params.display_name | default $uid }}" rel="author" aria-label="Read more articles by {{ $author.Params.display_name | default $uid }}">
                   {{- $author.Params.display_name | default $uid -}}
                 </a>

--- a/themes/digital.gov/layouts/partials/core/get_authors.html
+++ b/themes/digital.gov/layouts/partials/core/get_authors.html
@@ -35,8 +35,8 @@
           <div class="grid-col-9">
             <div class="details">
               <h5>
-                <span class="usa-sr-only">Orginally posted by {{- $author.Params.display_name | default $uid -}} on {{- $.Date.Format "Jan 2, 2006" -}}</span>
-                <a href="{{- (printf "authors/%s/" $uid) | absURL -}} " title="Posts by {{- $author.Params.display_name | default $uid -}} " rel="author" aria-label="Read more articles by {{- $author.Params.display_name | default $uid -}}">
+                <span class="usa-sr-only">Orginally posted by {{ $author.Params.display_name | default $uid }} on {{ $.Date.Format "Jan 2, 2006" }}</span>
+                <a href="{{ (printf "authors/%s/" $uid) | absURL }} " title="Posts by {{ $author.Params.display_name | default $uid }}" rel="author" aria-label="Read more articles by {{ $author.Params.display_name | default $uid }}">
                   {{- $author.Params.display_name | default $uid -}}
                 </a>
               </h5>

--- a/themes/digital.gov/layouts/partials/core/get_authors.html
+++ b/themes/digital.gov/layouts/partials/core/get_authors.html
@@ -35,8 +35,8 @@
           <div class="grid-col-9">
             <div class="details">
               <h5>
-                <span class="usa-sr-only">Orginally posted by&nbsp;{{- $author.Params.display_name | default $uid -}}&nbsp;on&nbsp;{{- $.Date.Format "Jan 2, 2006" -}}</span>
-                <a href="{{- (printf "authors/%s/" $uid) | absURL -}} " title="Posts by {{- $author.Params.display_name | default $uid -}} " rel="author" aria-label="Read more articles by&nbsp;{{- $author.Params.display_name | default $uid -}}">
+                <span class="usa-sr-only">Orginally posted by {{- $author.Params.display_name | default $uid -}} on {{- $.Date.Format "Jan 2, 2006" -}}</span>
+                <a href="{{- (printf "authors/%s/" $uid) | absURL -}} " title="Posts by {{- $author.Params.display_name | default $uid -}} " rel="author" aria-label="Read more articles by {{- $author.Params.display_name | default $uid -}}">
                   {{- $author.Params.display_name | default $uid -}}
                 </a>
               </h5>

--- a/themes/digital.gov/layouts/partials/core/get_authors.html
+++ b/themes/digital.gov/layouts/partials/core/get_authors.html
@@ -35,7 +35,8 @@
           <div class="grid-col-9">
             <div class="details">
               <h5>
-                <a href="{{- (printf "authors/%s/" $uid) | absURL -}} " title="Posts by {{- $author.Params.display_name | default $uid -}} " rel="author">
+                <span class="usa-sr-only">Orginally posted by&nbsp;{{- $author.Params.display_name | default $uid -}}&nbsp;on&nbsp;{{- $.Date.Format "Jan 2, 2006" -}}</span>
+                <a href="{{- (printf "authors/%s/" $uid) | absURL -}} " title="Posts by {{- $author.Params.display_name | default $uid -}} " rel="author" aria-label="Read more articles by&nbsp;{{- $author.Params.display_name | default $uid -}}">
                   {{- $author.Params.display_name | default $uid -}}
                 </a>
               </h5>

--- a/themes/digital.gov/layouts/partials/core/get_related.html
+++ b/themes/digital.gov/layouts/partials/core/get_related.html
@@ -66,6 +66,8 @@
     <h3>Get Started Building</h3>
   </header>
 
+  <ul class="usa-list usa-list--unstyled">
+
   {{- range $services -}}
 
     {{/* If an external link  */}}
@@ -81,9 +83,9 @@
           {{- $src := (printf "/logos/%s%s" $source.Params.logo "-icon.png") -}}
           {{/* Pass these vars into the list item template (botton of page) */}}
           
-          <ul class="usa-list usa-list--unstyled">
-            {{- template "promo" dict "item" . "href" (print .Params.source_url "?dg") "src" $src -}}
-          </ul>
+          
+          {{- template "promo" dict "item" . "href" (print .Params.source_url "?dg") "src" $src -}}
+          
 
         {{- end -}}
       {{/* No source? let's attempt to get the favicon for the URL */}}
@@ -91,9 +93,8 @@
         {{/* get the Favicon via Google Favicon service */}}
         {{- $src := (print "https://www.google.com/s2/favicons?domain=" .Params.source_url) -}}
         {{/* Pass these vars into the list item template (botton of page) */}}
-        <ul class="usa-list usa-list--unstyled">
-          {{- template "promo" dict "item" . "href" (print .Params.source_url "?dg") "src" $src -}}
-        </ul>
+        {{- template "promo" dict "item" . "href" (print .Params.source_url "?dg") "src" $src -}}
+        
       {{- end -}}
 
     {{/* If an internal link... */}}
@@ -101,13 +102,13 @@
 
       {{/* Use the digital.gov logo */}}
       {{/* Pass these vars into the list item template (botton of page) */}}
-      <ul class="usa-list usa-list--unstyled">
-        {{- template "promo" dict "item" . "href" (print .Params.source_url "?dg") "src" (print "/img/digit-50.png") -}}
-      </ul>
+      {{- template "promo" dict "item" . "href" (print .Params.source_url "?dg") "src" (print "/img/digit-50.png") -}}
 
     {{- end -}}
 
   {{- end -}}
+
+  </ul>
 
   <footer>
     <p class="more">

--- a/themes/digital.gov/layouts/partials/core/get_related.html
+++ b/themes/digital.gov/layouts/partials/core/get_related.html
@@ -130,7 +130,11 @@
     {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
     <li class="promo" data-edit-this="{{- $path -}}">
       <div class="promo__link-wrapper">
-        <a class="external-link" href="{{- .Params.source_url -}}?=dg" title="Visit {{ .Title | markdownify -}} services page"><span>{{- .Title | markdownify -}}</span></a>
+        {{- if isset .Params "source_url"}}
+          <a class="external-link" href="{{- .Params.source_url -}}?=dg" title="Visit {{ .Title | markdownify -}} services page"><span>{{- .Title | markdownify -}}</span></a>
+        {{- else -}}
+          <a class="external-link" href="{{- .Permalink -}}?=dg" title="Visit {{ .Title | markdownify -}} services page"><span>{{- .Title | markdownify -}}</span></a>
+        {{- end -}}
       </div>
       <img src="{{- $src | relURL -}}" alt="" aria-hidden="true"/>
     </li> 

--- a/themes/digital.gov/layouts/partials/core/get_related.html
+++ b/themes/digital.gov/layouts/partials/core/get_related.html
@@ -22,24 +22,25 @@
   <header>
     <h3>Join a Community</h3>
   </header>
-  {{- range $communities -}}
 
-    <div class="promo">
+  <ul class="usa-list usa-list--unstyled">
+    {{- range $communities -}}
+    <li class="promo">
       <div>
-        <h4><a href="{{ .Permalink }}?promo" title="{{ .Title }}">{{ .Title }}</a></h4>
+        <a href="{{ .Permalink }}?promo" title="{{ .Title }}">{{ .Title }}</a>
         {{- if .Params.members -}}
         <p class="members">{{- .Params.members -}}+</p>
         {{- end -}}
       </div>
-    </div>
-
-  {{- end -}}
+    </li>
+    {{- end -}}
+  </ul>
 
   <footer>
     <p class="more">
       <a href="{{ "/communities/" | absURL }}"><span>See all {{ len (where $.Site.RegularPages "Section" "communities") }} communities</span>
         <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-          <use xlink:href="{{- $.Site.BaseURL -}}uswds/img/sprite.svg#arrow_forward"></use>
+          <use xlink:href="{{ "uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
         </svg>
       </a>
     </p>
@@ -76,10 +77,13 @@
         {{- $source := .Site.GetPage (print "source_" .Params.source ) -}}
         {{/* If there is a logo defined in the source */}}
         {{- if $source.Params.logo -}}
-          {{/* get the path for the icon — e.g. 18f-icon.png */}}
+          {{/* get the path for the icon — e.g. 18f-icon.png */}}
           {{- $src := (printf "/logos/%s%s" $source.Params.logo "-icon.png") -}}
           {{/* Pass these vars into the list item template (botton of page) */}}
-          {{- template "promo" dict "item" . "href" (print .Params.source_url "?dg") "src" $src -}}
+          
+          <ul class="usa-list usa-list--unstyled">
+            {{- template "promo" dict "item" . "href" (print .Params.source_url "?dg") "src" $src -}}
+          </ul>
 
         {{- end -}}
       {{/* No source? let's attempt to get the favicon for the URL */}}
@@ -105,7 +109,7 @@
     <p class="more">
       <a href="{{ "/services/" | absURL }}"><span>See all {{ len (where $.Site.RegularPages "Section" "services") }} services</span>
         <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-          <use xlink:href="{{- $.Site.BaseURL -}}uswds/img/sprite.svg#arrow_forward"></use>
+          <use xlink:href="{{ "uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
         </svg>
       </a>
     </p>
@@ -119,13 +123,11 @@
   {{- $src := .src -}}
   {{- with .item -}}
     {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
-    <div class="promo" data-edit-this="{{- $path -}}">
+    <li class="promo" data-edit-this="{{- $path -}}">
       <div>
-        <h4>
-          <a class="external-link" href="{{- .Params.source_url -}}?=dg" title="{{ .Title | markdownify -}}"><span>{{- .Title | markdownify -}}</span></a>
-        </h4>
-        <img src="{{- $src | relURL -}}" alt="" aria-hidden="true"/>
+        <a class="external-link" href="{{- .Params.source_url -}}?=dg" title="{{ .Title | markdownify -}}"><span>{{- .Title | markdownify -}}</span></a>
       </div>
-    </div>
+      <img src="{{- $src | relURL -}}" alt="" aria-hidden="true"/>
+    </li> 
   {{- end -}}
 {{- end -}}

--- a/themes/digital.gov/layouts/partials/core/get_related.html
+++ b/themes/digital.gov/layouts/partials/core/get_related.html
@@ -26,8 +26,8 @@
   <ul class="usa-list usa-list--unstyled">
     {{- range $communities -}}
     <li class="promo">
-      <div>
-        <a href="{{ .Permalink }}?promo" title="{{ .Title }}">{{ .Title }}</a>
+      <div class="promo__link-wrapper">
+        <a href="{{ .Permalink }}?promo" title="Visit {{ .Title }} community page">{{ .Title }}</a>
         {{- if .Params.members -}}
         <p class="members">{{- .Params.members -}}+</p>
         {{- end -}}
@@ -128,8 +128,8 @@
   {{- with .item -}}
     {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
     <li class="promo" data-edit-this="{{- $path -}}">
-      <div>
-        <a class="external-link" href="{{- .Params.source_url -}}?=dg" title="{{ .Title | markdownify -}}"><span>{{- .Title | markdownify -}}</span></a>
+      <div class="promo__link-wrapper">
+        <a class="external-link" href="{{- .Params.source_url -}}?=dg" title="Visit {{ .Title | markdownify -}} services page"><span>{{- .Title | markdownify -}}</span></a>
       </div>
       <img src="{{- $src | relURL -}}" alt="" aria-hidden="true"/>
     </li> 

--- a/themes/digital.gov/layouts/partials/core/get_related.html
+++ b/themes/digital.gov/layouts/partials/core/get_related.html
@@ -91,7 +91,9 @@
         {{/* get the Favicon via Google Favicon service */}}
         {{- $src := (print "https://www.google.com/s2/favicons?domain=" .Params.source_url) -}}
         {{/* Pass these vars into the list item template (botton of page) */}}
-        {{- template "promo" dict "item" . "href" (print .Params.source_url "?dg") "src" $src -}}
+        <ul class="usa-list usa-list--unstyled">
+          {{- template "promo" dict "item" . "href" (print .Params.source_url "?dg") "src" $src -}}
+        </ul>
       {{- end -}}
 
     {{/* If an internal link... */}}
@@ -99,7 +101,9 @@
 
       {{/* Use the digital.gov logo */}}
       {{/* Pass these vars into the list item template (botton of page) */}}
-      {{- template "promo" dict "item" . "href" (print .Params.source_url "?dg") "src" (print "/img/digit-50.png") -}}
+      <ul class="usa-list usa-list--unstyled">
+        {{- template "promo" dict "item" . "href" (print .Params.source_url "?dg") "src" (print "/img/digit-50.png") -}}
+      </ul>
 
     {{- end -}}
 

--- a/themes/digital.gov/layouts/partials/core/list-topics.html
+++ b/themes/digital.gov/layouts/partials/core/list-topics.html
@@ -11,6 +11,9 @@
 {{/* Checks if there are topics applied to this page */}}
 {{- if .Params.topics -}}
 <div class="list-topics">
+  <header>
+    <h3>Related Topics</h3>
+  </header>
   {{/* Sets the taxonomy we're pulling here */}}
   {{- $taxonomy := "topics" -}}
   {{- $topics := .Param $taxonomy -}}

--- a/themes/digital.gov/src/scss/new/_promos.scss
+++ b/themes/digital.gov/src/scss/new/_promos.scss
@@ -8,45 +8,34 @@
   @include u-padding(1);
   @include u-border("1px", "gray-cool-10", "solid");
   @include u-radius("md");
+  @include u-display("flex");
+  @include u-flex("align-center");
+  @include u-flex("justify");
   & > div {
-    @include u-display("flex");
-    @include u-flex("align-center");
-    @include u-flex("justify");
-  }
-  h3 {
-    @include u-margin(0);
-    @include u-font("sans", "sm");
-    @include u-line-height("sans", 2);
-    @include u-display("inline");
-    z-index: 2;
-    position: relative;
-    a {
-      @include u-text("no-underline");
-      @include u-text("indigo-80");
-      &:hover {
-        @include u-border-bottom("2px", "accent-warm", "solid");
-      }
-    }
-  }
-  h4 {
     @include u-margin-top(0);
     @include u-font("sans", "xs");
     @include u-line-height("sans", 2);
     @include u-text("semibold");
-    a {
-      @include u-text("no-underline");
-      @include u-text("indigo-70");
-      &:hover {
-        @include u-border-bottom("2px", "accent-warm", "solid");
-      }
-      &::after {
-        content: "";
-        @include u-position("absolute");
-        @include u-top(0);
-        @include u-left(0);
-        @include u-right(0);
-        @include u-bottom(0);
-      }
+    @include u-margin-bottom(2.5);
+  }
+  a {
+    @include u-margin-top(0);
+    @include u-font("sans", "xs");
+    @include u-line-height("sans", 2);
+    @include u-text("semibold");
+    @include u-text("no-underline");
+    @include u-text("indigo-70");
+    
+    &:hover {
+      @include u-border-bottom('05', "accent-warm", "solid");
+    }
+    &::after {
+      content: "";
+      @include u-position("absolute");
+      @include u-top(0);
+      @include u-left(0);
+      @include u-right(0);
+      @include u-bottom(0);
     }
   }
   .members {
@@ -79,16 +68,11 @@
     @include u-text("no-underline");
   }
 
-  // &:last-child{
-  //   @include u-margin(0);
-  //   @include u-bg('gray-10');
-  // }
   // To make the whole PROMO clickable, we put and additional <a> tag with a <span> tag in the markup that stretches to the full height and width of the element.
   position: relative;
   &:hover {
     @include u-bg("gray-cool-5");
-    h3 a,
-    h4 a {
+    a {
       @include u-border-bottom("05", "accent-warm", "solid");
     }
     p a {


### PR DESCRIPTION
## Summary
Update news page template with heading and link structure changes for improved ARIA support.

## Problems & Solutions

### Update author **link** and **heading** aria markup to read more clear

Author link and header does not read clearly. Suggested copy for the author link could read "Read more articles by author name"

**Before Link**
<img width="1653" alt="Screen Shot 2022-10-14 at 4 54 07 PM" src="https://user-images.githubusercontent.com/104778659/195942403-ee84d810-e57e-479f-b25d-44283728c8e2.png">

**After Link**
<img width="1653" alt="Screen Shot 2022-10-14 at 4 54 57 PM" src="https://user-images.githubusercontent.com/104778659/195942478-f4ce73dc-f11b-4eec-8700-c578dc3190f4.png">

Suggested copy for the author header could read "Originally posted by author name on date October 7, 2022"

**Before Heading**
<img width="1653" alt="Screen Shot 2022-10-14 at 4 59 46 PM" src="https://user-images.githubusercontent.com/104778659/195943107-48ddefbd-6d28-4b77-8977-3e90853af0bf.png">

**After Heading**
<img width="1653" alt="Screen Shot 2022-10-14 at 4 59 19 PM" src="https://user-images.githubusercontent.com/104778659/195943128-e85b44bd-b507-45cb-a56b-c65c07e4c153.png">

### Update markup from `h4's` to a list or nav

The sidebar (left col) includes a series of links, all formatted as H4.
New code uses `.usa-list .usa-list--unstyled`.

**Before**
```
<div class="promo">
  <h4>
    <a href="/communities/uswds/?promo" title="U.S. Web Design System">U.S. Web Design System</a>
  </h4>
</div>    
```

<img width="1653" alt="Screen Shot 2022-10-19 at 4 25 06 PM" src="https://user-images.githubusercontent.com/104778659/196798195-340c31c1-3939-4db2-9fc0-5d30db1ba712.png">

**After**
```
<ul class="usa-list usa-list--unstyled">
  <li class="promo">
      <div>
         <a href="//localhost:1313/communities/uswds/?promo" title="U.S. Web Design System">U.S. Web Design System</a>. 
      </div>
  </li>
</ul>
```

<img width="1653" alt="Screen Shot 2022-10-19 at 4 26 09 PM" src="https://user-images.githubusercontent.com/104778659/196798215-1c5a3fbe-2c9b-495f-af6e-25917ac7dd20.png">

### Add header for related topics to match preceding sections.

**Before**
<img width="263" alt="Screen Shot 2022-10-14 at 4 50 55 PM" src="https://user-images.githubusercontent.com/104778659/195941894-42a65ba4-d22e-45eb-b37d-713e766d3ece.png">

**After**
<img width="255" alt="Screen Shot 2022-10-14 at 4 51 51 PM" src="https://user-images.githubusercontent.com/104778659/195941943-222e97be-03f5-4288-a64c-147703998868.png">

