### PR TITLE
Move return to top link to footer landmark

### DIFF
--- a/themes/digital.gov/layouts/partials/core/footer.html
+++ b/themes/digital.gov/layouts/partials/core/footer.html
@@ -1,19 +1,14 @@
-<section class="return-to-top">
-  <div class="grid-container grid-container-desktop usa-footer__return-to-top">
-    <div class="grid-row">
-      <div class="grid-col-auto">
-        <a href="#">
-          <span>Return to top</span>
-          <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-            <use xlink:href="{{ "uswds/img/sprite.svg#arrow_upward" | relURL }}"></use>
-          </svg>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
 <footer class="usa-footer usa-footer--big" role="contentinfo">
+  <section class="return-to-top">
+    <div class="grid-container grid-container-desktop usa-footer__return-to-top">
+      <a href="#">
+        <span>Return to top</span>
+        <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
+          <use xlink:href="{{ "uswds/img/sprite.svg#arrow_upward" | relURL }}"></use>
+        </svg>
+      </a>
+    </div>
+  </section>
   <div class="usa-footer__primary-section">
     <div class="grid-container grid-container-desktop">
       <nav class="usa-footer__nav" aria-label="Footer navigation">


### PR DESCRIPTION
This PR implements the following **changes:**

Resolves a11y issue with _Return to top_ link. Based on trello card `DG Footer - Move return to top link inside footer [All page content should be contained by landmarks]`

Return to top link should be contained inside of footer.
<img width="1175" alt="image" src="https://user-images.githubusercontent.com/3385219/200869282-2a0cd229-818d-4896-bd9a-89ecedcc96c6.png">


**How to test**
1. Go to any page with footer (like [homepage](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/jm-a11y-return-to-top/))
1. Inspect `Return to Top` link
1. Verify it's inside `<footer>` element
1. Run AXE scan
1. Verify error related to `Return to top` is gone [`All page content should be contained by landmarks`]
1. There should be **no** visual regressions
