### PR TITLE
pl fix

### DIFF
--- a/content/communities/federal-communicators-network.md
+++ b/content/communities/federal-communicators-network.md
@@ -25,8 +25,8 @@ community_list:
   - platform: listserv
     type: government
     subscribe_email: "fcn-request@listserv.gsa.gov"
-    subscribe_email_subject: "Join the Communicators Community" 
-    terms: "Government employees and contractors with an official .gov/.mil email are eligible to join."
+    subscribe_email_subject: "Join the Communicators Community"
+    terms: "Government employees and contractors with an official .gov or .mil email are eligible to join."
     members: 1,999
     blurb: "Communicator community members"
 

--- a/content/communities/multilingual.md
+++ b/content/communities/multilingual.md
@@ -39,7 +39,7 @@ community_list:
     type: government
     subscribe_email: "fmwc-request@listserv.gsa.gov"
     subscribe_email_subject: "Join the Multilingual Community"
-    terms: "Government employees and contractors with an official .gov/.mil email are eligible to join."
+    terms: "Government employees and contractors with an official .gov or .mil email are eligible to join."
     members: 534
     blurb: "Multilingual community members"
 

--- a/content/communities/social-media.md
+++ b/content/communities/social-media.md
@@ -35,7 +35,7 @@ community_list:
     type: government
     subscribe_email: "sm-cop-request@listserv.gsa.gov"
     subscribe_email_subject: "Join the Social Media Community"
-    terms: "Federal government employees and contractors with an official .gov/.mil email are eligible to join."
+    terms: "Federal government employees and contractors with an official .gov or .mil email are eligible to join."
     members: 1,181
     blurb: "Social Media community members"
 

--- a/content/communities/user-experience.md
+++ b/content/communities/user-experience.md
@@ -33,7 +33,7 @@ community_list:
     type: government
     subscribe_email: "ux-cop-request@listserv.gsa.gov"
     subscribe_email_subject: "Join the User Experience Community"
-    terms: "Government employees and contractors with an official .gov/.mil email are eligible to join."
+    terms: "Government employees and contractors with an official .gov or .mil email are eligible to join."
     members: 1,769
     blurb: "User Experience community members"
 

--- a/content/communities/web-analytics-and-optimization.md
+++ b/content/communities/web-analytics-and-optimization.md
@@ -41,7 +41,7 @@ community_list:
     type: government
     subscribe_email: "analyze-optimize-request@listserv.gsa.gov"
     subscribe_email_subject: "Join the Web Analytics Community"
-    terms: "Federal government employees and contractors with an official .gov/.mil email are eligible to join."
+    terms: "Federal government employees and contractors with an official .gov or .mil email are eligible to join."
     members: 719
     terms: Government employees and contractors only.
     blurb: "Web Analytic community members"

--- a/content/communities/web-managers-forum.md
+++ b/content/communities/web-managers-forum.md
@@ -46,7 +46,7 @@ community_list:
     type: government_only
     subscribe_email: "content-managers-l-request@listserv.gsa.gov"
     subscribe_email_subject: "Join the Web Managers Community"
-    terms: "Government employees with an official .gov/.mil email are eligible to join."
+    terms: "Government employees with an official .gov or .mil email are eligible to join."
     members: 1,796
     blurb: "Web Manager community members"
 


### PR DESCRIPTION
pl fix

This PR implements the following **changes:**

Replace forward slash in `an official .gov/.mil email are eligible to join.` with the word `or` in 6 CoP

https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/remove-slash-in-cop-terms/communities/federal-communicators-network/ 

