### PR TITLE
Adding USWDS Monthly Call Oct 2022 ppt file link to the event page

### DIFF
--- a/content/events/2022/10/2022-10-13-october-2022-uswds-monthly-call.md
+++ b/content/events/2022/10/2022-10-13-october-2022-uswds-monthly-call.md
@@ -27,6 +27,8 @@ primary_image: uswds-monthly-call-october-title-card
 
 ---
 
+[View the slides (PowerPoint, 7.2 MB, 67 pages)](https://digital.gov/files/uswds-monthly-call-october-2022.pptx)
+
 Many of the digital solutions we create rely on collecting personal information (like name, address, and phone number), allowing programs and services to connect with people who need assistance. Some of these people may be impacted by housing insecurity, homelessness, or displacement due to disaster.
 
 When what we ask for doesn’t allow users to confidently and accurately communicate their answers — or allow them to update this information as their circumstances change — we may have created a poor user experience and eroded trust from the start. We’ll discuss our approach to developing User Profile design patterns, look at some specific guidance, and talk about why it’s so important.


### PR DESCRIPTION
This PR implements the following **changes:**

Adding USWDS Monthly Call Oct 2022 ppt file link to the event page

**URL / Link to page**
Event page: https://digital.gov/event/2022/10/20/october-2022-uswds-monthly-call/
File: https://digital.gov/files/uswds-monthly-call-october-2022.pptx
Preview: https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/jdotyoon-patch-10/event/2022/10/20/october-2022-uswds-monthly-call/
