### PR TITLE
Card - a11y: Place title and content before decorative image

### DIFF
--- a/themes/digital.gov/layouts/events/card-event-past.html
+++ b/themes/digital.gov/layouts/events/card-event-past.html
@@ -41,7 +41,7 @@
       <svg xmlns="http://www.w3.org/2000/svg" role="img" alt="" aria-hidden="true" height="150" width="150" viewBox="0 0 25 25">
         <title>Calendar Event</title>
         <path d="M0 0h24v24H0z" fill="none"/>
-        <path fill="#005ea2" d="M17 12h-5v5h5v-5zM16 1v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2h-1V1h-2zm3 18H5V8h14v11z"/>
+        <path fill="#252f3e" d="M17 12h-5v5h5v-5zM16 1v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2h-1V1h-2zm3 18H5V8h14v11z"/>
       </svg>
     </div>
     {{- end -}}

--- a/themes/digital.gov/layouts/events/card-event-past.html
+++ b/themes/digital.gov/layouts/events/card-event-past.html
@@ -1,5 +1,5 @@
 {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
-<div class="card card-event card-event-past card-linked" data-edit-this="{{- $path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
+<article class="card card-event card-event-past card-linked" data-edit-this="{{- $path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
   <div class="grid-row tablet:grid-gap-4">
 
     {{- if .Params.youtube_id -}}
@@ -46,4 +46,4 @@
     </div>
 
   </div>
-</div>
+</article>

--- a/themes/digital.gov/layouts/events/card-event-past.html
+++ b/themes/digital.gov/layouts/events/card-event-past.html
@@ -1,49 +1,42 @@
 {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
-<article class="card card-event card-event-past card-linked" data-edit-this="{{- $path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
-  <div class="grid-row tablet:grid-gap-4">
+<article class="card card-event card-event-past card-linked {{ if not .Params.youtube_id -}}card-event--no-video{{ end }}" data-edit-this="{{- $path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
+  <div class="card__content">
+    {{- if .Params.kicker -}}
+    <div class="kicker">{{- .Params.kicker -}}</div>
+    {{- else -}}
+      {{- if .Params.youtube_id -}}
+      <div class="kicker">Video</div>
+      {{- end -}}
+    {{- end -}}
 
+    <h3>
+      <a href="{{ .Permalink }}" title="{{ .Title | markdownify }}" rel="bookmark">{{ .Title | markdownify }}</a>
+    </h3>
+    {{- if .Params.summary -}}
+      <div class="deck">{{ .Params.summary | markdownify -}}</div>
+    {{- else -}}
+      <div class="deck">{{ .Params.deck | markdownify -}}</div>
+    {{- end -}}
+
+    {{- partial "core/get_authors_short.html" . -}}
+  </div>
+
+  <div class="card__media">
     {{- if .Params.youtube_id -}}
-    <div class="grid-col-12 tablet:grid-col-4 tablet:order-last">
+    <div>
       <div aria-role="img" class="media-featured youtube-player" data-id="{{ .Params.youtube_id }}" data-link="{{ .Permalink }}"></div>
     </div>
     {{- else -}}
-    <div class="non-youtube-event-card grid-col-12 tablet:grid-col-4 tablet:order-last grid-row">
-      <div class="grid-row flex-align-self-center" data-link="{{ .Permalink }}">
-        <svg xmlns="http://www.w3.org/2000/svg" role="img" alt="" aria-hidden="true" height="150" width="150" viewBox="0 0 25 25">
-          <title>Calendar Event</title>
-          <path d="M0 0h24v24H0z" fill="none"/>
-          <path fill="#005ea2" d="M17 12h-5v5h5v-5zM16 1v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2h-1V1h-2zm3 18H5V8h14v11z"/>
-        </svg>
-      </div>
+    <div class="non-youtube-event-card" data-link="{{ .Permalink }}">
+      <svg xmlns="http://www.w3.org/2000/svg" role="img" alt="" aria-hidden="true" height="150" width="150" viewBox="0 0 25 25">
+        <title>Calendar Event</title>
+        <path d="M0 0h24v24H0z" fill="none"/>
+        <path fill="#005ea2" d="M17 12h-5v5h5v-5zM16 1v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2h-1V1h-2zm3 18H5V8h14v11z"/>
+      </svg>
     </div>
     {{- end -}}
-
-    <div class="grid-col-12 tablet:grid-col-8">
-
-      {{- if .Params.kicker -}}
-      <div class="kicker">{{- .Params.kicker -}}</div>
-      {{- else -}}
-        {{- if .Params.youtube_id -}}
-        <div class="kicker">Video</div>
-        {{- end -}}
-      {{- end -}}
-
-      <h3>
-        <a href="{{ .Permalink }}" title="{{ .Title | markdownify }}" rel="bookmark">{{ .Title | markdownify }}</a>
-      </h3>
-      {{- if .Params.summary -}}
-        <div class="deck">{{ .Params.summary | markdownify -}}</div>
-      {{- else -}}
-        <div class="deck">{{ .Params.deck | markdownify -}}</div>
-      {{- end -}}
-
-      {{- partial "core/get_authors_short.html" . -}}
-
-      <div class="meta">
-        <div class="date">{{ dateFormat "Jan 02, 2006" .Date }}</div>
-      </div>
-
-    </div>
-
+  </div>
+  <div class="card__meta">
+    <div class="date">{{ dateFormat "Jan 02, 2006" .Date }}</div>
   </div>
 </article>

--- a/themes/digital.gov/layouts/events/card-event-past.html
+++ b/themes/digital.gov/layouts/events/card-event-past.html
@@ -1,6 +1,16 @@
 {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
-<article class="card card-event card-event-past card-linked {{ if not .Params.youtube_id -}}card-event--no-video{{ end }}" data-edit-this="{{- $path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
+
+{{/*  Unique ID to link article to its title in screen readers  */}}
+{{ $titleID := (printf "%s%s" "title-" .Title) | urlize }}
+
+<article
+  class="card card-event card-event-past card-linked {{ if not .Params.youtube_id -}}card-event--no-video{{ end }}"
+  data-edit-this="{{- $path -}}"
+  {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}
+  aria-labelledby="{{ $titleID }}"
+>
   <div class="card__content">
+
     {{- if .Params.kicker -}}
     <div class="kicker">{{- .Params.kicker -}}</div>
     {{- else -}}
@@ -9,7 +19,7 @@
       {{- end -}}
     {{- end -}}
 
-    <h3>
+    <h3 id="{{ $titleID }}">
       <a href="{{ .Permalink }}" title="{{ .Title | markdownify }}" rel="bookmark">{{ .Title | markdownify }}</a>
     </h3>
     {{- if .Params.summary -}}

--- a/themes/digital.gov/layouts/events/card-event.html
+++ b/themes/digital.gov/layouts/events/card-event.html
@@ -1,11 +1,18 @@
 {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
 
-<article class="card card-event card-event-promo card-linked" data-edit-this="{{- $path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
+{{ $ }}
+
+<article
+  class="card card-event card-event-promo card-linked"
+  data-edit-this="{{- $path -}}"
+  {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}
+  aria-labelledby="{{ .Title | urlize }}"
+>
   <div class="card__content">
     {{- if .Params.kicker -}}
     <div class="kicker">{{- .Params.kicker -}}</div>
     {{- end -}}
-    <h3>
+    <h3 id="{{ .Title | urlize }}">
       <a href="{{ .Permalink }}" title="{{ .Title | markdownify }}" rel="bookmark">{{ .Title | markdownify }}</a>
     </h3>
 

--- a/themes/digital.gov/layouts/events/card-event.html
+++ b/themes/digital.gov/layouts/events/card-event.html
@@ -1,7 +1,5 @@
 {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
 
-{{ $ }}
-
 <article
   class="card card-event card-event-promo card-linked"
   data-edit-this="{{- $path -}}"

--- a/themes/digital.gov/layouts/events/card-event.html
+++ b/themes/digital.gov/layouts/events/card-event.html
@@ -2,7 +2,9 @@
 <article class="card card-event-promo card-linked" data-edit-this="{{- $path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
   <div class="grid-row tablet:grid-gap-4">
 
-    <div class="grid-col-9 tablet-lg:grid-col-10">
+
+<article class="card card-event card-event-promo card-linked" data-edit-this="{{- $path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
+  <div class="card__content">
       {{- if .Params.kicker -}}
       <div class="kicker">{{- .Params.kicker -}}</div>
       {{- end -}}
@@ -20,18 +22,26 @@
       <p class="host">Hosted by Digital.gov and the {{ .Params.host }}</p>
       {{- end -}}
 
-      <a [attr.aria-label]="Register for {{- .Params.title -}}" class="btn btn-register" href="{{- .Params.registration_url -}}" onclick="__gaTracker('send', 'event', 'outbound-article', '{{- .Params.registration_url -}}', 'REGISTER NOW');">Register</a>
+    <a
+      aria-label="Register for {{- .Params.title -}}"
+      class="btn btn-register"
+      href="{{- .Params.registration_url -}}"
+      onclick="__gaTracker('send', 'event', 'outbound-article', '{{- .Params.registration_url -}}', 'REGISTER NOW');">
+        Register
+    </a>
     </div>
 
-    <div class="grid-col-3 tablet-lg:grid-col-2 order-first">
-
+  <div class="card__media">
       <div class="date">
         <span class="date-mo">{{- dateFormat "Jan" .Date -}}</span>
         <span class="date-day">{{- dateFormat "02" .Date -}}</span>
-        <a [attr.aria-label]="Register for {{- .Params.title -}}" class="btn btn-register" href="{{- .Params.registration_url -}}" onclick="__gaTracker('send', 'event', 'outbound-article', '{{- .Params.registration_url -}}', 'REGISTER NOW');">Register</a>
-      </div>
-
+      <a
+        aria-label="Register for {{- .Params.title -}}"
+        class="btn btn-register"
+        href="{{- .Params.registration_url -}}"
+        onclick="__gaTracker('send', 'event', 'outbound-article', '{{- .Params.registration_url -}}', 'REGISTER NOW');">
+          Register
+      </a>
     </div>
   </div>
-
 </article>

--- a/themes/digital.gov/layouts/events/card-event.html
+++ b/themes/digital.gov/layouts/events/card-event.html
@@ -1,5 +1,5 @@
 {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
-<div class="card card-event-promo card-linked" data-edit-this="{{- $path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
+<article class="card card-event-promo card-linked" data-edit-this="{{- $path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
   <div class="grid-row tablet:grid-gap-4">
 
     <div class="grid-col-9 tablet-lg:grid-col-10">
@@ -34,4 +34,4 @@
     </div>
   </div>
 
-</div>
+</article>

--- a/themes/digital.gov/layouts/events/card-event.html
+++ b/themes/digital.gov/layouts/events/card-event.html
@@ -1,26 +1,23 @@
 {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
-<article class="card card-event-promo card-linked" data-edit-this="{{- $path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
-  <div class="grid-row tablet:grid-gap-4">
-
 
 <article class="card card-event card-event-promo card-linked" data-edit-this="{{- $path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
   <div class="card__content">
-      {{- if .Params.kicker -}}
-      <div class="kicker">{{- .Params.kicker -}}</div>
-      {{- end -}}
-      <h3>
-        <a href="{{ .Permalink }}" title="{{ .Title | markdownify }}" rel="bookmark">{{ .Title | markdownify }}</a>
-      </h3>
+    {{- if .Params.kicker -}}
+    <div class="kicker">{{- .Params.kicker -}}</div>
+    {{- end -}}
+    <h3>
+      <a href="{{ .Permalink }}" title="{{ .Title | markdownify }}" rel="bookmark">{{ .Title | markdownify }}</a>
+    </h3>
 
-      {{- if .Params.summary -}}
-      <div class="summary">{{ .Params.summary | markdownify }}</div>
-      {{- else -}}
-      <div class="deck">{{ .Params.deck | markdownify }}</div>
-      {{- end -}}
+    {{- if .Params.summary -}}
+    <div class="summary">{{ .Params.summary | markdownify }}</div>
+    {{- else -}}
+    <div class="deck">{{ .Params.deck | markdownify }}</div>
+    {{- end -}}
 
-      {{- if .Params.host -}}
-      <p class="host">Hosted by Digital.gov and the {{ .Params.host }}</p>
-      {{- end -}}
+    {{- if .Params.host -}}
+    <p class="host">Hosted by Digital.gov and the {{ .Params.host }}</p>
+    {{- end -}}
 
     <a
       aria-label="Register for {{- .Params.title -}}"
@@ -29,12 +26,12 @@
       onclick="__gaTracker('send', 'event', 'outbound-article', '{{- .Params.registration_url -}}', 'REGISTER NOW');">
         Register
     </a>
-    </div>
+  </div>
 
   <div class="card__media">
-      <div class="date">
-        <span class="date-mo">{{- dateFormat "Jan" .Date -}}</span>
-        <span class="date-day">{{- dateFormat "02" .Date -}}</span>
+    <div class="date">
+      <span class="date-mo">{{- dateFormat "Jan" .Date -}}</span>
+      <span class="date-day">{{- dateFormat "02" .Date -}}</span>
       <a
         aria-label="Register for {{- .Params.title -}}"
         class="btn btn-register"

--- a/themes/digital.gov/layouts/news/card-article.html
+++ b/themes/digital.gov/layouts/news/card-article.html
@@ -1,25 +1,26 @@
 {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+
 <article class="card card-article card-linked" data-edit-this="{{- $path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
   <div class="card__content">
-      {{- if .Params.kicker -}}
-      <div class="kicker">{{- .Params.kicker -}}</div>
-      {{- end -}}
-      <h3>
-        <a href="{{- .Permalink -}}">{{- .Title | markdownify -}}</a>
-      </h3>
+    {{- if .Params.kicker -}}
+    <div class="kicker">{{- .Params.kicker -}}</div>
+    {{- end -}}
+    <h3>
+      <a href="{{- .Permalink -}}">{{- .Title | markdownify -}}</a>
+    </h3>
 
-      {{- if .Params.summary -}}
+    {{- if .Params.summary -}}
     <div class="summary">{{ .Params.summary | markdownify }}</div>
-      {{- else -}}
+    {{- else -}}
     <div class="deck">{{ .Params.deck | markdownify }}</div>
-      {{- end -}}
+    {{- end -}}
 
-      {{- partial "core/get_authors_short.html" . -}}
-      </div>
+    {{- partial "core/get_authors_short.html" . -}}
+  </div>
 
   <div class="card__media">
     {{- partial "core/img-featured.html" . -}}
-    </div>
+  </div>
 
   <div class="card__meta">
     <div class="date">{{ dateFormat "Jan 02, 2006" .Date }}</div>

--- a/themes/digital.gov/layouts/news/card-article.html
+++ b/themes/digital.gov/layouts/news/card-article.html
@@ -1,11 +1,20 @@
 {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
 
-<article class="card card-article card-linked" data-edit-this="{{- $path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
+{{/*  Unique ID to link article to its title in screen readers  */}}
+{{ $titleID := (printf "%s%s" "title-" .Title) | urlize }}
+
+<article
+  class="card card-article card-linked"
+  data-edit-this="{{- $path -}}"
+  {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}
+  aria-labelledby="{{ $titleID }}"
+
+>
   <div class="card__content">
     {{- if .Params.kicker -}}
     <div class="kicker">{{- .Params.kicker -}}</div>
     {{- end -}}
-    <h3>
+    <h3 id="{{ $titleID }}">
       <a href="{{- .Permalink -}}">{{- .Title | markdownify -}}</a>
     </h3>
 

--- a/themes/digital.gov/layouts/news/card-article.html
+++ b/themes/digital.gov/layouts/news/card-article.html
@@ -1,11 +1,6 @@
 {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
 <article class="card card-article card-linked" data-edit-this="{{- $path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
-  <div class="grid-row tablet:grid-gap-4">
-    <div class="grid-col-12 tablet:grid-col-4 tablet:order-2">
-      {{- partial "core/img-featured.html" . -}}
-    </div>
-    <div class="grid-col-12 tablet:grid-col-8 tablet:order-1">
-
+  <div class="card__content">
       {{- if .Params.kicker -}}
       <div class="kicker">{{- .Params.kicker -}}</div>
       {{- end -}}
@@ -14,17 +9,19 @@
       </h3>
 
       {{- if .Params.summary -}}
-      <div class="deck">{{ .Params.summary | markdownify }}</div>
+    <div class="summary">{{ .Params.summary | markdownify }}</div>
       {{- else -}}
-      <div class="summary">{{ .Params.deck | markdownify }}</div>
+    <div class="deck">{{ .Params.deck | markdownify }}</div>
       {{- end -}}
 
       {{- partial "core/get_authors_short.html" . -}}
-
-      <div class="meta">
-        <div class="date">{{ dateFormat "Jan 02, 2006" .Date }}</div>
       </div>
+
+  <div class="card__media">
+    {{- partial "core/img-featured.html" . -}}
     </div>
 
+  <div class="card__meta">
+    <div class="date">{{ dateFormat "Jan 02, 2006" .Date }}</div>
   </div>
 </article>

--- a/themes/digital.gov/layouts/news/card-article.html
+++ b/themes/digital.gov/layouts/news/card-article.html
@@ -1,5 +1,5 @@
 {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
-<div class="card card-article card-linked" data-edit-this="{{- $path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
+<article class="card card-article card-linked" data-edit-this="{{- $path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
   <div class="grid-row tablet:grid-gap-4">
     <div class="grid-col-12 tablet:grid-col-4 tablet:order-2">
       {{- partial "core/img-featured.html" . -}}
@@ -27,4 +27,4 @@
     </div>
 
   </div>
-</div>
+</article>

--- a/themes/digital.gov/layouts/news/card-elsewhere.html
+++ b/themes/digital.gov/layouts/news/card-elsewhere.html
@@ -19,18 +19,18 @@
     </div>
   </div>
   <div class="card__media">
-      {{/* Favicon
-      If the there is a custom favicon set in /sources/source_[slug].md, then use that... */}}
-      {{- if $source -}}
-        {{- if $source.Params.logo -}}
-          {{- $src := (printf "/logos/%s%s" $source.Params.logo "-logo.png") -}}
+    {{/* Favicon
+    If the there is a custom favicon set in /sources/source_[slug].md, then use that... */}}
+    {{- if $source -}}
+      {{- if $source.Params.logo -}}
+        {{- $src := (printf "/logos/%s%s" $source.Params.logo "-logo.png") -}}
         <img src="{{ $src | relURL }}" alt="{{- $source.Params.name }} logo">
-        {{- end -}}
+      {{- end -}}
 
-      {{/* Otherwise, use the Favicon that Google stores for the site. */}}
-      {{- else -}}
+    {{/* Otherwise, use the Favicon that Google stores for the site. */}}
+    {{- else -}}
       <img src="https://www.google.com/s2/favicons?domain={{- .Params.source_url -}}" alt="{{- .Params.source }} logo">
-      {{ end }}
+    {{ end }}
   </div>
   <div class="card__meta">
     <p class="date">{{ dateFormat "Jan 02, 2006" .Date }}</p>

--- a/themes/digital.gov/layouts/news/card-elsewhere.html
+++ b/themes/digital.gov/layouts/news/card-elsewhere.html
@@ -32,7 +32,7 @@
       <img src="https://www.google.com/s2/favicons?domain={{- .Params.source_url -}}" alt="{{- .Params.source }} logo">
       {{ end }}
   </div>
-  <div class="card__meta meta">
+  <div class="card__meta">
     <p class="date">{{ dateFormat "Jan 02, 2006" .Date }}</p>
   </div>
 </article>

--- a/themes/digital.gov/layouts/news/card-elsewhere.html
+++ b/themes/digital.gov/layouts/news/card-elsewhere.html
@@ -1,10 +1,18 @@
 {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
 {{- $source := $.Site.GetPage "page" (print "source_" .Params.source ) -}}
 
-<article class="card card-elsewhere card-linked" data-edit-this="{{- $path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
+{{/*  Unique ID to link article to its title in screen readers  */}}
+{{ $titleID := (printf "%s%s" "title-" .Title) | urlize }}
+
+<article
+  class="card card-elsewhere card-linked"
+  data-edit-this="{{- $path -}}"
+  {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}
+  aria-labelledby="{{ $titleID }}"
+>
   <div class="card__content">
     <div class="card__summary">
-      <h3>
+      <h3 id="{{ $titleID }}">
         <a href="{{- .Permalink -}}">{{- .Title | markdownify -}}</a>
       </h3>
       <p>

--- a/themes/digital.gov/layouts/news/card-elsewhere.html
+++ b/themes/digital.gov/layouts/news/card-elsewhere.html
@@ -1,5 +1,5 @@
 {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
-<div class="card card-elsewhere card-linked" data-edit-this="{{- $path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
+<article class="card card-elsewhere card-linked" data-edit-this="{{- $path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
   <div>
     <div class="icon">
       {{/* Favicon
@@ -39,4 +39,4 @@
   <div class="meta">
     <p class="date">{{ dateFormat "Jan 02, 2006" .Date }}</p>
   </div>
-</div>
+</article>

--- a/themes/digital.gov/layouts/news/card-elsewhere.html
+++ b/themes/digital.gov/layouts/news/card-elsewhere.html
@@ -1,42 +1,38 @@
 {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+{{- $source := $.Site.GetPage "page" (print "source_" .Params.source ) -}}
+
 <article class="card card-elsewhere card-linked" data-edit-this="{{- $path -}}" {{ if .Params.short_url }}data-short_url="{{- .Params.short_url -}}"{{ end }}>
-  <div>
-    <div class="icon">
+  <div class="card__content">
+    <div class="card__summary">
+      <h3>
+        <a href="{{- .Permalink -}}">{{- .Title | markdownify -}}</a>
+      </h3>
+      <p>
+        {{- if .Params.deck -}}
+          {{- .Params.deck | markdownify | emojify -}}
+        {{- end -}}
+        {{- if $source -}}
+          {{ $url := urls.Parse .Params.source_url }}
+          <em class="card__source source">— via <a href="{{- if .Params.short_url -}}{{- .Params.short_url -}}{{- else -}}{{- .Params.source_url -}}{{- end -}}" title="Read at {{ $source.Params.name -}}">{{- $source.Params.name -}}</a></em>
+        {{ end }}
+      </p>
+    </div>
+  </div>
+  <div class="card__media">
       {{/* Favicon
       If the there is a custom favicon set in /sources/source_[slug].md, then use that... */}}
-      {{- $source := $.Site.GetPage "page" (print "source_" .Params.source ) -}}
       {{- if $source -}}
         {{- if $source.Params.logo -}}
           {{- $src := (printf "/logos/%s%s" $source.Params.logo "-logo.png") -}}
-          <img src="{{ $src | relURL }}" alt="{{- $source.Params.name -}} logo">
+        <img src="{{ $src | relURL }}" alt="{{- $source.Params.name }} logo">
         {{- end -}}
 
       {{/* Otherwise, use the Favicon that Google stores for the site. */}}
       {{- else -}}
-        <img src="https://www.google.com/s2/favicons?domain={{- .Params.source_url -}}" alt="{{- .Params.source -}} logo">
+      <img src="https://www.google.com/s2/favicons?domain={{- .Params.source_url -}}" alt="{{- .Params.source }} logo">
       {{ end }}
-    </div>
-
-    <div class="summary">
-      <p>
-        <h3>
-          <a href="{{- .Permalink -}}">{{- .Title | markdownify -}}</a>
-        </h3>
-        {{- if .Params.deck -}}{{- .Params.deck | markdownify | emojify -}}{{- end -}}
-        {{- if $source -}}
-          {{ $url := urls.Parse .Params.source_url }}
-          <em class="source">— via <a href="{{- if .Params.short_url -}}{{- .Params.short_url -}}{{- else -}}{{- .Params.source_url -}}{{- end -}}" title="Read at {{ $source.Params.name -}}">{{- $source.Params.name -}}</a></em>
-        {{ end }}
-      </p>
-      {{- if $source -}}
-        {{ $url := urls.Parse .Params.source_url }}
-        <p class="domain"></p>
-      {{ end }}
-
-    </div>
-
   </div>
-  <div class="meta">
+  <div class="card__meta meta">
     <p class="date">{{ dateFormat "Jan 02, 2006" .Date }}</p>
   </div>
 </article>

--- a/themes/digital.gov/layouts/news/list.html
+++ b/themes/digital.gov/layouts/news/list.html
@@ -28,63 +28,57 @@
 
   <section class="stream">
     <div class="grid-container grid-container-desktop">
-      <div class="grid-row">
+      {{/* Blog Posts by Topic —
+      List all of the blog posts tagged with this topic */}}
 
-        <div class="grid-col-12">
-          {{/* Blog Posts by Topic —
-          List all of the blog posts tagged with this topic */}}
+      {{/* Gets the past events */}}
+      {{- $events := where .Site.RegularPages.ByDate.Reverse "Section" "events" -}}
 
-          {{/* Gets the past events */}}
-          {{- $events := where .Site.RegularPages.ByDate.Reverse "Section" "events" -}}
+      {{- $past_events := where (where .Site.RegularPages.ByDate.Reverse "Section" "events") ".Date.Unix" "<" now.Unix -}}
 
-          {{- $past_events := where (where .Site.RegularPages.ByDate.Reverse "Section" "events") ".Date.Unix" "<" now.Unix -}}
+      {{ $all_events := union $past_events $events }}
 
-          {{ $all_events := union $past_events $events }}
+      {{/* Gets the recent blog posts */}}
+      {{- $posts := where .Pages "Section" "news" -}}
 
-          {{/* Gets the recent blog posts */}}
-          {{- $posts := where .Pages "Section" "news" -}}
+      {{/* Merges the past events and the recent blog posts */}}
+      {{ $stream := union $all_events $posts }}
 
-          {{/* Merges the past events and the recent blog posts */}}
-          {{ $stream := union $all_events $posts }}
+      {{/* If there are any items at all... */}}
+      {{- if $stream -}}
 
-          {{/* If there are any items at all... */}}
-          {{- if $stream -}}
+        {{/* Loop through all the pages */}}
+        {{/* Also sorting all the items by date and reverse chron */}}
+        {{- range (.Paginate ( $stream.ByDate.Reverse )).Pages -}}
 
-            {{/* Loop through all the pages */}}
-            {{/* Also sorting all the items by date and reverse chron */}}
-            {{- range (.Paginate ( $stream.ByDate.Reverse )).Pages -}}
+          {{- if eq .Type "events" -}}
+            {{- if ge .Date now.Unix }}
+              {{- .Render "card-event" -}}
+            {{- else -}}
+              {{- .Render "card-event-past" -}}
+            {{- end -}}
+          {{- end -}}
 
-              {{- if eq .Type "events" -}}
-                {{- if ge .Date now.Unix }}
-                  {{- .Render "card-event" -}}
-                {{- else -}}
-                  {{- .Render "card-event-past" -}}
-                {{- end -}}
-              {{- end -}}
-
-              {{- if eq .Type "news" -}}
-                {{/* External links */}}
-                {{- if .Params.source -}}
-                  {{/* see /layouts/news/ for card templates */}}
-                  {{ .Render "card-elsewhere"}}
-                {{ else }}
-                  {{/* Blog Posts — Internal links */}}
-                  {{- if .Params.deck }}
-                    {{/* see /layouts/news/ for card templates */}}
-                    {{ .Render "card-article"}}
-                  {{ else }}
-                    {{/* see /layouts/news/ for card templates */}}
-                    {{ .Render "card-article"}}
-                  {{ end }}
-                {{ end }}
-              {{- end -}}
-
+          {{- if eq .Type "news" -}}
+            {{/* External links */}}
+            {{- if .Params.source -}}
+              {{/* see /layouts/news/ for card templates */}}
+              {{ .Render "card-elsewhere"}}
+            {{ else }}
+              {{/* Blog Posts — Internal links */}}
+              {{- if .Params.deck }}
+                {{/* see /layouts/news/ for card templates */}}
+                {{ .Render "card-article"}}
+              {{ else }}
+                {{/* see /layouts/news/ for card templates */}}
+                {{ .Render "card-article"}}
+              {{ end }}
             {{ end }}
-          {{ end }}
-          {{ partial "core/pagination.html" . }}
-        </div>
+          {{- end -}}
 
-      </div>
+        {{ end }}
+      {{ end }}
+      {{ partial "core/pagination.html" . }}
     </div>
   </section>
 </main>

--- a/themes/digital.gov/layouts/partials/core/home/news_featured.html
+++ b/themes/digital.gov/layouts/partials/core/home/news_featured.html
@@ -88,22 +88,17 @@
           {{- end -}}
 
         {{- end -}}
-      </section>
 
-      <div class="grid-row">
-        <div class="grid-col-12 tablet:grid-col-8 tablet:grid-offset-2">
-          <footer>
-            <a class="btn" href="{{- "news" | absURL -}}" title="">
+        <footer>
+            <a class="btn" href="{{- "news" | absURL -}}" title="View news and updates page">
               <span>See all News</span>
               <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false" role="img">
                 <use xlink:href="{{ "uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
               </svg>
             </a>
-            <p>Have a case study to share? Did your team recently launch something?<br/><a href="{{- "contribute" | absURL -}}" title="Learn how you can contribute"><strong>Learn how you can contribute</strong></a></p>
+            <p>Have a case study to share? Did your team recently launch something?<br/><a href="{{- "contribute" | absURL -}}" title="Contribute to Digital.gov"><strong>Learn how you can contribute</strong></a></p>
           </footer>
-        </div>
-      </div>
-
+      </section>
     </div>
   </div>
 </section>

--- a/themes/digital.gov/layouts/partials/core/home/news_featured.html
+++ b/themes/digital.gov/layouts/partials/core/home/news_featured.html
@@ -11,7 +11,7 @@
             <p>Innovative work, news, and ideas from people and teams in government</p>
 
             <div class="join-buttons">
-              <a href="{{- "/join" | absURL -}}">Write for us</a>
+              <a href="{{- "/join" | relURL -}}">Write for us</a>
             </div>
 
           </header>
@@ -90,14 +90,14 @@
         {{- end -}}
 
         <footer>
-            <a class="btn" href="{{- "news" | absURL -}}" title="View news and updates page">
-              <span>See all News</span>
-              <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false" role="img">
-                <use xlink:href="{{ "uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
-              </svg>
-            </a>
-            <p>Have a case study to share? Did your team recently launch something?<br/><a href="{{- "contribute" | absURL -}}" title="Contribute to Digital.gov"><strong>Learn how you can contribute</strong></a></p>
-          </footer>
+          <a class="btn" href="{{- "news" | relURL -}}" title="View news and updates page">
+            <span>See all News</span>
+            <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false" role="img">
+              <use xlink:href="{{ "uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
+            </svg>
+          </a>
+          <p>Have a case study to share? Did your team recently launch something?<br/><a href="{{- "contribute" | relURL -}}" title="Contribute to Digital.gov"><strong>Learn how you can contribute</strong></a></p>
+        </footer>
       </section>
     </div>
   </div>

--- a/themes/digital.gov/layouts/partials/core/home/news_featured.html
+++ b/themes/digital.gov/layouts/partials/core/home/news_featured.html
@@ -18,83 +18,77 @@
         </div>
       </div>
 
-      <div class="grid-row">
-        <div class="grid-col-12">
+      <section class="stream" aria-label="Featured news and events">
 
-          <section class="stream">
+        {{/* Future Events ===========================  */}}
+        {{- $events := where .Site.RegularPages.Reverse "Section" "events" -}}
 
-            {{/* Future Events ===========================  */}}
-            {{- $events := where .Site.RegularPages.Reverse "Section" "events" -}}
+        {{/* gets the # of news items to display from the config.yml */}}
+        {{- $events_count := .Site.Params.events_count -}}
 
-            {{/* gets the # of news items to display from the config.yml */}}
-            {{- $events_count := .Site.Params.events_count -}}
+        {{- $events := $events | intersect (where $events "Date" "ge" (now.AddDate 0 0 0)) | first 2 -}}
 
-            {{- $events := $events | intersect (where $events "Date" "ge" (now.AddDate 0 0 0)) | first 2 -}}
+        {{/* Past Events =========================== */}}
+        {{- $past_events := where (where .Site.RegularPages.ByDate.Reverse "Section" "events") ".Date.Unix" "<" now.Unix -}}
 
-            {{/* Past Events =========================== */}}
-            {{- $past_events := where (where .Site.RegularPages.ByDate.Reverse "Section" "events") ".Date.Unix" "<" now.Unix -}}
+        {{/* News Posts =========================== */}}
+        {{/* Gets the recent blog posts */}}
+        {{- $posts := where .Site.RegularPages.ByDate.Reverse "Section" "news" -}}
 
-            {{/* News Posts =========================== */}}
-            {{/* Gets the recent blog posts */}}
-            {{- $posts := where .Site.RegularPages.ByDate.Reverse "Section" "news" -}}
+        {{/* Merges the past events and the recent blog posts */}}
+        {{ $stream := union $posts $past_events }}
+        {{/* {{ $stream := union $posts $events }} */}}
 
-            {{/* Merges the past events and the recent blog posts */}}
-            {{ $stream := union $posts $past_events }}
-            {{/* {{ $stream := union $posts $events }} */}}
+        {{/* Sorting all the items by date and reverse chron */}}
+        {{ $stream := $stream.ByDate.Reverse }}
+        {{/* $stream := $stream.ByWeight */}}
 
-            {{/* Sorting all the items by date and reverse chron */}}
-            {{ $stream := $stream.ByDate.Reverse }}
-            {{/* $stream := $stream.ByWeight */}}
+        {{/* gets the # of news items to display from the config.yml */}}
+        {{ $stream_count := .Site.Params.stream_count }}
 
-            {{/* gets the # of news items to display from the config.yml */}}
-            {{ $stream_count := .Site.Params.stream_count }}
+        {{/* Gets the first X items for the news stream */}}
+        {{/* The # is defined in the config.yml file */}}
+        {{- range $i, $el := first $stream_count $stream -}}
 
-            {{/* Gets the first X items for the news stream */}}
-            {{/* The # is defined in the config.yml file */}}
-            {{- range $i, $el := first $stream_count $stream -}}
-
-              {{- with $events -}}
-                {{- if eq $i 2 -}}
-                  {{- range first 1 $events -}}
-                    {{- .Render "card-event" -}}
-                  {{- end -}}
-                {{- end -}}
-
-                {{- if eq $i 8 -}}
-                  {{- range first 1 (after 1 $events) -}}
-                    {{- .Render "card-event" -}}
-                  {{- end -}}
-                {{- end -}}
+          {{- with $events -}}
+            {{- if eq $i 2 -}}
+              {{- range first 1 $events -}}
+                {{- .Render "card-event" -}}
               {{- end -}}
-
-              {{- if eq .Type "events" -}}
-                {{- if .Date.Before now -}}
-                  {{- .Render "card-event-past" -}}
-                {{- end -}}
-              {{- end -}}
-
-              {{- if eq .Type "news" -}}
-                {{/* External links */}}
-                {{- if .Params.source -}}
-                  {{/* see /layouts/news/ for card templates */}}
-                  {{ .Render "card-elsewhere"}}
-                {{ else }}
-                  {{/* Blog Posts — Internal links */}}
-                  {{- if .Params.deck }}
-                    {{/* see /layouts/news/ for card templates */}}
-                    {{ .Render "card-article"}}
-                  {{ else }}
-                    {{/* see /layouts/news/ for card templates */}}
-                    {{ .Render "card-article"}}
-                  {{ end }}
-                {{ end }}
-              {{- end -}}
-
             {{- end -}}
-          </section>
 
-        </div>
-      </div>
+            {{- if eq $i 8 -}}
+              {{- range first 1 (after 1 $events) -}}
+                {{- .Render "card-event" -}}
+              {{- end -}}
+            {{- end -}}
+          {{- end -}}
+
+          {{- if eq .Type "events" -}}
+            {{- if .Date.Before now -}}
+              {{- .Render "card-event-past" -}}
+            {{- end -}}
+          {{- end -}}
+
+          {{- if eq .Type "news" -}}
+            {{/* External links */}}
+            {{- if .Params.source -}}
+              {{/* see /layouts/news/ for card templates */}}
+              {{ .Render "card-elsewhere"}}
+            {{ else }}
+              {{/* Blog Posts — Internal links */}}
+              {{- if .Params.deck }}
+                {{/* see /layouts/news/ for card templates */}}
+                {{ .Render "card-article"}}
+              {{ else }}
+                {{/* see /layouts/news/ for card templates */}}
+                {{ .Render "card-article"}}
+              {{ end }}
+            {{ end }}
+          {{- end -}}
+
+        {{- end -}}
+      </section>
 
       <div class="grid-row">
         <div class="grid-col-12 tablet:grid-col-8 tablet:grid-offset-2">

--- a/themes/digital.gov/src/scss/new/_card-article.scss
+++ b/themes/digital.gov/src/scss/new/_card-article.scss
@@ -1,3 +1,5 @@
 @use "uswds-core" as *;
 
-.card{}
+.card-article {
+
+}

--- a/themes/digital.gov/src/scss/new/_card-elsewhere.scss
+++ b/themes/digital.gov/src/scss/new/_card-elsewhere.scss
@@ -1,6 +1,6 @@
 @use "uswds-core" as *;
 
-.card-elsewhere {
+.card.card-elsewhere {
   grid-template-areas:
     "c-media c-content"
     "c-meta c-meta";

--- a/themes/digital.gov/src/scss/new/_card-elsewhere.scss
+++ b/themes/digital.gov/src/scss/new/_card-elsewhere.scss
@@ -1,13 +1,10 @@
 @use "uswds-core" as *;
 
 .card-elsewhere {
-
-  @include at-media("tablet") {
-    grid-template-areas:
-      "c-media c-content"
-      "c-meta c-meta";
-    grid-template-columns: #{units(7)} 1fr;
-  }
+  grid-template-areas:
+    "c-media c-content"
+    "c-meta c-meta";
+  grid-template-columns: #{units(7)} 1fr;
 
   .card__summary {
     @include u-margin-top(0);
@@ -19,6 +16,7 @@
       @include u-text("normal");
     }
   }
+
   .card__source {
     @include u-margin-top("05");
     @include u-display("block");
@@ -48,5 +46,9 @@
         @include u-circle(7);
       }
     }
+  }
+
+  .card__meta {
+    grid-area: c-meta;
   }
 }

--- a/themes/digital.gov/src/scss/new/_card-elsewhere.scss
+++ b/themes/digital.gov/src/scss/new/_card-elsewhere.scss
@@ -1,13 +1,12 @@
 @use "uswds-core" as *;
 
 .card-elsewhere {
-  display: flex;
-  flex-flow: row wrap;
-  gap: units("105"); // Vertical spacing on mobile and horizontal on desktop
 
-  .card__content {
-    flex-grow: 1;
-    flex-basis: 80%;
+  @include at-media("tablet") {
+    grid-template-areas:
+      "c-media c-content"
+      "c-meta c-meta";
+    grid-template-columns: #{units(7)} 1fr;
   }
 
   .card__summary {
@@ -40,11 +39,6 @@
 
   .card__media {
     @include u-square(7);
-    @include at-media("mobile-lg") {
-      @include u-square(7);
-    }
-    flex-grow: 0;
-    flex-shrink: 0;
     order: -1;
 
     img {
@@ -54,9 +48,5 @@
         @include u-circle(7);
       }
     }
-  }
-
-  .card__meta {
-    width: 100%;
   }
 }

--- a/themes/digital.gov/src/scss/new/_card-elsewhere.scss
+++ b/themes/digital.gov/src/scss/new/_card-elsewhere.scss
@@ -10,10 +10,10 @@
     @include u-margin-top(0);
 
     p {
-      @include u-measure(5);
       @include u-line-height("sans", 3);
       @include u-font("sans", "md");
       @include u-text("normal");
+      max-width: none;
     }
   }
 

--- a/themes/digital.gov/src/scss/new/_card-elsewhere.scss
+++ b/themes/digital.gov/src/scss/new/_card-elsewhere.scss
@@ -1,58 +1,62 @@
 @use "uswds-core" as *;
 
 .card-elsewhere {
-  & > div {
-    @include u-display("flex");
-    @include u-flex("justify-start");
-    @include u-flex("align-start");
+  display: flex;
+  flex-flow: row wrap;
+  gap: units("105"); // Vertical spacing on mobile and horizontal on desktop
+
+  .card__content {
+    flex-grow: 1;
+    flex-basis: 80%;
   }
 
-  .icon {
-    @include u-margin-right(1);
-    @include u-square(7);
-    @include at-media("mobile-lg") {
-      @include u-square(7);
-    }
-    img {
-      @include u-circle(7);
-      @include at-media("mobile-lg") {
-        @include u-circle(7);
-      }
-      @include u-border("1px", "gray-cool-10", "solid");
-    }
-  }
-  .summary {
+  .card__summary {
     @include u-margin-top(0);
-    flex: 1;
+
     p {
       @include u-measure(5);
       @include u-line-height("sans", 3);
       @include u-font("sans", "md");
       @include u-text("normal");
     }
-    .source {
-      @include u-margin-top("05");
-      @include u-display("block");
-      a {
-        @include u-color("blue-50v");
-        &::after {
-          content: "";
-          @include u-position("absolute");
-          @include u-top(0);
-          @include u-left(0);
-          @include u-right(0);
-          @include u-bottom(0);
-        }
+  }
+  .card__source {
+    @include u-margin-top("05");
+    @include u-display("block");
+
+    a {
+      @include u-color("blue-50v");
+
+      &::after {
+        content: "";
+        @include u-position("absolute");
+        @include u-top(0);
+        @include u-left(0);
+        @include u-right(0);
+        @include u-bottom(0);
       }
     }
   }
-  .domain {
-    @include u-margin-top("05");
-    @include u-font("sans", "2xs");
-    @include u-color("gray-60");
-    @include u-text("italic");
-    a {
-      @include u-color("gray-60");
+
+  .card__media {
+    @include u-square(7);
+    @include at-media("mobile-lg") {
+      @include u-square(7);
     }
+    flex-grow: 0;
+    flex-shrink: 0;
+    order: -1;
+
+    img {
+      @include u-border("1px", "gray-cool-10", "solid");
+      @include u-circle(7);
+      @include at-media("mobile-lg") {
+        @include u-circle(7);
+      }
+    }
+  }
+
+  .card__meta {
+    width: 100%;
   }
 }

--- a/themes/digital.gov/src/scss/new/_card-event.scss
+++ b/themes/digital.gov/src/scss/new/_card-event.scss
@@ -102,8 +102,4 @@
 // ==========================================================================
 .card-event-past {
   border-top: none;
-
-  .non-youtube-event-card {
-    opacity: 0.8;
-  }
 }

--- a/themes/digital.gov/src/scss/new/_card-event.scss
+++ b/themes/digital.gov/src/scss/new/_card-event.scss
@@ -1,79 +1,107 @@
 @use "uswds-core" as *;
 
-.card-event-promo{
-	@include u-border-top('2px', 'primary-darker', 'solid');
+.card-event {
+  @include u-border-top("2px", "primary-darker", "solid");
+  column-gap: units("205"); // Gives border consistent spacing on both sides
 
-	.date{
-		@include u-margin(0);
-		@include u-padding-right(0);
-		@include at-media('tablet') {
-			@include u-padding-right('205');
-			@include u-border-right('1px', 'indigo-warm-80', 'solid');
-		}
-		span{
-			@include u-display('block');
-			@include u-text('center');
-			@include u-text('medium');
-		}
-		.date-mo{
-			@include u-text('uppercase');
-			@include u-font('sans', 'sm');
-			@include u-text('bold');
-			@include at-media('tablet') {
-				@include u-text('medium');
-			}
-		}
-		.date-day{
-			@include u-margin-bottom('05');
-			@include u-font('sans', '2xl');
-			@include u-text('thin');
-			@include u-line-height('sans', 1);
-			@include at-media('tablet') {
-				@include u-font('sans', '3xl');
-			}
-		}
-		.btn-register{
-			@include u-display('none');
-			@include at-media('tablet') {
-				@include u-display('block');
-			}
-		}
-	}
-	.btn-register{
-		@include u-padding-y(0);
-		@include u-padding-x(0);
-		@include u-font('sans', 'sm');
-		@include u-display('block');
-		@include u-radius('sm');
-		@include u-bg('white');
-		@include u-text('primary-vivid');
-		@include u-text('center');
-		@include u-border('2px', 'primary-vivid', 'solid');
-		transition: background-color .25s, color .25s;
-		@include at-media('tablet') {
-			@include u-display('none');
-		}
-	}
-	&:hover{
-		.btn-register{
-			@include u-bg('primary-vivid');
-			@include u-text('white');
-		}
-	}
+  .date {
+    @include u-margin(0);
+    @include u-padding-right(0);
+    @include at-media("tablet") {
+      @include u-padding-right("205");
+    }
+    span {
+      @include u-display("block");
+      @include u-text("center");
+      @include u-text("medium");
+    }
+    .date-mo {
+      @include u-text("uppercase");
+      @include u-font("sans", "sm");
+      @include u-text("bold");
+      @include at-media("tablet") {
+        @include u-text("medium");
+      }
+    }
+    .date-day {
+      @include u-margin-bottom("05");
+      @include u-font("sans", "2xl");
+      @include u-text("thin");
+      @include u-line-height("sans", 1);
+      @include at-media("tablet") {
+        @include u-font("sans", "3xl");
+      }
+    }
+    .btn-register {
+      @include u-display("none");
+      @include at-media("tablet") {
+        @include u-display("block");
+      }
+    }
+  }
+  .btn-register {
+    @include u-padding-y(0);
+    @include u-padding-x(0);
+    @include u-font("sans", "sm");
+    @include u-display("block");
+    @include u-radius("sm");
+    @include u-bg("white");
+    @include u-text("primary-vivid");
+    @include u-text("center");
+    @include u-border("2px", "primary-vivid", "solid");
+    transition: background-color 0.25s, color 0.25s;
+    @include at-media("tablet") {
+      @include u-display("none");
+    }
+  }
+  &:hover {
+    .btn-register {
+      @include u-bg("primary-vivid");
+      @include u-text("white");
+    }
+  }
 
-	.host{
-		@include u-margin-y('105');
-		@include u-text('gray-cool-60');
-		@include u-font('sans', 'xs');
-		@include at-media('tablet-lg') {
-			@include u-font('sans', 'sm');
-		}
-		@include u-line-height('sans', 2);
-	}
-	.time{
-		@include u-font('sans', 'md');
-		@include u-text('bold');
-		@include u-text('red-cool-40v');
-	}
+  .host {
+    @include u-margin-y("105");
+    @include u-text("gray-cool-60");
+    @include u-font("sans", "xs");
+    @include at-media("tablet-lg") {
+      @include u-font("sans", "sm");
+    }
+    @include u-line-height("sans", 2);
+  }
+  .time {
+    @include u-font("sans", "md");
+    @include u-text("bold");
+    @include u-text("red-cool-40v");
+  }
+}
 
+
+// ==========================================================================
+// Variants
+// ==========================================================================
+
+//
+// Upcoming events
+// ==========================================================================
+.card-event-promo {
+  grid-template-areas:
+  "c-date c-content"
+  "c-meta c-meta" !important;
+  grid-template-columns: 1fr 5fr !important;
+
+  .card__media {
+    @include u-border-right("1px", "indigo-warm-80", "solid");
+    grid-area: c-date !important;
+  }
+}
+
+//
+// Past events
+// ==========================================================================
+.card-event-past {
+  .non-youtube-event-card {
+    opacity: 0.8;
+  }
 }

--- a/themes/digital.gov/src/scss/new/_card-event.scss
+++ b/themes/digital.gov/src/scss/new/_card-event.scss
@@ -101,6 +101,8 @@
 // Past events
 // ==========================================================================
 .card-event-past {
+  border-top: none;
+
   .non-youtube-event-card {
     opacity: 0.8;
   }

--- a/themes/digital.gov/src/scss/new/_card-service-contact.scss
+++ b/themes/digital.gov/src/scss/new/_card-service-contact.scss
@@ -56,7 +56,7 @@
         }
       }
     }
-    .summary{
+    .card__summary{
       @include u-margin-y('105');
       @include u-font('sans', 'xs');
       @include at-media('tablet') {

--- a/themes/digital.gov/src/scss/new/_card-service-contact.scss
+++ b/themes/digital.gov/src/scss/new/_card-service-contact.scss
@@ -1,90 +1,90 @@
 @use "uswds-core" as *;
 
-.card.card-service-contact{
+.card.card-service-contact {
   @include u-margin-bottom(0);
-  @include u-padding-y('105');
-  @include u-font('sans', '2xs');
-  @include u-line-height('sans', 3);
-  .copy{
-    @include u-display('flex');
-    @include u-flex('align-start');
+  @include u-padding-y("105");
+  @include u-font("sans", "2xs");
+  @include u-line-height("sans", 3);
+  .copy {
+    @include u-display("flex");
+    @include u-flex("align-start");
 
-    p{
+    p {
       @include u-margin-top(0);
       @include u-margin-left(3);
-      @include at-media('tablet') {
+      @include at-media("tablet") {
         @include u-margin-left(0);
       }
     }
 
-    div{
+    div {
       flex: 1;
     }
-    .icon{
+    .icon {
       flex: none;
-      img{
+      img {
         @include u-margin-right(1);
         @include u-width(2);
-        @include u-position('relative');
-        @include u-top('2px');
+        @include u-position("relative");
+        @include u-top("2px");
       }
     }
 
-    h3{
-      @include u-font('sans', 'sm');
-      @include u-line-height('sans', 3);
-      a{
-        @include u-text('no-underline', !important);
-        @include u-text('medium');
-        &:hover{
-          span{
-            @include u-border-bottom('1px', 'blue-warm-70v', 'solid');
+    h3 {
+      @include u-font("sans", "sm");
+      @include u-line-height("sans", 3);
+      a {
+        @include u-text("no-underline", !important);
+        @include u-text("medium");
+        &:hover {
+          span {
+            @include u-border-bottom("1px", "blue-warm-70v", "solid");
           }
         }
       }
     }
-    .source_url{
-      @include u-margin-top('2px');
+    .source_url {
+      @include u-margin-top("2px");
       @include u-margin-left(0);
-      @include u-font('sans', '3xs');
-      @include u-line-height('sans', 2);
-      a{
-        @include u-text('base-dark');
-        @include u-text('no-underline');
-        &:hover{
-          @include u-text('underline');
+      @include u-font("sans", "3xs");
+      @include u-line-height("sans", 2);
+      a {
+        @include u-text("base-dark");
+        @include u-text("no-underline");
+        &:hover {
+          @include u-text("underline");
         }
       }
     }
-    .card__summary{
-      @include u-margin-y('105');
-      @include u-font('sans', 'xs');
-      @include at-media('tablet') {
+    .summary {
+      @include u-margin-y("105");
+      @include u-font("sans", "xs");
+      @include at-media("tablet") {
         @include u-margin-y(0);
       }
     }
-    .authors-list-short{
+    .authors-list-short {
       @include u-margin(0);
     }
   }
-  .copy-contacts{
+  .copy-contacts {
     @include u-margin-left(3);
-    @include at-media('tablet') {
+    @include at-media("tablet") {
       @include u-margin-left(0);
     }
-    @include u-display('flex');
-    @include u-flex('align-start');
-    .contact{
+    @include u-display("flex");
+    @include u-flex("align-start");
+    .contact {
       @include u-margin-top(1);
-      @include u-margin-right('105');
-      @include at-media('tablet') {
+      @include u-margin-right("105");
+      @include at-media("tablet") {
         @include u-margin-right(2);
       }
-      @include u-text('black');
-      @include u-text('no-underline');
-      &:hover{
-        span{
-          @include u-border-bottom('1px','black','solid');
+      @include u-text("black");
+      @include u-text("no-underline");
+      &:hover {
+        span {
+          @include u-border-bottom("1px", "black", "solid");
         }
       }
     }

--- a/themes/digital.gov/src/scss/new/_card.scss
+++ b/themes/digital.gov/src/scss/new/_card.scss
@@ -37,7 +37,7 @@
       }
     }
   }
-  .summary,
+  .card__summary,
   .deck {
     @include u-margin-top(1);
     @include u-line-height("sans", 3);

--- a/themes/digital.gov/src/scss/new/_card.scss
+++ b/themes/digital.gov/src/scss/new/_card.scss
@@ -7,11 +7,43 @@
   @include u-padding("105");
   @include u-padding-bottom(2);
   @include u-bg("white");
+  display: grid;
   transition: background-color 0.2s;
+  gap: units("105"); // Vertical spacing on mobile and horizontal on desktop
+
   @include at-media("tablet") {
     @include u-margin-bottom(1);
     @include u-padding("205");
+    grid-template-areas:
+      "c-content c-media"
+      "c-meta c-meta";
+    grid-template-columns: 2fr 1fr;
   }
+
+  &__content {
+    @include at-media("tablet") {
+      grid-area: c-content;
+    }
+  }
+
+  &__media {
+    order: -1;
+
+    @include at-media("tablet") {
+      grid-area: c-media;
+    }
+    @include at-media("tablet-lg") {
+      order: unset;
+    }
+  }
+
+  &__meta {
+    @include at-media("tablet") {
+      grid-area: c-meta;
+    }
+  }
+
+
   .kicker {
     @include u-margin(0);
     @include u-margin-bottom("05");
@@ -45,7 +77,7 @@
     @include u-text("normal");
   }
 
-  .meta {
+  .card__meta {
     @include u-margin-top("105");
     @include u-display("flex");
     @include at-media("tablet-lg") {


### PR DESCRIPTION
## Description

This PR implements the following **changes:**

* **Improved experience for screen readers.** Moved image _after_ text in markup so screen readers can read content before image (still keeps same visual style as on live site). [Trello ticket - Adjust news page mark-up so that image follows H3]
* **News & Updates markup refactor.** Simplified markup and removed unnecessary grid containers for news & updates on home and landing pages.
* **Cards use semantic markup.** Cards now use `<article>` element instead of a generic `div`.



### Card elsewhere

Mobile screenshots taken at 500px.

#### Before

![image](https://user-images.githubusercontent.com/3385219/198302983-dff4fd3d-b600-4c92-8324-a14fb8951e72.png)

#### After

![image](https://user-images.githubusercontent.com/3385219/198324881-750898cc-9b1b-43f5-964c-6121db31a591.png)

#### Before

Tested in 1000px.

![image](https://user-images.githubusercontent.com/3385219/198326995-72ca2880-c131-4d37-818a-b2ffdb17b273.png)

#### After

Slightly increased spacing between logo and section. USWDS spacing token was used to ensure consistency. 

![image](https://user-images.githubusercontent.com/3385219/198326856-3e4fa009-f321-4ee4-936f-b8b7ff328db5.png)

### Card article

**Before**
Tested in 500px.
![image](https://user-images.githubusercontent.com/3385219/198327694-24401581-a25d-4980-a5a9-bd5be824af9a.png)

**After**
![image](https://user-images.githubusercontent.com/3385219/198327517-75cc602c-d8cf-44f9-86f1-8dcaa0591948.png)

**Before**
![image](https://user-images.githubusercontent.com/3385219/198327897-1298fdf9-b328-4463-81b5-a588f18a14ee.png)

**After**
![image](https://user-images.githubusercontent.com/3385219/198327324-4c471afd-4c5b-43dc-8ba3-7168b971334e.png)

### Card event

**Before**
Taken from wayback machine url from [Oct. 17, 2022](https://web.archive.org/web/20221017000438/https://digital.gov/).
![image](https://user-images.githubusercontent.com/3385219/198330738-3d71395b-a608-4231-973f-6d80046b247a.png)


**After**
We can now improve separation of date from content thanks to CSS grid. The border now spans the full height.
![image](https://user-images.githubusercontent.com/3385219/198330398-ce84fd9f-0f25-428e-aeca-4cb4f6b0efd9.png)

**Before**

![image](https://user-images.githubusercontent.com/3385219/198331092-8a270274-612a-4e7e-b361-48ea73f063bc.png)

**After**
Spacing on date|content separator is now consistent on **both** sides.
![image](https://user-images.githubusercontent.com/3385219/198331227-fd16dfd8-13fb-4a5d-b462-18b7ab7993bc.png)


### Card event past

**Before**
![image](https://user-images.githubusercontent.com/3385219/198329178-7fc6d3e7-ca3f-4cd6-ba3d-3b986164bace.png)

**After**
![image](https://user-images.githubusercontent.com/3385219/198329630-47b539e5-d106-443a-9ecb-d623a239a211.png)


**Before**
![image](https://user-images.githubusercontent.com/3385219/198329357-86caf412-af1f-4863-91f3-6bd6d0586b77.png)

**After**
Image was increased so that it's an even 300px, instead of 293 +/-. The opacity is slightly lower to emphasize it's a past event and I didn't want to stray too far from live styles.
![image](https://user-images.githubusercontent.com/3385219/198329521-d2328919-66d2-4dab-94fd-166b03e2de02.png)


## Additional information

**Other**
* Set shared layout styles for generic cards that you can override on more specific types (e.g. events)
* Added BEM-style classes for easier and more consistent styling.
* Improved inner spacing for both mobile and desktop.


**URL / Link to page**

Pages where card styles appear (that I'm aware of).

- [Homepage](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/jm-a11y-news-page-image-h3/)
- [News and Updates](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/jm-a11y-news-page-image-h3/news/)
- [Events](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/jm-a11y-news-page-image-h3/events/)
- [Topics](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/jm-a11y-news-page-image-h3/topics/plain-language/) [🌟 added 10-31-22] 
- [Additional topics](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/jm-a11y-news-page-image-h3/topics/plain-language/page/2/) [🌟 added 10-31-22] 


## How to test

View URLs for Homepage, News and Updates, and Events in previous section. 

- There should be 0 visual regressions on mobile & desktop
- Images should follow content in markup order

<!-- Link to the page that will be changed -->
<!-- Delete this section if not needed -->

