### PR TITLE
Improve pagination contrast

### DIFF
--- a/themes/digital.gov/layouts/partials/core/pagination.html
+++ b/themes/digital.gov/layouts/partials/core/pagination.html
@@ -21,12 +21,13 @@
 {{ if gt $paginator.TotalPages 1 }}
 
   <ul class="pagination">
-
     <!-- First page. -->
     {{ if ne $paginator.PageNumber 1 }}
     <li class="pagination-first">
-      <a href="{{ $paginator.First.URL }}">
-        &#8676;
+      <a href="{{ $paginator.First.URL }}" aria-label="First page">
+        <svg class="usa-icon dg-icon dg-icon--large" aria-hidden="true" focusable="false" role="img">
+          <use xlink:href="{{ "uswds/img/sprite.svg#first_page" | relURL }}"></use>
+        </svg>
       </a>
     </li>
     {{ end }}
@@ -34,8 +35,10 @@
     <!-- Previous page. -->
     {{ if $paginator.HasPrev }}
     <li class="pagination-previous">
-      <a href="{{ $paginator.Prev.URL }}">
-        &#8592;
+      <a href="{{ $paginator.Prev.URL }}" aria-label="Previous page">
+        <svg class="usa-icon dg-icon dg-icon--standard" aria-hidden="true" focusable="false" role="img">
+          <use xlink:href="{{ "uswds/img/sprite.svg#arrow_back" | relURL }}"></use>
+        </svg>
       </a>
     </li>
     {{ end }}
@@ -96,8 +99,10 @@
     <!-- Next page. -->
     {{ if $paginator.HasNext }}
     <li class="pagination-next">
-      <a href="{{ $paginator.Next.URL }}">
-        &#8594;
+      <a href="{{ $paginator.Next.URL }}" aria-label="Next page">
+        <svg class="usa-icon dg-icon dg-icon--standard" aria-hidden="true" focusable="false" role="img">
+          <use xlink:href="{{ "uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
+        </svg>
       </a>
     </li>
     {{ end }}
@@ -105,8 +110,10 @@
     <!-- Last page. -->
     {{ if ne $paginator.PageNumber $paginator.TotalPages }}
     <li class="pagination-last">
-      <a href="{{ $paginator.Last.URL }}">
-        &#8677;
+      <a href="{{ $paginator.Last.URL }}" aria-label="Last page">
+        <svg class="usa-icon dg-icon dg-icon--large" aria-hidden="true" focusable="false" role="img">
+          <use xlink:href="{{ "uswds/img/sprite.svg#last_page" | relURL }}"></use>
+        </svg>
       </a>
     </li>
     {{ end }}

--- a/themes/digital.gov/src/scss/new/_stream.scss
+++ b/themes/digital.gov/src/scss/new/_stream.scss
@@ -35,7 +35,7 @@
     @include u-display("inline-block");
     @include u-text("center");
     a {
-      @include u-text("blue-60v");
+      @include u-text("blue-warm-70v");
       @include u-text("no-underline");
       @include u-circle(5);
       @include u-display("flex");
@@ -49,6 +49,6 @@
   }
   li.active a {
     @include u-text("white");
-    @include u-bg("blue-60v");
+    @include u-bg("blue-warm-70v");
   }
 }

--- a/themes/digital.gov/src/scss/new/_stream.scss
+++ b/themes/digital.gov/src/scss/new/_stream.scss
@@ -26,7 +26,7 @@
   @include u-margin-bottom(5);
   @include u-padding(0);
   display: flex;
-  flex-flow: row nowrap;
+  flex-flow: row wrap;
   align-items: center;
   column-gap: units("2px");
 

--- a/themes/digital.gov/src/scss/new/_stream.scss
+++ b/themes/digital.gov/src/scss/new/_stream.scss
@@ -25,12 +25,17 @@
   @include u-margin-top(3);
   @include u-margin-bottom(5);
   @include u-padding(0);
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  column-gap: units("2px");
+
   li {
     @include add-list-reset();
     @include u-display("inline-block");
     @include u-text("center");
     a {
-      @include u-text("blue-50v");
+      @include u-text("blue-60v");
       @include u-text("no-underline");
       @include u-circle(5);
       @include u-display("flex");
@@ -44,6 +49,6 @@
   }
   li.active a {
     @include u-text("white");
-    @include u-bg("blue-50v");
+    @include u-bg("blue-60v");
   }
 }

--- a/themes/digital.gov/src/scss/new/_stream.scss
+++ b/themes/digital.gov/src/scss/new/_stream.scss
@@ -1,49 +1,49 @@
 @use "uswds-core" as *;
 
-.stream{
-	h2{
-		@include u-font('sans', 'xl');
-		@include u-text('bold');
-		@include u-text('indigo-warm-80');
-		@include at-media('tablet-lg') {
-			@include u-font('sans', 'xl');
-		}
-	}
-	.card:first-child{
-		@include u-margin-top(0);
-	}
-	footer{
-		@include u-margin-y(2);
-		@include u-text('center');
-		p{
-			@include u-maxw('full');
-		}
-	}
+.stream {
+  h2 {
+    @include u-font("sans", "xl");
+    @include u-text("bold");
+    @include u-text("indigo-warm-80");
+    @include at-media("tablet-lg") {
+      @include u-font("sans", "xl");
+    }
+  }
+  .card:first-child {
+    @include u-margin-top(0);
+  }
+  footer {
+    @include u-margin-y(2);
+    @include u-text("center");
+    p {
+      @include u-maxw("full");
+    }
+  }
 }
 
-.pagination{
-	@include u-margin-top(3);
-	@include u-margin-bottom(5);
-	@include u-padding(0);
-	li{
-		@include add-list-reset();
-		@include u-display('inline-block');
-		@include u-text('center');
-		a{
-			@include u-text('blue-50v');
-			@include u-text('no-underline');
-			@include u-circle(5);
-			@include u-display('flex');
-			@include u-flex('column');
-			@include u-flex('justify-center');
-			@include u-flex('align-center');
-			&:hover{
-				@include u-bg('blue-10');
-			}
-		}
-	}
-	li.active a{
-		@include u-text('white');
-		@include u-bg('blue-50v');
-	}
+.pagination {
+  @include u-margin-top(3);
+  @include u-margin-bottom(5);
+  @include u-padding(0);
+  li {
+    @include add-list-reset();
+    @include u-display("inline-block");
+    @include u-text("center");
+    a {
+      @include u-text("blue-50v");
+      @include u-text("no-underline");
+      @include u-circle(5);
+      @include u-display("flex");
+      @include u-flex("column");
+      @include u-flex("justify-center");
+      @include u-flex("align-center");
+      &:hover {
+        @include u-bg("blue-10");
+      }
+    }
+  }
+  li.active a {
+    @include u-text("white");
+    @include u-bg("blue-50v");
+  }
 }


### PR DESCRIPTION
This PR implements the following **changes:**

**Improved pagination accessibility.** Pagination has improved contrast colors, uses USWDS icons, and flexbox for better alignment. Related to trello card `DG - Pagination - Increase contrast in pagination numbers and arrows [Elements must have sufficient color contrast]`

**URL / Link to page**
[News page 5](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/jm-a11y-pagination-contrast/news/page/5/)


**Before**
![image](https://user-images.githubusercontent.com/3385219/200902575-ed80648e-46a8-438c-b091-082c58024d1e.png)

**After**

![image](https://user-images.githubusercontent.com/3385219/201161832-b82b6134-34e8-4088-b650-30e9b1546f6e.png)


<!-- Link to the page that will be changed -->
<!-- Delete this section if not needed -->

## How to test
1. Visit News page
2. Verify new icons and darker USWDS blue `blue-60v` `#005ea2` previously `blue-50v`  `#0076d6`. 
3. Click on pagination links
4. There should be no visual regressions
5. Run axe scan, there should be no contrast errors
