### PR TITLE
a11y - Resources landing

### DIFF
--- a/themes/digital.gov/layouts/partials/core/header.html
+++ b/themes/digital.gov/layouts/partials/core/header.html
@@ -17,7 +17,7 @@
       </svg> Menu
     </button>
   </div>
-  <nav role="navigation" class="usa-nav">
+  <nav aria-label="Primary navigation" class="usa-nav">
     <div class="usa-nav__inner">
       <button class="usa-nav__close">
         <img src="{{ "/uswds/img/close.svg" | relURL }}" alt="close">

--- a/themes/digital.gov/layouts/resources/list.html
+++ b/themes/digital.gov/layouts/resources/list.html
@@ -88,19 +88,15 @@
                       </div>
                     </div>
                     <footer>
-                      <div class="grid-row">
-                        <div class="grid-col-12">
-                          <p class="more">
-                            <a href="{{- .Permalink -}}">
-                              <span>More on {{ .Title -}}</span>
-                              <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true"
-                                focusable="false">
-                                <use xlink:href="{{ " uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
-                              </svg>
-                            </a>
-                          </p>
-                        </div>
-                      </div>
+                      <p class="more">
+                        <a href="{{- .Permalink -}}">
+                          <span>More on {{ .Title -}}</span>
+                          <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true"
+                            focusable="false">
+                            <use xlink:href="{{ " uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
+                          </svg>
+                        </a>
+                      </p>
                     </footer>
                   </div>
                 {{- end -}}
@@ -174,18 +170,14 @@
           {{- end -}}
         </div>
         <footer>
-          <div class="grid-row tablet-lg:grid-gap-2">
-            <div class="grid-col-12">
-              <p class="more">
-                <a href="/topics">
-                  <span>See all topics</span>
-                  <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                    <use xlink:href="{{ " uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
-                  </svg>
-                </a>
-              </p>
-            </div>
-          </div>
+          <p class="more">
+            <a href="/topics">
+              <span>See all topics</span>
+              <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
+                <use xlink:href="{{ " uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
+              </svg>
+            </a>
+          </p>
         </footer>
       </div>
     </section>

--- a/themes/digital.gov/layouts/resources/list.html
+++ b/themes/digital.gov/layouts/resources/list.html
@@ -136,7 +136,7 @@
               <a href="{{- " /topics" | absURL -}}">
                 <span>See all topics</span>
                 <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                  <use xlink:href="{{ " uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
+                  <use xlink:href="{{ "uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
                 </svg>
               </a>
             </p>
@@ -174,7 +174,7 @@
             <a href="/topics">
               <span>See all topics</span>
               <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                <use xlink:href="{{ " uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
+                <use xlink:href="{{ "uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
               </svg>
             </a>
           </p>

--- a/themes/digital.gov/layouts/resources/list.html
+++ b/themes/digital.gov/layouts/resources/list.html
@@ -111,7 +111,7 @@
           </div>
 
           <div class="grid-col-12 tablet:grid-col-3 tablet:order-first">
-            <nav class="toc">
+            <nav class="toc" aria-label="Resources by topic">
               <ul>
 
                 {{/* Gets all the pages in the /topics directory */}}

--- a/themes/digital.gov/layouts/resources/list.html
+++ b/themes/digital.gov/layouts/resources/list.html
@@ -40,7 +40,8 @@
             {{- $resourcesfeatured := (sort $resourcesfeatured "Weight" "desc" ) -}}
 
             {{/* Pass $resourcesfeatured to the collection template */}}
-            {{- partial "core/collection.html" (dict "list" $resourcesfeatured "heading" "Popular Guides and Resources") -}}
+            {{- partial "core/collection.html" (dict "list" $resourcesfeatured "heading" "Popular Guides and Resources")
+            -}}
 
           </div>
         </div>
@@ -53,11 +54,8 @@
     <section class="usa-section" id="resources_by_topic">
       <div class="grid-container grid-container-desktop">
 
-        <div class="grid-row">
-          <div class="grid-col-12">
-            <h2>All Resources by Topic</h2>
-          </div>
-        </div>
+        <h2>All Resources by Topic</h2>
+
         <div class="grid-row grid-gap-4">
 
           <div class="grid-col-12 tablet:grid-col-9">
@@ -71,40 +69,40 @@
               {{/* Loop through all the topics... */}}
               {{ range $name, $taxonomy := $topics_featured }}
 
-                {{/* Get all resource pages with this current taxonomy */}}
-                {{- $resources_by_topic := (where .Pages "Section" "resources") -}}
+              {{/* Get all resource pages with this current taxonomy */}}
+              {{- $resources_by_topic := (where .Pages "Section" "resources") -}}
 
                 {{/* If there are resources... */}}
                 {{- if $resources_by_topic -}}
-                <div class="topic-section">
-                  <div class="grid-row">
-                    <div class="grid-col-12">
-                      <h3 id="{{- path.Base .RelPermalink -}}"><a href="{{- .Permalink -}}">{{- .Title -}}</a></h3>
-                    </div>
-                  </div>
-                  <div class="grid-row">
-                    <div class="grid-col-12 tablet-lg:grid-col-10">
-
-                      {{/* Pass the $resources_by_topic to the collection template */}}
-                      {{- partial "core/collection.html" (dict "list" $resources_by_topic) -}}
-
-                    </div>
-                  </div>
-                  <footer>
+                  <div class="topic-section">
                     <div class="grid-row">
                       <div class="grid-col-12">
-                        <p class="more">
-                          <a href="{{- .Permalink -}}">
-                            <span>More on {{ .Title -}}</span>
-                            <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                              <use xlink:href="{{ "uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
-                            </svg>
-                          </a>
-                        </p>
+                        <h3 id="{{- path.Base .RelPermalink -}}"><a href="{{- .Permalink -}}">{{- .Title -}}</a></h3>
                       </div>
                     </div>
-                  </footer>
-                </div>
+                    <div class="grid-row">
+                      <div class="grid-col-12 tablet-lg:grid-col-10">
+
+                        {{/* Pass the $resources_by_topic to the collection template */}}
+                        {{- partial "core/collection.html" (dict "list" $resources_by_topic) -}}
+                      </div>
+                    </div>
+                    <footer>
+                      <div class="grid-row">
+                        <div class="grid-col-12">
+                          <p class="more">
+                            <a href="{{- .Permalink -}}">
+                              <span>More on {{ .Title -}}</span>
+                              <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true"
+                                focusable="false">
+                                <use xlink:href="{{ " uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
+                              </svg>
+                            </a>
+                          </p>
+                        </div>
+                      </div>
+                    </footer>
+                  </div>
                 {{- end -}}
               {{ end }}
             {{ end }}
@@ -117,17 +115,21 @@
                 {{/* Gets all the pages in the /topics directory */}}
                 {{- with ($.Site.GetPage (printf "/%s" "topics")) -}}
 
-                  {{/* Get only the pages that are greater than or equal to 2 */}}
-                  {{- $topics_featured := (where .Pages ".Params.weight" "ge" 2 ) -}}
+                {{/* Get only the pages that are greater than or equal to 2 */}}
+                {{- $topics_featured := (where .Pages ".Params.weight" "ge" 2 ) -}}
 
-                  {{/* Loop through all the topics... */}}
-                  {{ range $name, $taxonomy := $topics_featured }}
+                {{/* Loop through all the topics... */}}
+                {{ range $name, $taxonomy := $topics_featured }}
 
-                    {{/* Get all resource pages with this current taxonomy */}}
-                    {{- $resources_by_topic := (where .Pages "Section" "resources") -}}
+                  {{/* Get all resource pages with this current taxonomy */}}
+                  {{- $resources_by_topic := (where .Pages "Section" "resources") -}}
                     {{- if $resources_by_topic -}}
                       {{- $slug := .RelPermalink -}}
-                      <li><a href="#{{- path.Base .RelPermalink -}}"><span>{{- .Title -}}</span></a></li>
+                      <li>
+                        <a href="#{{- path.Base .RelPermalink -}}">
+                          <span>{{- .Title -}}</span>
+                        </a>
+                      </li>
                     {{- end -}}
                   {{- end -}}
                 {{- end -}}
@@ -135,10 +137,10 @@
               </ul>
             </nav>
             <p class="more">
-              <a href="{{- "/topics" | absURL -}}">
+              <a href="{{- " /topics" | absURL -}}">
                 <span>See all topics</span>
                 <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                  <use xlink:href="{{ "uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
+                  <use xlink:href="{{ " uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
                 </svg>
               </a>
             </p>
@@ -147,8 +149,6 @@
         </div>
       </div>
     </section>
-
-
 
     <section class="topic-buttons">
       <div class="grid-container grid-container-desktop">
@@ -162,13 +162,13 @@
           {{- range $name, $taxonomy := $top_topics -}}
             {{- with $.Site.GetPage (printf "/topics/%s" $name) -}}
               {{- if or (eq .Params.weight 2) (eq .Params.weight 3) -}}
-                <div class="grid-col-12 tablet:grid-col-4">
-                  <div class="topic" data-edit-this="{{- $path -}}">
-                    <h3>
-                      <a href="{{- .Permalink | absURL -}}" title="{{- .Title -}}">{{- .Title -}} <span>&#8594;</span></a>
-                    </h3>
-                  </div>
+              <div class="grid-col-12 tablet:grid-col-4">
+                <div class="topic" data-edit-this="{{- $path -}}">
+                  <h3>
+                    <a href="{{- .Permalink | absURL -}}" title="{{- .Title -}}">{{- .Title -}} <span>&#8594;</span></a>
+                  </h3>
                 </div>
+              </div>
               {{- end -}}
             {{- end -}}
           {{- end -}}
@@ -180,7 +180,7 @@
                 <a href="/topics">
                   <span>See all topics</span>
                   <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
-                    <use xlink:href="{{ "uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
+                    <use xlink:href="{{ " uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>
                   </svg>
                 </a>
               </p>


### PR DESCRIPTION
Resolves card: `DG - Resources landing a11y issues`.

This PR implements the following **changes:**

* Resolves a11y error with _Landmarks must be unique_
* Adds unique aria label to main navigation [0efe6ec7e51bf949773f36aa91b76b6939b043e4]
* Adds unique aria label to Table of Contents on Resources [5db4534c9bcf6db4b2624b0f491bd078e758378b]
* Adds prettier HTML formatting [d44f41669bb800de317c350ebb6a70caaa4ba606]
* Removes unnecessary grid containers on **More** links [2b17c84ebbd8b8b13c4a4b491b202aedd6216ccf]

## How to test

- Verify main navigation has aria label
- Verify Table of Contents on main navigation has aria label
- There should be **no** visual regressions

**Main navigation** (after)

`<nav aria-label="Primary navigation" class="usa-nav">`

**Table of contents** (after)
`<nav class="toc" aria-label="Resources by topic">`


**URL / Link to page**

[Resources landing →](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/jm-a11y-resources-landing/resources/)

