### PR TITLE
Update email copy on community pages

### DIFF
--- a/content/communities/federal-communicators-network.md
+++ b/content/communities/federal-communicators-network.md
@@ -24,7 +24,8 @@ event_cop:
 community_list:
   - platform: listserv
     type: government
-    subscribe_email: "FCN-subscribe-request@listserv.gsa.gov"
+    subscribe_email: "fcn-request@listserv.gsa.gov "
+    subscribe_email_subject: "Join the Communicators Community" 
     terms: "Anyone with a .gov or .mil email address is eligible to join."
     members: 1954
 

--- a/content/communities/federal-communicators-network.md
+++ b/content/communities/federal-communicators-network.md
@@ -24,9 +24,9 @@ event_cop:
 community_list:
   - platform: listserv
     type: government
-    subscribe_email: "fcn-request@listserv.gsa.gov "
+    subscribe_email: "fcn-request@listserv.gsa.gov"
     subscribe_email_subject: "Join the Communicators Community" 
-    terms: "Anyone with a .gov or .mil email address is eligible to join."
+    terms: "Government employees and contractors with an official .gov/.mil email are eligible to join."
     members: 1954
 
 # Controls how this page appears across the site

--- a/content/communities/multilingual.md
+++ b/content/communities/multilingual.md
@@ -38,6 +38,7 @@ community_list:
   - platform: listserv
     type: government
     subscribe_email: "FMWC-subscribe-request@listserv.gsa.gov"
+    subscribe_email_subject: "Join the Multilingual Community"
     terms: "Anyone with a .gov or .mil email address is eligible to join."
     members: 504
 

--- a/content/communities/multilingual.md
+++ b/content/communities/multilingual.md
@@ -37,9 +37,9 @@ dg_acronym: ML
 community_list:
   - platform: listserv
     type: government
-    subscribe_email: "FMWC-subscribe-request@listserv.gsa.gov"
+    subscribe_email: "fmwc-request@listserv.gsa.gov"
     subscribe_email_subject: "Join the Multilingual Community"
-    terms: "Anyone with a .gov or .mil email address is eligible to join."
+    terms: "Government employees and contractors with an official .gov/.mil email are eligible to join."
     members: 504
 
 primary_image: "white-bg-digital-gov-card-community"

--- a/content/communities/plain-language-community-of-practice.md
+++ b/content/communities/plain-language-community-of-practice.md
@@ -41,7 +41,7 @@ dg_acronym: PL
 community_list:
   - platform: listserv
     type: public
-    subscribe_email: "PL-COP-MAIN-subscribe-request@listserv.gsa.gov"
+    subscribe_email: "pl-cop-main-subscribe-request@listserv.gsa.gov"
     terms: "Anyone is eligible to join."
     members: 1940
 

--- a/content/communities/social-media.md
+++ b/content/communities/social-media.md
@@ -33,9 +33,9 @@ dg_acronym: SM
 community_list:
   - platform: listserv
     type: government
-    subscribe_email: "SM-COP-subscribe-request@listserv.gsa.gov"
+    subscribe_email: "ux-cop-request@listserv.gsa.gov"
     subscribe_email_subject: "Join the Social Media Community"
-    terms: "Federal employees and federal contractor employees with a .gov or .mil email address are eligible to join."
+    terms: "Federal government employees and contractors with an official .gov/.mil email are eligible to join."
     members: 1166
 
 primary_image: "white-bg-digital-gov-card-community"

--- a/content/communities/social-media.md
+++ b/content/communities/social-media.md
@@ -34,6 +34,7 @@ community_list:
   - platform: listserv
     type: government
     subscribe_email: "SM-COP-subscribe-request@listserv.gsa.gov"
+    subscribe_email_subject: "Join the Social Media Community"
     terms: "Federal employees and federal contractor employees with a .gov or .mil email address are eligible to join."
     members: 1166
 

--- a/content/communities/user-experience.md
+++ b/content/communities/user-experience.md
@@ -32,7 +32,7 @@ community_list:
   - platform: "listserv"
     type: government
     subscribe_email: ux-cop-request@listserv.gsa.gov
-    subscribe_email_subject: "Join UX Community"
+    subscribe_email_subject: "Join the User Experience Community"
     members: 1714
 
 # see all authors at https://digital.gov/authors

--- a/content/communities/user-experience.md
+++ b/content/communities/user-experience.md
@@ -31,8 +31,9 @@ dg_acronym: UX
 community_list:
   - platform: "listserv"
     type: government
-    subscribe_email: ux-cop-request@listserv.gsa.gov
+    subscribe_email: "ux-cop-request@listserv.gsa.gov"
     subscribe_email_subject: "Join the User Experience Community"
+    terms: "Government employees and contractors with an official .gov/.mil email are eligible to join."
     members: 1714
 
 # see all authors at https://digital.gov/authors
@@ -48,10 +49,6 @@ Join other federal user experience practitioners and learn how to make better us
 ## Join
 
 Send an email from your official government email to [ux-cop-request@listserv.gsa.gov](mailto:ux-cop-request@listserv.gsa.gov?subject=Join%20UX%20Community), with “Join UX Community” in the subject line.
-
-## Community Managers:
-
-Jean Fox (BLS) and Silvia Salazar (NIH)
 
 ## Overview
 

--- a/content/communities/web-analytics-and-optimization.md
+++ b/content/communities/web-analytics-and-optimization.md
@@ -39,7 +39,8 @@ dg_acronym: WAO
 community_list:
   - platform: listserv
     type: government
-    subscribe_email: ANALYZE-OPTIMIZE-subscribe-request@LISTSERV.GSA.GOV
+    subscribe_email: analyze-optimize-request@listserv.gsa.gov
+    subscribe_email_subject: "Join the Web Analytics Community"
     members: 707
     terms: Government employees and contractors only.
 

--- a/content/communities/web-analytics-and-optimization.md
+++ b/content/communities/web-analytics-and-optimization.md
@@ -39,8 +39,9 @@ dg_acronym: WAO
 community_list:
   - platform: listserv
     type: government
-    subscribe_email: analyze-optimize-request@listserv.gsa.gov
+    subscribe_email: "analyze-optimize-request@listserv.gsa.gov"
     subscribe_email_subject: "Join the Web Analytics Community"
+    terms: "Federal government employees and contractors with an official .gov/.mil email are eligible to join."
     members: 707
     terms: Government employees and contractors only.
 

--- a/content/communities/web-managers-forum.md
+++ b/content/communities/web-managers-forum.md
@@ -46,7 +46,7 @@ community_list:
     type: government_only
     subscribe_email: "content-managers-l-request@listserv.gsa.gov"
     subscribe_email_subject: "Join the Web Managers Community"
-    terms: "U.S. government employees only are eligible to join."
+    terms: "Government employees with an official .gov/.mil email are eligible to join."
     members: 1791
 
 primary_image: "white-bg-digital-gov-card-community"

--- a/content/communities/web-managers-forum.md
+++ b/content/communities/web-managers-forum.md
@@ -44,7 +44,8 @@ dg_acronym: WCM
 community_list:
   - platform: listserv
     type: government_only
-    subscribe_email: "CONTENT-MANAGERS-L-subscribe-request@listserv.gsa.gov"
+    subscribe_email: "content-managers-l-request@listserv.gsa.gov"
+    subscribe_email_subject: "Join the Web Managers Community"
     terms: "U.S. government employees only are eligible to join."
     members: 1791
 

--- a/themes/digital.gov/layouts/partials/core/community-join-without-form.html
+++ b/themes/digital.gov/layouts/partials/core/community-join-without-form.html
@@ -17,4 +17,4 @@
   Join by email
 </a>
 
-<p>To join, email <strong>{{ .e.subscribe_email }}</strong> with {{ if .e.subscribe_email_subject }} <code>{{ .e.subscribe_email_subject }}</code>{{ else }} nothing {{ end }} in the subject {{- if .e.subscribe_email_body }} and <code>{{ .e.subscribe_email_body }}</code> in the body{{- end -}}.</p>
+<p>Email <strong>{{ .e.subscribe_email }}</strong> to join. Include {{ if .e.subscribe_email_subject }} <code>{{ .e.subscribe_email_subject }}</code>{{ else }} nothing {{ end }} in the subject line{{- if .e.subscribe_email_body }} and <code>{{ .e.subscribe_email_body }}</code> in the body{{- end -}}.</p>


### PR DESCRIPTION
### Summary

Update email and email copy for the communities "join by email" button.

### Steps to Recreate

1. Visit any communities page - https://digital.gov/communities/user-experience/
2. Email link should be updated to new address
3. Email copy should read "Join the Community Name Community"


### Pages Affected

- [Communicators]()
- [Multilingual]()
- ~~[Plain Language]()~~
- [Social Media]()
- [User Experience]()
- [Web Analytics]()
- [Web Managers]()
