### PR TITLE
Add aria-label to TOC sidebar navigation

### DIFF
--- a/themes/digital.gov/src/js/common/toc.js
+++ b/themes/digital.gov/src/js/common/toc.js
@@ -1,0 +1,6 @@
+// add aria-label to the built-in .TableOfContents variable. Cannot override from configuration file
+const tableOfContents = document.querySelector('nav#TableOfContents');
+
+if (tableOfContents) {
+  tableOfContents.ariaLabel = "Table of contents";
+}

--- a/themes/digital.gov/static/js/toc.js
+++ b/themes/digital.gov/static/js/toc.js
@@ -1,12 +1,5 @@
 jQuery(function ($) {
 
-	// add aria-label to the built-in .TableOfContents variable. Cannot override from configuration file
-	const tableOfContents = document.querySelector('nav#TableOfContents');
-
-	if (tableOfContents) {
-	  tableOfContents.ariaLabel = "Table of contents";
-	}
-
 	// Cleans up the #TableOfContents from HUGO
 	$('#TableOfContents > ul:first').contents().unwrap();
 	$('#TableOfContents > li:first').contents().unwrap();

--- a/themes/digital.gov/static/js/toc.js
+++ b/themes/digital.gov/static/js/toc.js
@@ -1,5 +1,12 @@
 jQuery(function ($) {
 
+	// add aria-label to the built-in .TableOfContents variable. Cannot override from configuration file
+	const tableOfContents = document.querySelector('nav#TableOfContents');
+
+	if (tableOfContents) {
+	  tableOfContents.ariaLabel = "Table of contents";
+	}
+
 	// Cleans up the #TableOfContents from HUGO
 	$('#TableOfContents > ul:first').contents().unwrap();
 	$('#TableOfContents > li:first').contents().unwrap();


### PR DESCRIPTION
### Summary

"In this page" aside navigation is missing an aria-label. Hugo [documentation](https://gohugo.io/getting-started/configuration-markup/#table-of-contents) does not allow for setting attributes on the navigation.
`.TableOfContents` generates `<nav id="TableOfContents">` without allowing to add attributes in the configuration.

### Solution

Add `aria-label="Table of contents"` dynamically with javascript checking if `<nav id="TableOfContents">` exists on the given page.

### Screenshots

#### Before
<img width="1661" alt="Screen Shot 2023-01-04 at 4 10 15 PM" src="https://user-images.githubusercontent.com/104778659/210656866-ce70e391-10b3-4453-acec-aecd919df07b.png">

#### After
<img width="1661" alt="Screen Shot 2023-01-04 at 4 33 55 PM" src="https://user-images.githubusercontent.com/104778659/210656891-cdb5d6c4-f23e-4e47-8564-b278563ec6ed.png">

### How to Test

1. Visit any page with "In this page" aside
    - [resources](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/nl-label-for-toc/resources/required-web-content-and-links/)
    - [write for us](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/cms/news/2015/02/2015-02-02-agency-perspectives-on-personas-use-development-and-challenges/about/contribute/)
3. Open VoiceOver and should see "Table of contents navigation"
