### PR TITLE
Db no shuffle

### DIFF
--- a/themes/digital.gov/layouts/authors/terms.html
+++ b/themes/digital.gov/layouts/authors/terms.html
@@ -33,7 +33,7 @@
                         {{- if $author.Params.github -}}
                         <img src="https://github.com/{{- $author.Params.github -}}.png?size=50" alt="">
                         {{- else -}}
-                        {{- $default_profile := print "img/digit-" (index (shuffle (slice "light" "dark")) 0) ".png" -}}
+                        {{- $default_profile := print "img/digit-" (cond (eq (mod $i 2) 0) "light" "dark") ".png" -}}
                         <img src="{{- $default_profile | absURL -}}" alt="">
                         {{- end -}}
                       </div>

--- a/themes/digital.gov/layouts/partials/core/get_author_image.html
+++ b/themes/digital.gov/layouts/partials/core/get_author_image.html
@@ -12,7 +12,6 @@ If the author has defined where they want to pull their author photo from:
 - digit-pride
 */}}
 {{- if .author.Params.profile_source -}}
-
   {{/* Sets $profile_source as a variable */}}
   {{- $profile_source := .author.Params.profile_source -}}
 
@@ -23,8 +22,8 @@ If the author has defined where they want to pull their author photo from:
       {{/* get the GitHub template (see bottom of this file) */}}
       {{- template "github" (dict "id" .author.Params.github ) -}}
     {{- else -}}
-      {{/* If they selected github, but don't have a GitHub ID, we're giving them a random 'digit-light' or 'digit-dark' icon */}}
-      {{- $icon_path := print "img/" (index (shuffle (slice "digit-light" "digit-dark")) 0) ".png" -}}
+      {{/* If they selected github, but don't have a GitHub ID, we're giving them a semi-random 'digit-light' or 'digit-dark' icon */}}
+      {{- $icon_path := print "img/digit-" (cond (eq (mod (len .author.Params.slug) 2) 0) "light" "dark") ".png" -}}
       {{- template "digitalgov_icon" (dict "id" $profile_source "icon_path" $icon_path ) -}}
     {{- end -}}
   {{/* if the $profile_source is not "github", meaning it is one of the other options... */}}
@@ -39,14 +38,17 @@ Logic for if the author.Params.profile_source is not set in the author file
 which accounts for most of the author files on Digital.gov
 */}}
 {{- else -}}
-  {{/* A quick check to see if they have a github ID set */}}
-  {{- if .author.Params.github -}}
-    {{- template "github" (dict "id" .author.Params.github ) -}}
+  {{/* A quick check to make sure this isn't the index page */}}
+  {{- if .author.Params.slug -}}
+    {{/* A quick check to see if they have a github ID set */}}
+    {{- if .author.Params.github -}}
+      {{- template "github" (dict "id" .author.Params.github ) -}}
 
-  {{/* If they do not have a GitHub ID, then we're giving them a random 'digit-light' or 'digit-dark' icon */}}
-  {{- else -}}
-    {{- $icon_path := print "img/" (index (shuffle (slice "digit-light" "digit-dark")) 0) ".png" -}}
-    {{- template "digitalgov_icon" (dict "id" .author.Params.profile_source "icon_path" $icon_path ) -}}
+    {{/* If they do not have a GitHub ID, then we're giving them a semi-random 'digit-light' or 'digit-dark' icon */}}
+    {{- else -}}
+      {{- $icon_path := print "img/digit-" (cond (eq (mod (len .author.Params.slug) 2) 0) "light" "dark") ".png" -}}
+      {{- template "digitalgov_icon" (dict "id" .author.Params.profile_source "icon_path" $icon_path ) -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 

--- a/themes/digital.gov/layouts/partials/core/get_related.html
+++ b/themes/digital.gov/layouts/partials/core/get_related.html
@@ -10,10 +10,13 @@
 {{- $related_pages := .Site.Pages.Related  . -}}
 
 {{/* gets only the related community pages */}}
-{{- $communities := where $related_pages "Section" "communities" -}}
+{{- $.Scratch.Set "communities" (where $related_pages "Section" "communities") -}}
 
-{{/* Now shuffle the community pages and pick the first 5 */}}
-{{- $communities := first 5 $communities | shuffle -}}
+{{/* Now conditionally shuffle the community pages and pick the first 5 */}}
+{{ if (gt (len ($.Scratch.Get "communities")) 5) }}
+  {{- $.Scratch.Set "communities" (first 5 ($.Scratch.Get "communities") | shuffle) -}}
+{{ end }}
+{{ $communities := ($.Scratch.Get "communities")}}
 
 {{/* If there are community pages... */}}
 {{- with $communities -}}
@@ -55,8 +58,13 @@
 {{/* gets only the related service pages */}}
 {{- $services := where $related_pages "Section" "services" -}}
 
-{{/* Now shuffle the service pages and pick the first 5 */}}
-{{- $services := first 5 $services | shuffle -}}
+{{- $.Scratch.Set "services" (where $related_pages "Section" "services") -}}
+
+{{/* Now conditionally shuffle the service pages and pick the first 5 */}}
+{{ if (gt (len ($.Scratch.Get "services")) 5) }}
+  {{- $.Scratch.Set "services" (first 5 ($.Scratch.Get "services") | shuffle) -}}
+{{ end }}
+{{ $services := ($.Scratch.Get "services")}}
 
 {{/* If there are services... */}}
 {{- with $services -}}


### PR DESCRIPTION
This PR implements the following **changes:**
- removes use of the hugo function `shuffle` to create more consistent (faster) builds
  - this is used for creating default author thumbnails (on many pages)
  - also used for showing related communities and services (on many pages)
- implements #5831 
