### PR TITLE
Adding USWDS MC Dec 2022 slides to event page

### DIFF
--- a/content/events/2022/12/2022-12-01-uswds-monthly-call-december-2022.md
+++ b/content/events/2022/12/2022-12-01-uswds-monthly-call-december-2022.md
@@ -23,6 +23,9 @@ slug: uswds-monthly-call-december-2022
 event_platform: zoom
 primary_image: 2022-uswds-monthly-call-dec-title-card
 ---
+
+{{< asset-static file="uswds-monthly-call-december-2022.pptx" label="View the slides (PowerPoint, 9.7 MB, 75 pages)" >}}
+
 What things — small and large — made 2022 a great year for the Design System? This month, we’ll hear members of the Core Team share their favorite Design System updates from 2022. Join us as we look back at the year — you never know what you might have missed!
 
 *This event is part of a monthly series that takes place on the third Thursday of each month. Don’t forget to set a placeholder on your personal calendar for our future events this year.*


### PR DESCRIPTION
This PR implements the following **changes:**
Adding USWDS MC Dec 2022 slides to event page

**URL / Link to page**
Event page: https://digital.gov/event/2022/12/15/uswds-monthly-call-december-2022/
Preview link: https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/jdotyoon-patch-11/event/2022/12/15/uswds-monthly-call-december-2022/
