### PR TITLE
Update 2014-07-29-deconstructing-public-prize-competitions-can-result…

### DIFF
--- a/content/news/2014/07/2014-07-29-deconstructing-public-prize-competitions-can-result-in-better-solutions.md
+++ b/content/news/2014/07/2014-07-29-deconstructing-public-prize-competitions-can-result-in-better-solutions.md
@@ -7,19 +7,15 @@ authors:
   - tlowden
 topics:
   - challenges
-  - Centers for Medicare and Medicaid Services
   - challenge-gov
   - challenges-and-prizes-community-of-practice
-  - CMS
-  - digitalgov-university
-  - HHS
   - recaps
-  - united-states-department-of-health-and-human-services
+
 ---
 
-{{< legacy-img src="2014/07/600-x-420-Gold-medals-Igor-Poleshchuk-Hemera-Thinkstock-101861678.jpg" alt="Gold medals" caption="Igor Poleshchuk/Hemera/Thinkstock" >}}
-
 When faced with a big, daunting problem to solve, it’s human nature to try to tackle it by breaking it down into smaller parts and taking it “one step at a time.” The message from a recent DigitalGov University webinar on public prize competitions (AKA ‘challenges’) was that the government can often receive better solutions by going through the exact same process, and giving awards at each step.
+
+{{< legacy-img src="2014/07/600-x-420-Gold-medals-Igor-Poleshchuk-Hemera-Thinkstock-101861678.jpg" alt="Gold medals" caption="Igor Poleshchuk/Hemera/Thinkstock" >}}
 
 A great example of the power of this style of challenge is the <a href="http://www.topcoder.com/cms/hfpp/" target="_blank">Healthcare Fraud Prevention Partnership (HFPP) Challenge</a>, which was run by the Centers for Medicare and Medicaid Services (CMS). It was broken into 55 discrete pieces, with an award at the end of each “mini-competition.”
 


### PR DESCRIPTION
This PR implements the following **changes:**

fix formatting, remove DGU topic

**URL / Link to page**

https://digital.gov/2014/07/29/deconstructing-public-prize-competitions-can-result-in-better-solutions/ 

https://web.archive.org/web/20150707040545/https://www.digitalgov.gov/2014/07/29/deconstructing-public-prize-competitions-can-result-in-better-solutions/ 

Preview: 
