### PR TITLE
Fix DST for "last updated at" time

### DIFF
--- a/themes/digital.gov/src/js/common/date-format.js
+++ b/themes/digital.gov/src/js/common/date-format.js
@@ -1,0 +1,4 @@
+// Nov 25, 2022 at 3:57 pm ET
+
+const today = new Date();
+console.log(today)

--- a/themes/digital.gov/src/js/common/date-format.js
+++ b/themes/digital.gov/src/js/common/date-format.js
@@ -1,4 +1,0 @@
-// Nov 25, 2022 at 3:57 pm ET
-
-const today = new Date();
-console.log(today)

--- a/themes/digital.gov/src/js/common/github.js
+++ b/themes/digital.gov/src/js/common/github.js
@@ -61,14 +61,14 @@ jQuery(document).ready(function($) {
 				"<span class='commit-author'>"+commit_author+"</span>",
 			"</a> on ",
 			"<a href="+commit_history_url+">",
-				"<span class='commit-date'>"+getFormattedDate(commit_date)+"</span>",
+				"<span class='commit-date'>"+formatDate(commit_date)+"</span>",
 			"</a></p>",
 			""
 		] : [
 			branch_link,
 			"<p>Last updated on",
 			"<a href="+commit_history_url+">",
-				"<span class='commit-date'>"+getFormattedDate(commit_date)+"</span>",
+				"<span class='commit-date'>"+formatDate(commit_date)+"</span>",
 			"</a></p>",
 			""
 		];
@@ -119,18 +119,25 @@ jQuery(document).ready(function($) {
 });
 
 
-function todayNow() {
+function formatDate(timezone_date) {
+	// console.log("Ouput: Nov 25, 2022 at 3:57 pm ET |||| ", `Input: ${timezone_date}`);
 	// Nov 25, 2022 at 3:57 pm ET
-	const today_date = new Date();
+	const input_date = new Date(timezone_date);
 
 	const dateOptions = {
 		day: "numeric",
-		weekday: "long",
-		month: "long",
+		month: "short",
 		year: "numeric"
 	}
 
-	console.log("date-testing:", today_date.toLocaleDateString(undefined, dateOptions)) // 11/29/2022
-}
+	const timeOptions = {
+		hour: "2-digit",
+		minute: "2-digit",
+		timeZoneName: "shortGeneric" // shortOffset, short, long, longGeneric
+	}
 
-todayNow();
+	const ouput_date = input_date.toLocaleDateString(undefined, dateOptions);
+	const output_time = input_date.toLocaleTimeString("en-US", timeOptions);
+
+	return `${ouput_date} at ${output_time}`;
+}

--- a/themes/digital.gov/src/js/common/github.js
+++ b/themes/digital.gov/src/js/common/github.js
@@ -50,6 +50,7 @@ jQuery(document).ready(function($) {
 		var branch_link = get_branch_link(branch);
  		var commit_data = $.isArray(data) ? data[0] : data;
 		var commit_date = commit_data.commit.committer.date;
+		console.log("commit_date:", commit_date);
 		var commit_author = (commit_data.author || {}).login;
 		var commit_author_url = 'https://github.com/' + commit_author;
 		var commit_history_url = 'https://github.com/GSA/digitalgov.gov/commits/'+branch+'/content/' + filepath;
@@ -116,3 +117,20 @@ jQuery(document).ready(function($) {
 	  return date_string;
 	}
 });
+
+
+function todayNow() {
+	// Nov 25, 2022 at 3:57 pm ET
+	const today_date = new Date();
+
+	const dateOptions = {
+		day: "numeric",
+		weekday: "long",
+		month: "long",
+		year: "numeric"
+	}
+
+	console.log("date-testing:", today_date.toLocaleDateString(undefined, dateOptions)) // 11/29/2022
+}
+
+todayNow();

--- a/themes/digital.gov/src/js/common/github.js
+++ b/themes/digital.gov/src/js/common/github.js
@@ -50,7 +50,6 @@ jQuery(document).ready(function($) {
 		var branch_link = get_branch_link(branch);
  		var commit_data = $.isArray(data) ? data[0] : data;
 		var commit_date = commit_data.commit.committer.date;
-		console.log("commit_date:", commit_date);
 		var commit_author = (commit_data.author || {}).login;
 		var commit_author_url = 'https://github.com/' + commit_author;
 		var commit_history_url = 'https://github.com/GSA/digitalgov.gov/commits/'+branch+'/content/' + filepath;
@@ -120,8 +119,6 @@ jQuery(document).ready(function($) {
 
 
 function formatDate(timezone_date) {
-	// console.log("Ouput: Nov 25, 2022 at 3:57 pm ET |||| ", `Input: ${timezone_date}`);
-	// Nov 25, 2022 at 3:57 pm ET
 	const input_date = new Date(timezone_date);
 
 	const dateOptions = {
@@ -133,7 +130,7 @@ function formatDate(timezone_date) {
 	const timeOptions = {
 		hour: "2-digit",
 		minute: "2-digit",
-		timeZoneName: "shortGeneric" // shortOffset, short, long, longGeneric
+		timeZoneName: "shortGeneric"
 	}
 
 	const ouput_date = input_date.toLocaleDateString(undefined, dateOptions);


### PR DESCRIPTION
### Summary

Daylight Savings Time (DST) is missing from the github date formatting at the bottom of each page.
Added DST calculation to keep timing consistenst across time changes throughout the year.

### Problem

Github timestamps are not checking for DST and gain or lose an hour depending on when DST is in effect.

**On github**
<img width="1563" alt="Screen Shot 2022-11-30 at 1 16 51 PM" src="https://user-images.githubusercontent.com/104778659/204877354-a4ef9bcb-cc04-4873-976e-b354b2b2f152.png">

**On live site**
<img width="612" alt="Screen Shot 2022-11-30 at 1 19 29 PM" src="https://user-images.githubusercontent.com/104778659/204877369-b47e631c-fb45-4867-9d29-9b64bd0e1861.png">

### Solution

Implemented date functions `toLocaleDateString` & `toLocaleTimeString` functions to read `2022-11-17T17:38:26Z` into `Nov 17, 2022 at 12:38 PM ET`.
This sets the date based on the user agent's timezone when calculating the time to reflect DST.

### Steps to Recreate

1. Visit any top level page (news, event, communities, etc) — https://digital.gov/event/2022/08/24/2022-federal-plain-language-summit/
2. Compare against file date on github - [file](https://github.com/GSA/digitalgov.gov/blob/main/content/events/2022/07/2022-07-29-2022-federal-plain-language-summit.md)
3. Go to bottom of page to see "Last updated by..."
4. Date is 1 hour behind, it should be on time

https://user-images.githubusercontent.com/104778659/204877566-f29bfed2-1d6b-40e8-94d2-69949f7f8a40.mov


