### PR TITLE
Update in-page-navigation.js

### DIFF
--- a/themes/digital.gov/src/js/common/in-page-navigation.js
+++ b/themes/digital.gov/src/js/common/in-page-navigation.js
@@ -1,10 +1,8 @@
 document.addEventListener("DOMContentLoaded", () => {
   const relatedItems = document.querySelector(".content__related-items");
   const inPageNav = document.querySelector(".usa-in-page-nav__nav");
-  const inPageNavHeader = inPageNav.querySelector(".usa-in-page-nav__heading");
+  const inPageNavHeader = document.querySelector(".usa-in-page-nav__heading");
   const navItems = document.querySelectorAll("li.usa-in-page-nav__item:not(.usa-in-page-nav__item--sub-item)");
-
-
 
   if (!relatedItems) {
     return;


### PR DESCRIPTION
Updated javascript to fix null error on line 4 when page does not have the `in-page nav` component.

<img width="1680" alt="Screen Shot 2023-03-03 at 2 57 21 PM" src="https://user-images.githubusercontent.com/104778659/222814599-7e5b17ee-1d05-4110-9307-d7680c5734e3.png">





