### PR TITLE
Create component for USWDS button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "digitalgov.gov",
       "version": "2.0.0",
       "dependencies": {
-        "@uswds/uswds": "^3.3.0",
-        "autoprefixer": "^10.4.13",
+        "@uswds/uswds": "^3.4.1",
+        "autoprefixer": "^10.4.14",
         "gulp": "^4.0.2",
         "gulp-concat": "^2.6.1",
         "gulp-dart-scss": "^1.1.0",
@@ -18,14 +18,14 @@
         "gulp-replace": "^1.1.4",
         "gulp-sass": "^5.1.0",
         "gulp-sourcemaps": "^3.0.0",
-        "gulp-svg-sprite": "2.0.1",
+        "gulp-svg-sprite": "2.0.3",
         "gulp-uglify": "^3.0.2",
-        "jquery": "^3.6.3",
+        "jquery": "^3.6.4",
         "jshint": "^2.13.6",
         "npm-run-all": "^4.1.5",
         "postcss-csso": "^5.0.1",
-        "sass": "^1.58.3",
-        "sass-embedded": "^1.58.3"
+        "sass": "^1.60.0",
+        "sass-embedded": "^1.60.0"
       },
       "devDependencies": {
         "del": "^3.0.0",
@@ -369,9 +369,9 @@
       }
     },
     "node_modules/@uswds/uswds": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.3.0.tgz",
-      "integrity": "sha512-qiugkbwrO+eIIwi4lbEdH15LCHuAjfUMDRQNBBujakR99Ka3iqmrLpPllffdKaJJnnYkt75v0lltnJ5Nnd/obQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.4.1.tgz",
+      "integrity": "sha512-eLYbWUqf9eWUa2P6CO3ckIjtQyM3AylrIOHxN5gYG3P62TDd3FzRDyoACfvOe6CNk0w0PqXWJnuPzxpNoOgWNA==",
       "dependencies": {
         "classlist-polyfill": "1.0.3",
         "object-assign": "4.1.1",
@@ -729,9 +729,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.13",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
-      "integrity": "sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==",
+      "version": "10.4.14",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
+      "integrity": "sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -743,8 +743,8 @@
         }
       ],
       "dependencies": {
-        "browserslist": "^4.21.4",
-        "caniuse-lite": "^1.0.30001426",
+        "browserslist": "^4.21.5",
+        "caniuse-lite": "^1.0.30001464",
         "fraction.js": "^4.2.0",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -1074,9 +1074,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001462",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001462.tgz",
-      "integrity": "sha512-PDd20WuOBPiasZ7KbFnmQRyuLE7cFXW2PVd7dmALzbkUXEP46upAuCDm9eY9vho8fgNMGmbAX92QBZHzcnWIqw==",
+      "version": "1.0.30001473",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001473.tgz",
+      "integrity": "sha512-ewDad7+D2vlyy+E4UJuVfiBsU69IL+8oVmTuZnH5Q6CIUbxNfI50uVpRHbUPDD6SUaN2o0Lh4DhTrvLG/Tn1yg==",
       "funding": [
         {
           "type": "opencollective",
@@ -1085,6 +1085,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -3218,15 +3222,26 @@
       }
     },
     "node_modules/gulp-svg-sprite": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/gulp-svg-sprite/-/gulp-svg-sprite-2.0.1.tgz",
-      "integrity": "sha512-hK+ipciM9YU9G3lAeBMqZJaDsiq7NMXOkirR7DkU/YhhzE+JEnhp8DzzYC58Dt09KpAmwoK49SIyyk/1UvkJLg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/gulp-svg-sprite/-/gulp-svg-sprite-2.0.3.tgz",
+      "integrity": "sha512-cQClfYEHyFTqEqlFoMiDXYdGXt3qFU7OxWp8m0ZJNhN/EpOGYRRPAtxJV3Uum7VO0qvZBkcv70y54QSxRKTWBA==",
       "dependencies": {
-        "plugin-error": "^1.0.1",
+        "plugin-error": "^2.0.1",
         "svg-sprite": "^2.0.2"
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/gulp-svg-sprite/node_modules/plugin-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-2.0.1.tgz",
+      "integrity": "sha512-zMakqvIDyY40xHOvzXka0kUvf40nYIuwRE8dWhti2WtjQZ31xAgBZBhxsK7vK3QbRXS1Xms/LO7B5cuAsfB2Gg==",
+      "dependencies": {
+        "ansi-colors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/gulp-tap": {
@@ -6304,9 +6319,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.58.3",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.58.3.tgz",
-      "integrity": "sha512-Q7RaEtYf6BflYrQ+buPudKR26/lH+10EmO9bBqbmPh/KeLqv8bjpTNqxe71ocONqXq+jYiCbpPUmQMS+JJPk4A==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.60.0.tgz",
+      "integrity": "sha512-updbwW6fNb5gGm8qMXzVO7V4sWf7LMXnMly/JEyfbfERbVH46Fn6q02BX7/eHTdKpE7d+oTkMMQpFWNUMfFbgQ==",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -6320,9 +6335,9 @@
       }
     },
     "node_modules/sass-embedded": {
-      "version": "1.58.3",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.58.3.tgz",
-      "integrity": "sha512-PKU971G3mRgHfimkUJ9rGcYNkviz36muU/QtxTfkPB/YLWyVwHmlU+vvZ7WsBiauvWJapEwAoBDdJ5FlTYm3lQ==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.60.0.tgz",
+      "integrity": "sha512-pTCcbAaymfRX0Zkc17fGAVRBX3PPnj0vmWg93oGpeP/IMncxa58s+OPgDNIjSTDJ5wZGjTc95L1QY/zlubjC0g==",
       "dependencies": {
         "@bufbuild/protobuf": "^1.0.0",
         "buffer-builder": "^0.2.0",
@@ -6334,20 +6349,20 @@
         "node": ">=14.0.0"
       },
       "optionalDependencies": {
-        "sass-embedded-darwin-arm64": "1.58.3",
-        "sass-embedded-darwin-x64": "1.58.3",
-        "sass-embedded-linux-arm": "1.58.3",
-        "sass-embedded-linux-arm64": "1.58.3",
-        "sass-embedded-linux-ia32": "1.58.3",
-        "sass-embedded-linux-x64": "1.58.3",
-        "sass-embedded-win32-ia32": "1.58.3",
-        "sass-embedded-win32-x64": "1.58.3"
+        "sass-embedded-darwin-arm64": "1.60.0",
+        "sass-embedded-darwin-x64": "1.60.0",
+        "sass-embedded-linux-arm": "1.60.0",
+        "sass-embedded-linux-arm64": "1.60.0",
+        "sass-embedded-linux-ia32": "1.60.0",
+        "sass-embedded-linux-x64": "1.60.0",
+        "sass-embedded-win32-ia32": "1.60.0",
+        "sass-embedded-win32-x64": "1.60.0"
       }
     },
     "node_modules/sass-embedded-darwin-arm64": {
-      "version": "1.58.3",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.58.3.tgz",
-      "integrity": "sha512-6CrksxvM10xKAQJX3KTJzrW6gfz21ExxUQnV6w5Ggje0adsq+QQu+BBgoPO2ziBVq+UiupcP7apcbmEHvyuZ7w==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.60.0.tgz",
+      "integrity": "sha512-vgHLlLo+HggvmDT60fwMDJjjSUBRp65yZBbaXNEigUjHCAt4ghQ0fsWmcyWRXX8yFAOVH3Ya8qtbUlkvE1e3qw==",
       "cpu": [
         "arm64"
       ],
@@ -6360,9 +6375,9 @@
       }
     },
     "node_modules/sass-embedded-darwin-x64": {
-      "version": "1.58.3",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.58.3.tgz",
-      "integrity": "sha512-clajXOWN0YP/WItxZJnmAvIiUBts6G28X8Oy/TPcNNzRSwRORHyHXKetbTazULWAkaSBJFFg95aP8sqJvmo+Iw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.60.0.tgz",
+      "integrity": "sha512-K7uFEzL5CnzPh7uNscstd2v4NooTJoQyjd64z6y3MWb3ArCl57w4ig/QAzwnydJ2YgaJD2YYVQrokCHyu4tjOw==",
       "cpu": [
         "x64"
       ],
@@ -6375,9 +6390,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm": {
-      "version": "1.58.3",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.58.3.tgz",
-      "integrity": "sha512-FhXfAkeVIqClbSziaMWENjy4CJNeZlKVHTML037hVyxntWAmi86OJ9+J13QmlDILiB8bw9BSpRJEkly8O15Tzw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.60.0.tgz",
+      "integrity": "sha512-bLefkjt6kaHI9XqxRd+xHPSiKd/Klx7aVOV7K68F4O4YQSIs1pvdryrj6XeHtAyuNckkBStyRruD+bRPwJ7LmQ==",
       "cpu": [
         "arm"
       ],
@@ -6390,9 +6405,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm64": {
-      "version": "1.58.3",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.58.3.tgz",
-      "integrity": "sha512-dDaYRmV2vWxxZTiVFosfcgA6qJ+VEmHCFIO2XPO03W+uUmIGxa0G9oxdWxhLWjtUu2Z4R57sKKLj3eHI8Lj38Q==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.60.0.tgz",
+      "integrity": "sha512-VoN/aLHWnSNZbRR0eifsylrPBWzqQsG++J2qPbzvnuakRspaIRDCirw2QGFhksmyty5bn/syekKAIUUaCamBJQ==",
       "cpu": [
         "arm64"
       ],
@@ -6405,9 +6420,9 @@
       }
     },
     "node_modules/sass-embedded-linux-ia32": {
-      "version": "1.58.3",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.58.3.tgz",
-      "integrity": "sha512-UClCoXgaLNGHTLBRqUTQAgQXZQFkrGIaWVLIfkVN2AEyLmYJzZ31bQfq1B6mLZPBANuFQaeg3eOcdCTpNaXaOg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.60.0.tgz",
+      "integrity": "sha512-2XkIOT+7rNkjuDMugFASnbvwh9Fg48hZZh8kW4ZPGj1QxHtZNlGLXt0C/i0jAZUdjhhyjd9l+xUIxZj5/JClPg==",
       "cpu": [
         "ia32"
       ],
@@ -6420,9 +6435,9 @@
       }
     },
     "node_modules/sass-embedded-linux-x64": {
-      "version": "1.58.3",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.58.3.tgz",
-      "integrity": "sha512-/waLcKwkWQp4QJrNz6EqTS44IdGYup5TGh/qmv3iz9UeL4LtgeM4lVHrFsknsF7viDPLuCOARdrHNSjqKkLRPw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.60.0.tgz",
+      "integrity": "sha512-V0ZooknRIkS3lqn+3Yh2xrpfgd82A4n9PvzV/1KJWs4p5eJsapRIx/yGXHPFHfooHagN57kDWaFFdQYUfuYHrw==",
       "cpu": [
         "x64"
       ],
@@ -6435,9 +6450,9 @@
       }
     },
     "node_modules/sass-embedded-win32-ia32": {
-      "version": "1.58.3",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.58.3.tgz",
-      "integrity": "sha512-T6QYEf1NUDZY+9htvE7Zn9/Ixg0bXGQ54NcHBRSkyVY2n2KBLwQ2ZKp48AlSNxsvJiSOb9lqDE4U7VjH7WJSXg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.60.0.tgz",
+      "integrity": "sha512-pMNKxcysEVK4Dh27yLFNBAMqAKAJoVsl67lQ79LNrlZIVlIIwo/s1ajvImbf2srhWzizDJ1irxH2oBpF0kvxEA==",
       "cpu": [
         "ia32"
       ],
@@ -6450,9 +6465,9 @@
       }
     },
     "node_modules/sass-embedded-win32-x64": {
-      "version": "1.58.3",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.58.3.tgz",
-      "integrity": "sha512-Jc6Q1Rx5+cxk/yIsI8trkpNQEHjVM9I65p7ArpCLfMU33YRQWUm35QCFH2Szaue3HnTtwXl3ZDQdgo0ZHCHLzg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.60.0.tgz",
+      "integrity": "sha512-vGPeil9FzxJhPnWZ0zMLrY+GTT/fAUDVrKWQoXTxPfc7EugngbrqZ1qwVIVVCOC5zXDULB6LixCLFS8ut9R3KA==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   },
   "license": "",
   "dependencies": {
-    "@uswds/uswds": "^3.3.0",
-    "autoprefixer": "^10.4.13",
+    "@uswds/uswds": "^3.4.1",
+    "autoprefixer": "^10.4.14",
     "gulp": "^4.0.2",
     "gulp-concat": "^2.6.1",
     "gulp-dart-scss": "^1.1.0",
@@ -34,14 +34,14 @@
     "gulp-replace": "^1.1.4",
     "gulp-sass": "^5.1.0",
     "gulp-sourcemaps": "^3.0.0",
-    "gulp-svg-sprite": "2.0.1",
+    "gulp-svg-sprite": "2.0.3",
     "gulp-uglify": "^3.0.2",
-    "jquery": "^3.6.3",
+    "jquery": "^3.6.4",
     "jshint": "^2.13.6",
     "npm-run-all": "^4.1.5",
     "postcss-csso": "^5.0.1",
-    "sass": "^1.58.3",
-    "sass-embedded": "^1.58.3"
+    "sass": "^1.60.0",
+    "sass-embedded": "^1.60.0"
   },
   "devDependencies": {
     "del": "^3.0.0",

--- a/themes/digital.gov/layouts/partials/core/usa-button.html
+++ b/themes/digital.gov/layouts/partials/core/usa-button.html
@@ -1,0 +1,18 @@
+{{- $thisHref := .href -}}
+{{- $thisHref := replaceRE "^/" "" $thisHref -}}
+{{- $.Scratch.Set "thisHref" $thisHref -}}
+
+{{- $prefix := replaceRE "^(http[s]://).+$" "$1" $thisHref -}}
+{{- $suffix := replaceRE "^.+(.{3,3})$" "$1" $thisHref -}}
+
+{{- if ne $prefix $thisHref -}}
+{{/* Local links */}}
+{{- else if eq $suffix ".md" -}}
+{{- $.Scratch.Set "thisHref" (relref $.Page $thisHref) -}}
+{{- else -}}
+{{- $.Scratch.Set "thisHref" ($thisHref | absURL) -}}
+{{- end -}}
+
+<a class="usa-button usa-button--outline" href="{{ .href | safeURL }}">
+  {{- .text -}}
+</a>

--- a/themes/digital.gov/layouts/shortcodes/button.html
+++ b/themes/digital.gov/layouts/shortcodes/button.html
@@ -1,15 +1,1 @@
-{{- $thisHref := .Get "href" -}}
-{{- $thisHref := replaceRE "^/" "" $thisHref -}}
-{{- $.Scratch.Set "thisHref" $thisHref -}}
-{{- $prefix := replaceRE "^(http[s]://).+$" "$1" $thisHref -}}
-{{- $suffix := replaceRE "^.+(.{3,3})$" "$1" $thisHref -}}
-
-{{- if ne $prefix $thisHref -}}
-{{- else if eq $suffix ".md" -}}
-  {{- $.Scratch.Set "thisHref" (relref $.Page $thisHref) -}}
-{{- else -}}
-    {{- $.Scratch.Set "thisHref" ($thisHref | absURL) -}}
-{{- end -}}
-{{- $thisHref := $.Scratch.Get "thisHref" -}}
-
-<a class="usa-button usa-button--outline" href="{{- $thisHref -}}">{{- .Get "text" -}}</a>
+{{ partial "core/usa-button.html" (dict "href" .Params.href "text" .Params.text) }}

--- a/themes/digital.gov/layouts/shortcodes/button.html
+++ b/themes/digital.gov/layouts/shortcodes/button.html
@@ -1,1 +1,3 @@
-{{ partial "core/usa-button.html" (dict "href" .Params.href "text" .Params.text) }}
+{{ if .Params }}
+  {{ partial "core/usa-button.html" (dict "href" .Params.href "text" .Params.text) }}
+{{ end }}

--- a/themes/digital.gov/layouts/shortcodes/card-prompt.html
+++ b/themes/digital.gov/layouts/shortcodes/card-prompt.html
@@ -63,7 +63,7 @@ If not, it will not render the shortcode.
 
   {{/* Checks if the button exists */}}
   {{- if (.Get "button-text") -}}
-    {{ partial "core/usa-button.html" (dict "href" (.Get " button-url") "text" (.Get "button-text")) }}
+    {{ partial "core/usa-button.html" (dict "href" (.Get "button-url") "text" (.Get "button-text")) }}
   {{ end }}
 
   {{/* Fallback text (I forget what this was for) */}}

--- a/themes/digital.gov/layouts/shortcodes/card-prompt.html
+++ b/themes/digital.gov/layouts/shortcodes/card-prompt.html
@@ -63,14 +63,13 @@ If not, it will not render the shortcode.
 
   {{/* Checks if the button exists */}}
   {{- if (.Get "button-text") -}}
-  <div class="submit">
-    <button class="usa-button"><a href="{{- .Get "button-url" -}}" title="{{- .Get "button-text" -}}">{{- .Get "button-text" -}}</a></button>
-    <span></span>
-  </div>
-  {{- end -}}
+    {{ partial "core/usa-button.html" (dict "href" (.Get " button-url") "text" (.Get "button-text")) }}
+  {{ end }}
 
   {{/* Fallback text (I forget what this was for) */}}
-  {{- if (.Get "fallback") -}}<p class="fallback">{{- .Get "fallback" | markdownify -}}</p>{{- end -}}
+  {{- if (.Get "fallback") -}}
+    <p class="fallback">{{- .Get "fallback" | markdownify -}}</p>
+  {{- end -}}
 
 </div>
 {{- end -}}

--- a/themes/digital.gov/layouts/shortcodes/note.html
+++ b/themes/digital.gov/layouts/shortcodes/note.html
@@ -88,11 +88,4 @@ additional text goes here...
 
   {{- .Inner | markdownify -}}
 
-  {{- if (.Get "button-text") -}}
-  <div class="submit">
-    <button class="usa-button"><a href="{{- .Get "button-url" -}}" title="{{- .Get "button-text" -}}">{{- .Get "button-text" -}}</a></button>
-    <span></span>
-  </div>
-  {{- end -}}
-
 </div>


### PR DESCRIPTION
## Summary

Creates a single USWDS button component for use in other components and shortcodes. There will be additional work in the future to extend functionality and use in other components.

### Affected components

- shortcode/button
- shortcode/card-prompt
- shortcode/note

### Preview

- Page with button shortcode [[Agencies on a Mission to Match Service Members with Civilian Careers]](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/jm-button-shortcode/2020/01/21/agencies-on-a-mission-match-service-members/)
- Page with component that uses new button component [[Building the Elements That Earn Trust]](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/jm-button-shortcode/2019/11/18/building-elements-that-earn-trust/)


### Solution

1. Created a usa-button partial
2. Used that for button shortcodes
3. Used in other shortcodes/partials
4. Button **shouldn't** appear if `href` and `text` is missing.


### How To Test

1. There should be no regressions to button shortcode
2. No regressions in card prompts 

---

### Dev Checklist

- [x] PR has correct labels
