### PR TITLE
Events: Add placeholder to upcoming events section

### DIFF
--- a/themes/digital.gov/layouts/events/list.html
+++ b/themes/digital.gov/layouts/events/list.html
@@ -40,6 +40,14 @@
             {{ .Render "card-event"}}
           {{ end }}
         {{ end }}
+      {{ else }}
+        {{/*  @TODO Add as an option for card refactor */}}
+        <section
+          class="upcoming-events__placeholder card card--placeholder"
+          aria-label="There are no scheduled events yet"
+        >
+          No upcoming events scheduled
+        </section>
       {{ end }}
     </div>
   </section>

--- a/themes/digital.gov/layouts/events/list.html
+++ b/themes/digital.gov/layouts/events/list.html
@@ -1,27 +1,21 @@
 {{ define "content" }}
 
+{{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
+
 <main role="main" id="main-content">
   <header class="page-head page-head-{{- .Type -}}">
-    <div class="grid-container grid-container-desktop">
-      <div class="grid-row">
-        {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
-        <div class="grid-col-12" data-edit-this="{{- $path -}}">
+    <div class="grid-container grid-container-desktop" data-edit-this="{{- $path -}}">
+      {{/* Page Title */}}
+      <h1>{{- .Title | markdownify -}} </h1>
 
-          {{/* Page Title */}}
-          <h1>{{- .Title | markdownify -}} </h1>
+      {{/* Deck */}}
+      {{- if .Params.deck -}}
+      <div class="deck">{{- .Params.deck | markdownify -}}</div>
+      {{- end -}}
 
-          {{/* Deck */}}
-          {{- if .Params.deck -}}
-          <div class="deck">{{- .Params.deck | markdownify -}}</div>
-          {{- end -}}
-
-          <div class="join-buttons">
-            <a href="https://www.youtube.com/@DigitalGov">Video library</a>
-            <a href="#events-past">Past events</a>
-          </div>
-
-
-        </div>
+      <div class="join-buttons">
+        <a href="https://www.youtube.com/@DigitalGov">Video library</a>
+        <a href="#events-past">Past events</a>
       </div>
     </div>
   </header>
@@ -57,23 +51,15 @@
   <section id="events-past">
     <header>
       <div class="grid-container grid-container-desktop">
-        <div class="grid-row">
-          <div class="grid-col-12">
-            <h2>Past Events</h2>
-          </div>
-        </div>
+        <h2>Past Events</h2>
       </div>
     </header>
     <div class="article-list">
       <div class="grid-container grid-container-desktop">
-        <div class="grid-row tablet-lg:grid-gap-3">
-          <div class="grid-col-12">
-            {{ $events := where .Site.RegularPages.ByDate "Section" "events" }}
-            {{ range where $events.Reverse ".Date.Unix" "<" now.Unix }}
-              {{ .Render "card-event-past"}}
-            {{ end }}
-          </div>
-        </div>
+        {{ $events := where .Site.RegularPages.ByDate "Section" "events" }}
+        {{ range where $events.Reverse ".Date.Unix" "<" now.Unix }}
+          {{ .Render "card-event-past"}}
+        {{ end }}
       </div>
     </div>
   </section>

--- a/themes/digital.gov/layouts/events/list.html
+++ b/themes/digital.gov/layouts/events/list.html
@@ -26,13 +26,8 @@
 
       {{/*  Show upcoming events up until event ends  */}}
       {{ range where .Site.Pages.Reverse "Params.End_date" ">=" $now }}
-        {{ $start := .Date.Format "2006-01-02" }}
-
-        {{ $end := dateFormat "2006-01-02" .Params.End_date }}
-        {{ if or (ge $start $now) (ge $end $now)}}
-          {{ if .Params.registration_url }}
-            {{ .Render "card-event"}}
-          {{ end }}
+        {{ if .Params.registration_url }}
+          {{ .Render "card-event"}}
         {{ end }}
       {{ else }}
         {{/*  @TODO Add as an option for card refactor */}}

--- a/themes/digital.gov/layouts/events/list.html
+++ b/themes/digital.gov/layouts/events/list.html
@@ -2,6 +2,8 @@
 
 {{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
 
+{{ $now := now.Format "2006-01-02" }}
+
 <main role="main" id="main-content">
   <header class="page-head page-head-{{- .Type -}}">
     <div class="grid-container grid-container-desktop" data-edit-this="{{- $path -}}">
@@ -22,8 +24,6 @@
 
   <section class="upcoming-events article-list">
     <div class="grid-container grid-container-desktop">
-      {{ $now := now.Format "2006-01-02" }}
-
       <h2>Upcoming Events</h2>
 
       {{/*  Show upcoming events up until event ends  */}}
@@ -53,7 +53,11 @@
       <div class="grid-container grid-container-desktop">
         {{ $events := where .Site.RegularPages.ByDate "Section" "events" }}
         {{ range where $events.Reverse ".Date.Unix" "<" now.Unix }}
-          {{ .Render "card-event-past"}}
+          {{ $endDate := .Params.End_date | time.Format "2006-01-02"}}
+
+          {{ if lt $endDate $now }}
+            {{ .Render "card-event-past"}}
+          {{ end }}
         {{ end }}
       </div>
     </div>

--- a/themes/digital.gov/layouts/events/list.html
+++ b/themes/digital.gov/layouts/events/list.html
@@ -34,7 +34,7 @@
       {{ else }}
         {{/*  @TODO Add as an option for card refactor */}}
         <div class="upcoming-events__placeholder card card--placeholder">
-          <h3>Upcoming events will be added soon</h3>
+          <h3>Upcoming events will be added soon.</h3>
           To be notified of new events, <a href="{{ "subscribe" | relURL }}">subscribe to our newsletter</a>!
         </div>
       {{ end }}

--- a/themes/digital.gov/layouts/events/list.html
+++ b/themes/digital.gov/layouts/events/list.html
@@ -26,30 +26,21 @@
     </div>
   </header>
 
-  <section class="article-list">
+  <section class="upcoming-events article-list">
     <div class="grid-container grid-container-desktop">
-      <div class="grid-row tablet-lg:grid-gap-3">
-        <div class="grid-col-12">
-          {{ range .Data.Pages.Reverse }}
-          {{ $now := now.Format "2006-01-02" }}
-          {{ $start := .Date.Format "2006-01-02"  }}
+      {{ $now := now.Format "2006-01-02" }}
 
-          {{ if .Params.End_date }}
-            {{ $end := dateFormat "2006-01-02" .Params.End_date }}
-            {{ if or (ge $start $now) (ge $end $now)}}
-              {{ if .Params.registration_url }}
-                {{ .Render "card-event"}}
-              {{ end }}
-            {{ end }}
+      {{/*  Show upcoming events up until event ends  */}}
+      {{ range where .Site.Pages.Reverse "Params.End_date" ">=" $now }}
+        {{ $start := .Date.Format "2006-01-02" }}
 
-            {{ else if ge $start $now }}
-              {{ if .Params.registration_url }}
-                {{ .Render "card-event"}}
-              {{ end }}
-            {{ end }}
+        {{ $end := dateFormat "2006-01-02" .Params.End_date }}
+        {{ if or (ge $start $now) (ge $end $now)}}
+          {{ if .Params.registration_url }}
+            {{ .Render "card-event"}}
           {{ end }}
-        </div>
-      </div>
+        {{ end }}
+      {{ end }}
     </div>
   </section>
 

--- a/themes/digital.gov/layouts/events/list.html
+++ b/themes/digital.gov/layouts/events/list.html
@@ -33,12 +33,10 @@
         {{ end }}
       {{ else }}
         {{/*  @TODO Add as an option for card refactor */}}
-        <section
-          class="upcoming-events__placeholder card card--placeholder"
-          aria-label="There are no scheduled events yet"
-        >
-          No upcoming events scheduled
-        </section>
+        <div class="upcoming-events__placeholder card card--placeholder">
+          <h3>Upcoming events will be added soon</h3>
+          To be notified of new events, <a href="{{ "subscribe" | relURL }}">subscribe to our newsletter</a>!
+        </div>
       {{ end }}
     </div>
   </section>

--- a/themes/digital.gov/layouts/events/list.html
+++ b/themes/digital.gov/layouts/events/list.html
@@ -24,6 +24,8 @@
     <div class="grid-container grid-container-desktop">
       {{ $now := now.Format "2006-01-02" }}
 
+      <h2>Upcoming Events</h2>
+
       {{/*  Show upcoming events up until event ends  */}}
       {{ range where .Site.Pages.Reverse "Params.End_date" ">=" $now }}
         {{ if .Params.registration_url }}

--- a/themes/digital.gov/src/scss/new/_card.scss
+++ b/themes/digital.gov/src/scss/new/_card.scss
@@ -144,7 +144,7 @@
 
 // Used in upcoming events section
 .card.card--placeholder {
-  @include u-font("ui", "xl");
+  @include u-font("ui", "lg");
   border-top: 2px solid color("base-lighter");
   display: block;
   font-weight: font-weight(300);

--- a/themes/digital.gov/src/scss/new/_card.scss
+++ b/themes/digital.gov/src/scss/new/_card.scss
@@ -141,3 +141,13 @@
     }
   }
 }
+
+// Used in upcoming events section
+.card.card--placeholder {
+  @include u-font("ui", "xl");
+  border-top: 2px solid color("base-lighter");
+  display: block;
+  font-weight: font-weight(300);
+  padding: units(7);
+  text-align: center;
+}

--- a/themes/digital.gov/src/scss/new/_events.scss
+++ b/themes/digital.gov/src/scss/new/_events.scss
@@ -150,11 +150,3 @@
     }
   }
 }
-
-#events-past {
-  header h2 {
-    @include u-margin-y(2);
-    @include u-font("sans", "xl");
-    @include u-text("heavy");
-  }
-}

--- a/themes/digital.gov/src/scss/new/_events.scss
+++ b/themes/digital.gov/src/scss/new/_events.scss
@@ -2,159 +2,159 @@
 
 // Events
 
-.events-list{
-  .event{
+.events-list {
+  .event {
     @include u-margin-bottom(5);
-    h2,h3{
+    h2,
+    h3 {
       @include u-margin(0);
-      @include u-margin-bottom('05');
-      @include u-text('bold');
-      @include u-font('sans', 'lg');
-      a{
-        @include u-text('no-underline');
-        @include u-text('primary-darkest');
-        &:hover{
-          @include u-border-bottom('2px', 'primary-vivid', 'solid');
+      @include u-margin-bottom("05");
+      @include u-text("bold");
+      @include u-font("sans", "lg");
+      a {
+        @include u-text("no-underline");
+        @include u-text("primary-darkest");
+        &:hover {
+          @include u-border-bottom("2px", "primary-vivid", "solid");
         }
       }
     }
-    h5{
+    h5 {
       @include u-margin(0);
-      @include u-font('sans', 'sm');
-      @include u-text('medium');
-      @include u-text('accent-warm-dark');
-      span{
-        @include u-margin-x('05');
-        @include u-text('accent-warm-dark');
+      @include u-font("sans", "sm");
+      @include u-text("medium");
+      @include u-text("accent-warm-dark");
+      span {
+        @include u-margin-x("05");
+        @include u-text("accent-warm-dark");
       }
     }
-    p{
+    p {
       @include u-margin-top(1);
-      @include u-font('sans', 'sm');
-      @include u-text('light');
+      @include u-font("sans", "sm");
+      @include u-text("light");
       @include u-measure(2);
     }
   }
 }
 
-.event{
-  .datetime{
+.event {
+  .datetime {
     @include u-margin-y(2);
-    @include u-text('semibold');
-    span{
-      @include u-display('block');
-      @include at-media('tablet') {
-        @include u-margin-left('105');
-  			@include u-display('inline');
-  		}
+    @include u-text("semibold");
+    span {
+      @include u-display("block");
+      @include at-media("tablet") {
+        @include u-margin-left("105");
+        @include u-display("inline");
+      }
     }
-
   }
-  .host{
-    @include u-text('gray-warm-60');
+  .host {
+    @include u-text("gray-warm-60");
   }
-  .stage{
+  .stage {
     @include u-margin-bottom(5);
-    @include u-bg('base-lightest');
+    @include u-bg("base-lightest");
     @include u-padding(3);
 
     // YouTube LIVE Chatbox
-    .chat-box{
-      iframe{
-        width:322px;
+    .chat-box {
+      iframe {
+        width: 322px;
       }
     }
   }
-  .stage-zoom{
+  .stage-zoom {
     @include u-margin-bottom(4);
     @include u-padding(2);
-    @include u-radius('sm');
-    @include u-display('flex');
-    p{
+    @include u-radius("sm");
+    @include u-display("flex");
+    p {
       @include u-margin-top(0);
       @include u-margin-bottom(2);
-      @include u-maxw('full');
-      @include u-font('sans', '2xs');
-      @include u-line-height('sans', 3);
-      @include at-media('tablet') {
-        @include u-font('sans', 'xs');
-        @include u-line-height('sans', 3);
+      @include u-maxw("full");
+      @include u-font("sans", "2xs");
+      @include u-line-height("sans", 3);
+      @include at-media("tablet") {
+        @include u-font("sans", "xs");
+        @include u-line-height("sans", 3);
       }
-      &:last-child{
+      &:last-child {
         @include u-margin-bottom(0);
       }
     }
 
-    .icon{
-      @include u-font('sans', 'md');
-      @include u-margin-top('05');
+    .icon {
+      @include u-font("sans", "md");
+      @include u-margin-top("05");
       @include u-margin-right(1);
-      @include at-media('tablet') {
-        @include u-margin-right('105');
-        @include u-font('sans', 'lg');
+      @include at-media("tablet") {
+        @include u-margin-right("105");
+        @include u-font("sans", "lg");
       }
-      p{
-        @include u-text('primary-darker');
-        @include u-text('center');
+      p {
+        @include u-text("primary-darker");
+        @include u-text("center");
         @include u-circle(5);
-        @include at-media('tablet') {
+        @include at-media("tablet") {
           @include u-circle(6);
-    		}
-        @include u-border('2px', 'solid', 'primary-darker');
-        @include u-display('flex');
-        @include u-flex('align-center');
-        @include u-flex('justify-center');
+        }
+        @include u-border("2px", "solid", "primary-darker");
+        @include u-display("flex");
+        @include u-flex("align-center");
+        @include u-flex("justify-center");
       }
     }
   }
 
   // Captions URL
-  .captions{
+  .captions {
     @include u-padding-y(1);
     @include u-padding-x(0);
-    @include u-font('sans', 'xs');
-    @include u-text('no-underline');
-    @include u-text('primary-darker');
-    &:hover{
-      span{
-        @include u-border-bottom('2px','primary-vivid','solid');
+    @include u-font("sans", "xs");
+    @include u-text("no-underline");
+    @include u-text("primary-darker");
+    &:hover {
+      span {
+        @include u-border-bottom("2px", "primary-vivid", "solid");
       }
     }
   }
 
-  .event-tools{
+  .event-tools {
     @include u-padding(1);
-    @include u-bg('gray-warm-2');
+    @include u-bg("gray-warm-2");
     // YouTube LIVE
     // styles for a link that takes people directly to YouTube
-    .youtube{
+    .youtube {
       @include u-padding-y(1);
       @include u-padding-x(1);
-      @include u-font('sans', 'xs');
-      @include u-text('no-underline');
-      @include u-radius('md');
-      @include u-text('red-50');
-      &:hover{
-        span{
-          border-bottom:2px #d83933 solid;
+      @include u-font("sans", "xs");
+      @include u-text("no-underline");
+      @include u-radius("md");
+      @include u-text("red-50");
+      &:hover {
+        span {
+          border-bottom: 2px #d83933 solid;
         }
       }
     }
-    .captions{
+    .captions {
       @include u-padding-x(1);
     }
     // YouTube LIVE Comments box notice
-    .notice{
+    .notice {
       @include u-padding-x(1);
-      @include u-font('sans', '3xs');
+      @include u-font("sans", "3xs");
     }
   }
 }
 
-#events-past{
-  header h2{
+#events-past {
+  header h2 {
     @include u-margin-y(2);
-    @include u-font('sans', 'xl');
-    @include u-text('heavy');
+    @include u-font("sans", "xl");
+    @include u-text("heavy");
   }
 }


### PR DESCRIPTION
This PR implements the following **changes:**

* Simplifies upcoming date logic on Events landing
* Adds a placeholder when there are no upcoming events


**URL / Link to page**
- [Events landing (no upcoming)](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/jm-events-upcoming-placeholder/events/)
- [Events landing (multiple events)](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/jm-events-upcoming-placeholder-test/events/)

**Preview**

![image](https://user-images.githubusercontent.com/3385219/228620969-b862758d-d582-4a3a-a8f6-4ff2e4764d7a.png)
