### PR TITLE
Update list.html

### DIFF
--- a/themes/digital.gov/layouts/resources/list.html
+++ b/themes/digital.gov/layouts/resources/list.html
@@ -133,7 +133,7 @@
               </ul>
             </nav>
             <p class="more">
-              <a href="{{- " /topics" | absURL -}}">
+              <a href="{{- "/topics" | absURL -}}">
                 <span>See all topics</span>
                 <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false">
                   <use xlink:href="{{ "uswds/img/sprite.svg#arrow_forward" | relURL }}"></use>


### PR DESCRIPTION
This PR implements the following **changes:**
There's an extra space in link for "See all topics" beneath the left menu list, goes to `https://digital.gov/%20/topics/` 

Removed space from line 136

>  <a href="{{- " /topics" | absURL -}}">

**URL / Link to page**

https://digital.gov/resources/ 


