### PR TITLE
RPA CoP redirect

### DIFF
--- a/content/communities/rpa-community.md
+++ b/content/communities/rpa-community.md
@@ -16,6 +16,8 @@ topics:
 authors:
   - gabrielle-perret
 
+redirectto: https://www.gsa.gov/technology/government-it-initiatives/federal-robotic-process-automation-community-of-practice
+
 # Page weight: controls how this page appears across the site
 # 0 -- hidden
 # 1 -- visible


### PR DESCRIPTION
This PR implements the following **changes:**

* page redirect to GSA site


**URL / Link to page**

https://digital.gov/communities/rpa/

https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/RPA-CoP-redirect/communities/ 

https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/RPA-CoP-redirect/communities/rpa/ 
~ redirects to: https://www.gsa.gov/technology/government-it-initiatives/federal-robotic-process-automation-community-of-practice 
