### PR TITLE
Update start and end times for transcript post

### DIFF
--- a/themes/digital.gov/static/workflow/config.yml
+++ b/themes/digital.gov/static/workflow/config.yml
@@ -982,13 +982,20 @@ collections:
         search_fields: ["slug", "title"]
         multiple: false
         required: true
-      - label: "Event Date"
-        name: "event date"
+      - label: "Start Date/Time"
+        name: "date"
         widget: "datetime"
         dateFormat: "YYYY-MM-DD" # e.g. 2021-11.23
         timeFormat: "HH:mm" # e.g. 21:00
         format: "YYYY-MM-DD HH:mm:00 -0500"
         hint: "The start date and time of the event (Note: uses a 24hr clock, e.g. 13:00)"
+      - label: "End time"
+        name: "end_date"
+        widget: "datetime"
+        dateFormat: "YYYY-MM-DD" # e.g. 2021-11.23
+        timeFormat: "HH:mm" # e.g. 21:00
+        format: "YYYY-MM-DD HH:mm:00 -0500"
+        hint: "The end date and time of the event (Note: uses a 24hr clock, e.g. 14:00)"
       - label: "Topics"
         name: "topics"
         widget: "relation"


### PR DESCRIPTION
## Summary

`transcript` uses the same template as `event` but was missing the **start** and **end** time, instead it just had an **event date**.

`transcript` now requires a start and end time to build successfully. 
resolves #5524 with testing a new transcript https://github.com/GSA/digitalgov.gov/pull/5528