### PR TITLE
Global - Last updated: remove name author name from link

### DIFF
--- a/themes/digital.gov/src/js/common/edit-this.js
+++ b/themes/digital.gov/src/js/common/edit-this.js
@@ -2,7 +2,7 @@ jQuery(function ($) {
   function enable_edit_this(){
     $('*[data-edit-this]').each(function(){
       var filepath = $(this).data('edit-this');
-      var edit_link = '<a class="edit_this_btn" href="https://github.com/'+git_org+'/'+git_repo+'/edit/'+branch+'/content/'+filepath+'" title="edit this" target="_blank"><span>edit</span></a>';
+      var edit_link = `<a class="edit_this_btn" href="https://github.com/${git_org}/${git_repo}/edit/${branch}/content/${filepath}" title="edit this" target="_blank"><span>edit</span></a>`;
       $(this).addClass('edit-this').append(edit_link);
     });
   }

--- a/themes/digital.gov/src/js/common/github.js
+++ b/themes/digital.gov/src/js/common/github.js
@@ -16,7 +16,7 @@ jQuery(function ($) {
     if (branch == "main") {
       branchpath = "";
     } else {
-      branchpath = "/" + branch;
+      branchpath = `/${branch}`;
     }
     var commit_api_path = `https://api.github.com/repos/${git_org}/${git_repo}/commits${branchpath}?path=/content/${filepath}`;
     if (commit_api_path !== undefined) {
@@ -42,38 +42,17 @@ jQuery(function ($) {
     var branch_link = get_branch_link(branch);
     var commit_data = Array.isArray(data) ? data[0] : data;
     var commit_date = commit_data.commit.committer.date;
-    var commit_author = (commit_data.author || {}).login;
-    var commit_author_url = `https://github.com/${commit_author}`;
     var commit_history_url = `https://github.com/GSA/digitalgov.gov/commits/${branch}/content/${filepath}`;
-    if (commit_author) {
-      last_commit = [
-        branch_link,
-        `<p>Last updated by
-          <a href="${commit_author_url}" title="${commit_author}">
-          <span class="commit-author">${commit_author}</span>
-          </a> on <a href="${commit_history_url}"><span class="commit-date">${formatDate(
-          commit_date
-        )}</span>
-        </a></p>`,
-      ];
-    } else {
-      last_commit = [
-        branch_link,
-        `<p>Last updated on <a href=${commit_history_url}>
-          <span class='commit-date'>${formatDate(commit_date)}</span>
-        </a></p>`,
-      ];
-    }
+
+    last_commit = [
+      branch_link,
+      `<p>Last updated on <a href=${commit_history_url}>
+        <span class='commit-date'>${formatDate(commit_date)}</span>
+      </a></p>`,
+    ];
+
     $(".edit_file").each(function (i, items_list) {
       $(this).append(last_commit.join("\n"));
-    });
-  }
-
-  function show_branch_last_commit(data, branch) {
-    var branch_link = get_branch_link(branch);
-    var last_commit = [branch_link].join("\n");
-    $(".edit_file").each(function (i, items_list) {
-      $(this).append(last_commit).removeClass("hidden");
     });
   }
 });

--- a/themes/digital.gov/src/js/common/github.js
+++ b/themes/digital.gov/src/js/common/github.js
@@ -40,7 +40,7 @@ jQuery(function ($) {
 
   function show_last_commit(data, branch) {
     var branch_link = get_branch_link(branch);
-    var commit_data = $.isArray(data) ? data[0] : data;
+    var commit_data = Array.isArray(data) ? data[0] : data;
     var commit_date = commit_data.commit.committer.date;
     var commit_author = (commit_data.author || {}).login;
     var commit_author_url = `https://github.com/${commit_author}`;

--- a/themes/digital.gov/src/js/common/github.js
+++ b/themes/digital.gov/src/js/common/github.js
@@ -76,50 +76,6 @@ jQuery(function ($) {
       $(this).append(last_commit).removeClass("hidden");
     });
   }
-
-  function getFormattedDate(d) {
-    var date = new Date(d);
-    date.setUTCHours(date.getUTCHours() - 4);
-    var monthNames = [
-      "Jan",
-      "Feb",
-      "Mar",
-      "Apr",
-      "May",
-      "Jun",
-      "Jul",
-      "Aug",
-      "Sep",
-      "Oct",
-      "Nov",
-      "Dec",
-    ];
-    var year = date.getUTCFullYear();
-    var month = date.getUTCMonth().toString();
-    var hours;
-    month = monthNames[month];
-    var day = date.getUTCDate().toString();
-    day = day.length > 1 ? day : "0" + day;
-    var globalhours = parseInt(date.getUTCHours().toString());
-    if (globalhours === 0) {
-      hours = 12;
-    } else if (globalhours > 12) {
-      hours = globalhours - 12;
-    } else {
-      hours = globalhours;
-    }
-    var minutes = date.getUTCMinutes().toString();
-    minutes = minutes.length > 1 ? minutes : "0" + minutes;
-    var seconds = date.getUTCSeconds().toString();
-    var ampm;
-    if (globalhours > 11) {
-      ampm = "pm";
-    } else {
-      ampm = "am";
-    }
-    var date_string = `${month} ${day}, ${year} at ${hours}:${minutes} ${ampm} ET`;
-    return date_string;
-  }
 });
 
 function formatDate(timezone_date) {

--- a/themes/digital.gov/src/js/common/github.js
+++ b/themes/digital.gov/src/js/common/github.js
@@ -139,6 +139,9 @@ function formatDate(timezone_date) {
   };
 
   const output_date = input_date.toLocaleDateString(undefined, dateOptions);
-  const output_time = input_date.toLocaleTimeString("en-US", timeOptions).replace('AM', 'a.m.,').replace('PM', 'p.m.,');
+  const output_time = input_date
+    .toLocaleTimeString("en-US", timeOptions)
+    .replace("AM", "a.m.,")
+    .replace("PM", "p.m.,");
   return `${output_date} at ${output_time}`;
 }

--- a/themes/digital.gov/src/js/common/github.js
+++ b/themes/digital.gov/src/js/common/github.js
@@ -4,7 +4,7 @@ jQuery(function ($) {
     // editpathURL is set the <head>
     if (editpathURL !== undefined) {
       // Build the edit link
-      var edit = `<a target='_blank' class='edit_file_link' href='${editpathURL}' title='Edit in GitHub'><span>Edit</span></a>`;
+      var edit = `<a target='_blank' class='edit_file_link' href='${editpathURL}' title='Edit in GitHub'>Edit</a>`;
 
       // Insert the .edit_file_link html into the .edit_file div and remove the .hidden class
       $("#page-data .edit_file").html(edit).removeClass("hidden");


### PR DESCRIPTION
## Summary

Basic description of work done. Remove unnecessary code
<!-- Closes trello card _Remove "last edited by" name at the bottom of each DG page_. -->

### Additional information

- Ran prettier formatting
- Cleaned up `Edit this` markup in script
- Removed unused code

<!--
```diff
- Last updated by [ToniBonittoGSA ](https://github.com/ToniBonittoGSA)on [Mar 3, 2023 at 4:57 p.m., ET](https://github.com/GSA/digitalgov.gov/commits/main/content/resources/checklist-of-requirements-for-federal-digital-services.md)
+ Last updated on [Mar 3, 2023 at 4:57 p.m., ET](https://github.com/GSA/digitalgov.gov/commits/main/content/resources/checklist-of-requirements-for-federal-digital-services.md)
```
-->

### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/jm-remove-last-edited-name/resources/checklist-of-requirements-for-federal-digital-services/?dg#:~:text=Last%20updated%20on%20Mar%2031%2C%202023%20at%202%3A34%20p.m.%2C%20ET)


<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

<!--
### Solution

### How To Test

1. Visit any page
2. View `Updated` line at the bottom
3. Verify that username is gone
4. Edit link should function as normal
-->

---

### Dev Checklist

- [x] PR has correct labels
- [x] Code is formatted properly
