### PR TITLE
Add CSS to ensure alt text is visible when images are turned off

### DIFF
--- a/themes/digital.gov/layouts/partials/core/header.html
+++ b/themes/digital.gov/layouts/partials/core/header.html
@@ -4,7 +4,7 @@
     <div class="usa-logo" id="extended-logo">
       <em class="usa-logo__text">
         <a href="{{- "/" | relURL -}}" title="{{- .Site.Title }} Home" aria-label="{{- .Site.Title }} Home">
-          <img class="logo-black" src="{{- "img/digitalgov-logo.svg" | absURL -}}" alt="{{- .Site.Title -}} Logo" />
+          <img class="logo-black" src="{{- "img/digitalgov-logo.svg" | absURL -}}" alt="{{ .Site.Title }} Logo" />
         </a>
       </em>
       <p class="sub-head display-none">{{- .Site.Params.description -}}</p>

--- a/themes/digital.gov/src/scss/new/_footer.scss
+++ b/themes/digital.gov/src/scss/new/_footer.scss
@@ -47,4 +47,7 @@ footer.usa-footer{
 		}
 	}
 
+	img[alt] {
+	  @include u-text('white');
+	}
 }

--- a/themes/digital.gov/src/scss/new/_footer.scss
+++ b/themes/digital.gov/src/scss/new/_footer.scss
@@ -46,8 +46,4 @@ footer.usa-footer{
 			}
 		}
 	}
-
-	img[alt] {
-	  @include u-text('white');
-	}
 }

--- a/themes/digital.gov/src/scss/new/_images.scss
+++ b/themes/digital.gov/src/scss/new/_images.scss
@@ -43,7 +43,3 @@
   @include u-float('left');
   @include u-width('card-lg');
 }
-
-.usa-identifier img[alt] {
-  @include u-text('white');
-}

--- a/themes/digital.gov/src/scss/new/_images.scss
+++ b/themes/digital.gov/src/scss/new/_images.scss
@@ -43,3 +43,7 @@
   @include u-float('left');
   @include u-width('card-lg');
 }
+
+.usa-identifier img[alt] {
+  @include u-text('white');
+}

--- a/themes/digital.gov/src/scss/new/_images.scss
+++ b/themes/digital.gov/src/scss/new/_images.scss
@@ -43,3 +43,7 @@
   @include u-float('left');
   @include u-width('card-lg');
 }
+
+p img[alt] {
+  font-style: italic;
+}

--- a/themes/digital.gov/src/scss/new/_images.scss
+++ b/themes/digital.gov/src/scss/new/_images.scss
@@ -44,6 +44,6 @@
   @include u-width('card-lg');
 }
 
-p img[alt] {
+img[alt] {
   font-style: italic;
 }

--- a/themes/digital.gov/src/scss/new/_uswds-overrides.scss
+++ b/themes/digital.gov/src/scss/new/_uswds-overrides.scss
@@ -1,0 +1,5 @@
+@use "uswds-core" as *;
+
+.usa-identifier img[alt] {
+  @include u-text('white');
+}

--- a/themes/digital.gov/src/scss/new/styles.scss
+++ b/themes/digital.gov/src/scss/new/styles.scss
@@ -12,7 +12,6 @@
 // Import individual theme settings
 
 @forward 'uswds-theme';
-@forward 'uswds-overrides';
 @forward "usa-site-alert";
 
 // @forward "uswds-global";

--- a/themes/digital.gov/src/scss/new/styles.scss
+++ b/themes/digital.gov/src/scss/new/styles.scss
@@ -12,6 +12,7 @@
 // Import individual theme settings
 
 @forward 'uswds-theme';
+@forward 'uswds-overrides';
 @forward "usa-site-alert";
 
 // @forward "uswds-global";


### PR DESCRIPTION
### Summary

Increase color contrast on footer logo image alt text when images are not displayed.

### Problem

When images are turned off, the footer defaults to the visited link text and is below color contrast ratio with `indigo-warm-60v`/`#5942d2` on `gray-90`/`#1b1b1b` = 2.57 contrast.

### Solution

Styled `alt` text in footer to be white `#FFFFFF` on `gray-90`/`#1b1b1b` = 17.22 contrast.

### Steps to Recreate

1. hide images in browser settings
2. scroll down to footer
3. text should be white on `gray-90`

### Questions/Notes

1. There is no `_identifier.scss` stylesheet, so image alt styles are moved to `_images.scss` if that seems reasonable?
2. I've used `#ffffff` as the style color, I did not find a token or theme variable that provided this function.