### PR TITLE
adding 2 new data links

### DIFF
--- a/content/guides/site-scanning/data.md
+++ b/content/guides/site-scanning/data.md
@@ -11,10 +11,12 @@ There's a complete API available for accessing all of the scan data.  Full docum
 
 **Direct Downloads**
 
-The scan data is also exported on a weekly basis and can be downloaded as:  
+The scan data is also exported on a weekly basis and can be downloaded in one of two sets. The primary set includes scan data for all live URLs (those that return a 2xx server code):  
 
 * [CSV](https://api.gsa.gov/technology/site-scanning/data/weekly-snapshot.csv)
 * [JSON](https://api.gsa.gov/technology/site-scanning/data/weekly-snapshot.json)
   
+The second set includes scan data for all URLs that were scanned, regardless of whether they are live or not (some may be inaccessible over the public internet, no longer live, or experiencing downtime): 
    
-
+* [CSV](https://api.gsa.gov/technology/site-scanning/data/weekly-snapshot-all.csv)  
+* [JSON](https://api.gsa.gov/technology/site-scanning/data/weekly-snapshot-all.json)  


### PR DESCRIPTION
This PR implements the following **changes:**

This adds 2 links for new site scanning datasets to our data page.  

**[URL / Link to page](https://digital.gov/guides/site-scanning/data/)**


