### PR TITLE
Fix 'Edit this' feature on Guide landing pages

### DIFF
--- a/themes/digital.gov/layouts/guides/list.html
+++ b/themes/digital.gov/layouts/guides/list.html
@@ -10,7 +10,7 @@
     <div class="grid-container grid-container-desktop">
       <div class="grid-row grid-gap-4">
 
-        <div class="grid-col-12 tablet-lg:grid-col-2" data-edit-this="{{- $path -}}">
+        <div class="grid-col-12 tablet-lg:grid-col-2">
           {{- partial "core/guides/guide-nav.html" . -}}
         </div>
 

--- a/themes/digital.gov/layouts/guides/list.html
+++ b/themes/digital.gov/layouts/guides/list.html
@@ -1,4 +1,5 @@
 {{ define "content" }}
+{{ $path := "" }}{{ with .File }}{{ $path = .Path }}{{ else }}{{ $path = .Path }}{{ end }}
 
 <main role="main" id="main-content">
 
@@ -9,12 +10,12 @@
     <div class="grid-container grid-container-desktop">
       <div class="grid-row grid-gap-4">
 
-        <div class="grid-col-12 tablet-lg:grid-col-2">
+        <div class="grid-col-12 tablet-lg:grid-col-2" data-edit-this="{{- $path -}}">
           {{- partial "core/guides/guide-nav.html" . -}}
         </div>
 
         <div class="grid-col-12 tablet-lg:grid-col-8">
-          <div class="usa-layout-docs__main usa-prose">
+          <div class="usa-layout-docs__main usa-prose" data-edit-this="{{- $path -}}">
 
             {{- partial "core/guides/guide-page-head.html" . -}}
 

--- a/themes/digital.gov/layouts/guides/single.html
+++ b/themes/digital.gov/layouts/guides/single.html
@@ -10,7 +10,7 @@
     <div class="grid-container grid-container-desktop">
       <div class="grid-row grid-gap-4">
 
-        <div class="grid-col-12 tablet-lg:grid-col-2" data-edit-this="{{- $path -}}">
+        <div class="grid-col-12 tablet-lg:grid-col-2">
           {{- partial "core/guides/guide-nav.html" . -}}
         </div>
 


### PR DESCRIPTION
## Summary

Guide landing pages are now editable via the `Edit` button (blue pencil).

### Preview

Any guide landing page - [Guide to the Digital Analytics Program](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/jm-edit-this-guide-pages/guides/dap/)

![image](https://user-images.githubusercontent.com/3385219/231496628-349df945-4ac7-408b-8474-c35e89e766bd.png)


### Solution

Adds missing data attribute & path `data-edit-this="{{- $path -}}"` to template.

### How To Test

1. Visit any guide landing page
   - [[Guide to the Digital Analytics Program]](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/jm-edit-this-guide-pages/guides/dap/)
   - [Mobile Principles ](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/jm-edit-this-guide-pages/guides/mobile-principles/)
   - [[Public Participation Playbook]](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/jm-edit-this-guide-pages/guides/public-participation/)
   - 
2. Click the blue pencil button to edit
3. Sections should be highlighted yellow and editable



---

### Dev Checklist

- [x] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
