### PR TITLE
update head comment to remove updated date, federalist -> pages

### DIFF
--- a/themes/digital.gov/layouts/partials/core/head-comment.html
+++ b/themes/digital.gov/layouts/partials/core/head-comment.html
@@ -7,12 +7,10 @@ Follow us on Twitter: @digital_gov
 
 =======
 
-Digital.gov was last updated on {{ now.Format "Jan 2, 2006 at 3:04pm ET" }}
-
 We edit in the open at https://workflow.digital.gov/
 Built by the Digital.gov team in the GSA, using modern development practices.
 See the full source code: https://github.com/GSA/digitalgov.gov
 
-Built using HUGO. Hosted on Federalist https://federalist.18f.gov/
+Built using HUGO. Hosted on cloud.gov Pages https://cloud.gov/pages/
 
 {{ "-->" | safeHTML }}


### PR DESCRIPTION
This PR implements the following **changes:**

In the HTML comment that is added to most pages:
- Update "Federalist" to "cloud.gov Pages"
- Remove the "Updated at" section; this adds considerable time to the site build and many pages already indicate when they were edited last

