### PR TITLE
AS_API redirect

### DIFF
--- a/content/communities/apis.md
+++ b/content/communities/apis.md
@@ -18,6 +18,8 @@ topics:
 authors:
   - gray-brooks
 
+redirectto: https://groups.google.com/forum/?nomobile=true#!forum/us-government-apis
+
 # Page weight: controls how this page appears across the site
 # 0 -- hidden
 # 1 -- visible


### PR DESCRIPTION
This PR implements the following **changes:**

* Redirecting API CoP off Digital.gov to https://groups.google.com/forum/?nomobile=true#!forum/us-government-apis as part of streamline effort


**URL / Link to page**

https://digital.gov/communities/apis/

