### PR TITLE
[hotfix] Remove deleted tweet that's affecting site builds

### DIFF
--- a/content/news/2015/06/2015-06-12-digitalgov-citizen-services-summit-reflections-from-our-livestream-host-and-full-recording-now-available.md
+++ b/content/news/2015/06/2015-06-12-digitalgov-citizen-services-summit-reflections-from-our-livestream-host-and-full-recording-now-available.md
@@ -65,8 +65,6 @@ Federal agencies were also invited to showcase their programs, tools and innovat
 
 {{< tweet user="ePolicyWorks" id="601374497288146944" >}}
 
-<!-- {{< tweet user="CorinaDuBois" id="601388501872091137" >}} -->
-
 {{< tweet user="jakegab" id="601206392905674752" >}}
 
 {{< tweet user="lauraandotis" id="601432623186051072" >}}

--- a/content/news/2015/06/2015-06-12-digitalgov-citizen-services-summit-reflections-from-our-livestream-host-and-full-recording-now-available.md
+++ b/content/news/2015/06/2015-06-12-digitalgov-citizen-services-summit-reflections-from-our-livestream-host-and-full-recording-now-available.md
@@ -65,7 +65,7 @@ Federal agencies were also invited to showcase their programs, tools and innovat
 
 {{< tweet user="ePolicyWorks" id="601374497288146944" >}}
 
-{{< tweet user="CorinaDuBois" id="601388501872091137" >}}
+<!-- {{< tweet user="CorinaDuBois" id="601388501872091137" >}} -->
 
 {{< tweet user="jakegab" id="601206392905674752" >}}
 


### PR DESCRIPTION
This PR implements the following **changes:**

* Removed deleted tweet/account. Tweet shortcode connecting to user `CorinaDuBois` was causing builds to fail. The HTTP response was returning an error because the account and tweet have been deleted.

**Before**

![image](https://user-images.githubusercontent.com/3385219/202785912-e939c3be-535b-4146-8702-1d91ea8723cb.png)

**After**
Tweet was removed.

![image](https://user-images.githubusercontent.com/3385219/202785968-025cf5bf-1bcb-4761-b54f-ffd2baf298f2.png)


**URL / Link to page**
[[News] DigitalGov Citizen Services Summit: Reflections from Our Livestream Host, and Full Recording Now Available!](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/jm-twitter-build-debug//2015/06/12/digitalgov-citizen-services-summit-reflections-from-our-livestream-host-and-full-recording-now-available/)

