### PR TITLE
Short link post fixes

### DIFF
--- a/themes/digital.gov/static/workflow/config.yml
+++ b/themes/digital.gov/static/workflow/config.yml
@@ -789,7 +789,7 @@ collections:
 
   # SHORT LINK =======================
   - <<: *defaults
-    name: "short link"
+    name: "shortlink"
     label: "Short Link"
     label_singular: "Short Link Post"
     description: "A short link post is a shorter blog post that links to external orgs."


### PR DESCRIPTION
### Summary

Workflow displays an error that could be related to the configuration `name` field settings with a space in the field.

**Current:**
```
    name: "short link" = error
```

**New change:**
```
    name: "shortlink"  = no error is displaued
```

### Steps to recreate

1. Log in to [workflow](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/nl-fix-short-link-post/workflow/#/collections/authors)
2. Create shortlink post
3. Should see successful post saved and published

### Before

<img width="1280" alt="workflow_short_link_error" src="https://user-images.githubusercontent.com/104778659/211386219-ea4794b9-0584-43fa-9cd9-aa2be0ad5ff7.png">

### After

<img width="1672" alt="Screen Shot 2023-01-09 at 1 52 54 PM" src="https://user-images.githubusercontent.com/104778659/211385608-93c80629-2f92-4198-bb2d-ac5bd1c0e9c5.png">

[Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/nl-fix-short-link-post/workflow/#/collections/shortlink)