### PR TITLE
correcting a small detail on the site scanning pages

### DIFF
--- a/content/guides/site-scanning/data.md
+++ b/content/guides/site-scanning/data.md
@@ -12,7 +12,7 @@ There's a complete API available for accessing all of the scan data. Full docume
 
 **Direct Downloads**
 
-The scan data is also exported on a weekly basis and can be downloaded in one of two sets. The primary set includes scan data for all live URLs (those that return a 2xx server code):
+The scan data is also exported on a weekly basis and can be downloaded in one of two sets. The primary set includes scan data for all live URLs (i.e. `Final URL - Live` = TRUE):
 
 * [CSV](https://api.gsa.gov/technology/site-scanning/data/weekly-snapshot.csv)
 * [JSON](https://api.gsa.gov/technology/site-scanning/data/weekly-snapshot.json)


### PR DESCRIPTION
This PR implements the following **changes:**

There's a very small detail in the site scanning documentation that I needed to correct.  This PR makes that change.  

**URL / Link to page**

https://digital.gov/guides/site-scanning/data/

