### PR TITLE
Transcript post updates 

### DIFF
--- a/themes/digital.gov/static/workflow/config.yml
+++ b/themes/digital.gov/static/workflow/config.yml
@@ -956,12 +956,12 @@ collections:
         comment: "Enter the path of the URL that you want redirected to this page"
         field: { label: Redirect, name: redirect, widget: string }
 
-  # TRANSCRIPT =======================
+  # TRANSCRIPTS =======================
   - <<: *defaults
-    name: "transcript"
+    name: "event transcript"
     label: "Transcript"
-    label_singular: "transcript page"
-    description: "This page will create a transcript only page for reading"
+    label_singular: "Transcript"
+    description: "This page will create an event transcript"
     folder: "content/events"
     summary: "{{title}} ({{year}}-{{month}}-{{day}})"
     path: "{{year}}/{{month}}/{{slug}}"
@@ -969,19 +969,10 @@ collections:
     preview_path: event/{{year}}/{{month}}/{{day}}/{{title}}
     preview_path_date_field: "date"
     fields:
-      - label: "Video Title"
-        name: "video title"
+      - label: "Transcript Title"
+        name: "title"
         widget: "string"
-        hint: "Title for the video"
-      - label: "Event Name"
-        name: "event name"
-        widget: "relation"
-        collection: "events"
-        value_field: "slug"
-        displayField: "title"
-        search_fields: ["slug", "title"]
-        multiple: false
-        required: true
+        hint: "USWDS Monthly Call - October 2022 Transcript"
       - label: "Start Date/Time"
         name: "date"
         widget: "datetime"
@@ -1041,6 +1032,7 @@ collections:
         name: "body"
         widget: "markdown"
         required: false
+        hint: "Don't forget to link to the original event page at the top of the post"
         <<: *editorComponents
 
   # IMAGE UPLOAD =======================


### PR DESCRIPTION
## Summary

Transcript post updates include:

- fixed slug
- fixed filename length
- authors field values

## Steps to recreate

1. Log into [workflow](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/nl-transcript-post-fixes/workflow)
2. Click on "Transcript" in the side menu
3. Fill out required fields
4. Click "publish", you may get an error which could be related to some federalist and netlify cms issue 

This is related to https://github.com/GSA/digitalgov.gov/pull/5524