### PR TITLE
Set timezone for "last updated at" date display

### DIFF
--- a/themes/digital.gov/src/js/common/github.js
+++ b/themes/digital.gov/src/js/common/github.js
@@ -124,12 +124,15 @@ function formatDate(timezone_date) {
 	const dateOptions = {
 		day: "numeric",
 		month: "short",
-		year: "numeric"
+		year: "numeric",
+		timeZone: "America/New_York",
+		timeZoneName: "shortGeneric"
 	}
 
 	const timeOptions = {
 		hour: "2-digit",
 		minute: "2-digit",
+		timeZone: "America/New_York",
 		timeZoneName: "shortGeneric"
 	}
 


### PR DESCRIPTION
### Summary
An enhancement for #5628, sets to the timezone to display the date in EST.

```
const dateOptions = {
  day: "numeric",
  month: "short",
  year: "numeric"
  year: "numeric",
  timeZone: "America/New_York",
  timeZoneName: "shortGeneric"
}
```

### Steps to Recreate

1. https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/nl-fix-dst-display/event/2022/09/15/uswds-monthly-call-september-2022/

