### PR TITLE
Remove sitewide alert for hurricane ian

### DIFF
--- a/content/resources/checklist-of-requirements-for-federal-digital-services.md
+++ b/content/resources/checklist-of-requirements-for-federal-digital-services.md
@@ -11,7 +11,7 @@ aliases:
   - /resources/dot-gov-domain-freeze-and-waivers/
   - /resources/checklist/
   - /resources/policies-for-federal-agency-public-websites-m-05-04/
-weight: 3
+weight: 5
 topics:
   - product-management
   - policy

--- a/content/resources/hurricane-ian-guidance-for-u-s-government-websites-and-social-media.md
+++ b/content/resources/hurricane-ian-guidance-for-u-s-government-websites-and-social-media.md
@@ -19,7 +19,7 @@ aliases:
 # 0 -- hidden
 # 1 -- visible
 # 2 -- highlighted
-weight: 2
+weight: 4
 
 topics:
   - web-content-managers-forum

--- a/themes/digital.gov/layouts/_default/baseof.html
+++ b/themes/digital.gov/layouts/_default/baseof.html
@@ -20,7 +20,6 @@
 
     {{- partialCached "core/notice-bar.html" . -}}
     {{- partialCached "core/usa-banner.html" . -}}
-    {{- partialCached "core/sitewide-alert.html" . -}}
     {{- partialCached "core/header.html" . -}}
 
 

--- a/themes/digital.gov/layouts/partials/core/sitewide-alert.html
+++ b/themes/digital.gov/layouts/partials/core/sitewide-alert.html
@@ -1,3 +1,4 @@
+// Creates sitewide banner alert at top of page under the banner
 <section
   class="usa-site-alert usa-site-alert--info" aria-label="Site alert">
   <div class="usa-alert">


### PR DESCRIPTION
## Summary

Remove Hurricane Ian sitewide alert and put as 2nd item on the "Popular Guides & Resources"

