### PR TITLE
Fix JS console error that's breaking YouTube thumbnails

### DIFF
--- a/themes/digital.gov/src/js/common/subscribe.js
+++ b/themes/digital.gov/src/js/common/subscribe.js
@@ -1,8 +1,14 @@
-// scroll form into view when on /subscribe page
-const subscribeButton = document.querySelector(".subscribe-button");
-const signupForm = document.querySelector("#newsletter-signup");
+/**
+ * Scroll form into view when on the `/subscribe` page.
+ */
 
-subscribeButton.addEventListener("click", function() {
-  signupForm.scrollIntoView({behavior: "smooth", block: "start"})
-  signupForm.focus();
-})
+const subscribeButton = document.querySelector(".subscribe-button");
+
+if (subscribeButton) {
+  const signupForm = document.querySelector("#newsletter-signup");
+
+  subscribeButton.addEventListener("click", function() {
+    signupForm.scrollIntoView({behavior: "smooth", block: "start"})
+    signupForm.focus();
+  });
+}


### PR DESCRIPTION
This PR implements the following **changes:**

* **YouTube thumbnails render properly.** Subscribe button JS now only runs if the subscribe button exists. 
  Closes trello ticket.

**Before**
![image](https://user-images.githubusercontent.com/3385219/199080332-533eed11-fe5e-45dc-a08a-7738c65e6cd6.png)

**After**

Error is gone on `/events` pages and button on subscribe page **still** works as expected.
![image](https://user-images.githubusercontent.com/3385219/199082113-1325d58b-5c76-4647-9532-0922ce7c7fa0.png)

Subscribe button still functions on `about/` page.
[jm-youtube-thumbnail-bug 2022-10-31 at 13.28.40.webm](https://user-images.githubusercontent.com/3385219/199083770-756c7aea-cd9d-4143-83b3-b8157825f6dc.webm)



**URL / Link to page**

- [Events](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/jm-youtube-thumbnail-bug/events/)
- [Subscribe page](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/jm-youtube-thumbnail-bug/about/subscribe/)
