### PR TITLE
Update a11y for secondary navigation dividers

### DIFF
--- a/themes/digital.gov/layouts/partials/core/header.html
+++ b/themes/digital.gov/layouts/partials/core/header.html
@@ -44,12 +44,10 @@
           <li class="usa-nav__secondary-item">
             <a href="{{- "/contribute/" | relURL -}}"><span>Write for us</span></a>
           </li>
-
           <li class="usa-nav__secondary-item">
             <a href="{{- "/about/contact/" | relURL -}}"><span>Contact</span></a>
           </li>
         </ul>
-
 
         <form accept-charset="UTF-8" action="https://find.digitalgov.gov/search" id="search_form" method="get" class="usa-search usa-search--small">
           <input name="utf8" type="hidden" value="&#x2713;" />

--- a/themes/digital.gov/src/scss/new/_navigation.scss
+++ b/themes/digital.gov/src/scss/new/_navigation.scss
@@ -1,0 +1,12 @@
+@use "uswds-core" as *;
+
+.usa-nav__secondary-links {
+  .usa-nav__secondary-item {
+    & + .usa-nav__secondary-item::before {
+      @include at-media("desktop") {
+        padding-right: units(0.5);
+        content: "\007C"; // Code for "|" character
+      }
+    }
+  }
+}

--- a/themes/digital.gov/src/scss/new/_navigation.scss
+++ b/themes/digital.gov/src/scss/new/_navigation.scss
@@ -1,19 +1,18 @@
 @use "uswds-core" as *;
 
-.usa-nav__secondary-links {
-  .usa-nav__secondary-item {
-    @include at-media("desktop") {
-      padding-left: units(0.5);
-      & + .usa-nav__secondary-item::before {
-        background-color: color("base-lighter");
-        display: inline-block;
-        width: units("1px");
-        height: units(2);
-        content: "";
-        margin-right: units(0.5);
-        vertical-align: middle;
-        padding-right: 0;
-      }
+.usa-nav__secondary-links .usa-nav__secondary-item {
+  @include at-media("desktop") {
+    padding-left: units(0.5);
+    
+    & + .usa-nav__secondary-item::before {
+      background-color: color("base-lighter");
+      content: "";
+      display: inline-block;
+      height: units(2);
+      margin-right: units(0.5);
+      padding-right: 0;
+      vertical-align: middle;
+      width: units("1px");
     }
   }
 }

--- a/themes/digital.gov/src/scss/new/_navigation.scss
+++ b/themes/digital.gov/src/scss/new/_navigation.scss
@@ -2,10 +2,13 @@
 
 .usa-nav__secondary-links {
   .usa-nav__secondary-item {
+    padding-left: 0; // removed .25rem value, moved to margin-left below for Safari
     & + .usa-nav__secondary-item::before {
       @include at-media("desktop") {
-        padding-right: units(0.5);
-        content: "\007C"; // Code for "|" character
+        padding-right: 6px;
+        content: "";
+        border-left: 1.5px solid color("base-lighter");
+        margin-left: .25rem;
       }
     }
   }

--- a/themes/digital.gov/src/scss/new/_navigation.scss
+++ b/themes/digital.gov/src/scss/new/_navigation.scss
@@ -2,13 +2,17 @@
 
 .usa-nav__secondary-links {
   .usa-nav__secondary-item {
-    padding-left: 0; // removed .25rem value, moved to margin-left below for Safari
-    & + .usa-nav__secondary-item::before {
-      @include at-media("desktop") {
-        padding-right: 6px;
+    @include at-media("desktop") {
+      padding-left: units(0.5);
+      & + .usa-nav__secondary-item::before {
+        background-color: color("base-lighter");
+        display: inline-block;
+        width: units("1px");
+        height: units(2);
         content: "";
-        border-left: 1.5px solid color("base-lighter");
-        margin-left: .25rem;
+        margin-right: units(0.5);
+        vertical-align: middle;
+        padding-right: 0;
       }
     }
   }

--- a/themes/digital.gov/src/scss/new/styles.scss
+++ b/themes/digital.gov/src/scss/new/styles.scss
@@ -93,6 +93,7 @@
 @forward 'paper';
 
 @forward 'header';
+@forward 'navigation';
 
 @forward 'newsletter-signup';
 @forward 'footer';


### PR DESCRIPTION
### Summary

Secondary navigation uses a hardcoded `|` as the divider which is read in JAWS as “Link About Vertical Bar, Link Subscribe Vertical Bar… (JAWS) or “Pipe” between secondary navigation links.

Solution provided by https://github.com/uswds/uswds/pull/4963 to use an entity code for the pipe separator:

`content: "\007C" / "";`

### Question

Firefox says this is an invalid value and the override fails. If I remove `/ ""` then it works.
Any suggestions for Firefox support?

### Safari

Removing `padding-left: .25rem` on `.usa-nav__secondary-item` prevents this Safari display bug:

<img width="1521" alt="Screen Shot 2023-02-02 at 10 14 19 AM" src="https://user-images.githubusercontent.com/104778659/216372797-ad69046f-e9ce-410d-9d09-f014bf6a2266.png">

I've added `margin-left: .25rem` to `.usa-nav__secondary-item::before` to maintain equal spacing for the divider.

