### PR TITLE
a11y - Heading order fixes 

### DIFF
--- a/content/about/contact.md
+++ b/content/about/contact.md
@@ -2,7 +2,6 @@
 title: "Contact Us"
 deck: "We are human, we promise."
 summary: "How to contact the Digital.gov team."
-
 ---
 
 **Digital.gov** is made up of a cross-functional team of writers, editors, strategists, technologists, and designers who all work at the Technology Transformation Services (TTS) at the General Services Administration (GSA).
@@ -15,7 +14,7 @@ For a wider list of contacts, see our [**Directory of services, tools, and teams
 
 ---
 
-**On social media**
+## On social media
 
 - Follow [@digital_gov on Twitter](https://twitter.com/digital_gov/)
 - Digital.gov on [GitHub](https://github.com/GSA/digitalgov.gov)

--- a/content/about/subscribe.md
+++ b/content/about/subscribe.md
@@ -6,7 +6,7 @@ deck: "Stay connected with the innovative work, news, events and ideas from peop
 summary: "Stay connected with the innovative work, news, events and ideas from people and teams across government"
 featured_image:
   uid: subscribe-card-1
-  alt: ''
+  alt: ""
 aliases:
   - /subscribe/
   - /newsletter
@@ -16,15 +16,13 @@ aliases:
 
 Our strategy is to provide you with just the right amount of information to help you and your team make something better. We’re not interested in flooding your inbox with emails you don’t need.
 
-_Interested in contributing to Digital.gov? [Check out our contribution page »]({{< ref "/about/contribute.md" >}})_ <br /><br />
-
+_Interested in contributing to Digital.gov? [Check out our contribution page »]({{< ref "/about/contribute.md" >}})_
 
 {{< hs-form-subscribe >}}
 
+:envelope:Have additional questions? Email us at [digitalgov@gsa.gov](mailto:digitalgov@gsa.gov)
 
-<br /><br />:envelope: Have additional questions? Email us at [digitalgov@gsa.gov](mailto:digitalgov@gsa.gov)
-
-## Other ways to subscribe and follow
+### Other ways to subscribe and follow
 
 - [Join a community of practice]({{< ref "/communities/_index.md" >}})
 - [Digital.gov on GitHub](https://github.com/GSA/digitalgov.gov)

--- a/themes/digital.gov/layouts/authors/terms.html
+++ b/themes/digital.gov/layouts/authors/terms.html
@@ -11,7 +11,7 @@
               {{- if .Params.deck -}}
                 <div class="deck">{{- .Params.deck | markdownify -}}</div>
               {{- end -}}
-              <h4>{{ len $authors }} authors, writers, and contributors</h4>
+              <em>{{ len $authors }} authors, writers, and contributors</em>
             </div>
           </div>
         </div>
@@ -19,61 +19,53 @@
 
       <section>
         <div class="grid-container grid-container-desktop">
-          <div class="grid-row">
-            <div class="grid-col-12">
-              <div class="authors-list">
-                {{- range $i, $author := $authors -}}
-                  {{ if .Params.slug }}
-                    {{ $link := printf "authors/%s/" .Params.slug }}
-                    {{ $path := "" }}{{ with .File }}
-                      {{ $path = .Path }}
-                    {{ else }}
-                      {{ $path = .Path }}
-                    {{ end }}
-                    <div class="author grid-row" data-edit-this="{{- $path -}}">
-                      <div class="grid-col-auto">
-                        <div class="photo">
-                          {{- if $author.Params.github -}}
-                            <img
-                              src="https://github.com/{{- $author.Params.github -}}.png?size=50"
-                              alt=""
-                            />
-                          {{- else -}}
-                            {{- $default_profile := print "img/digit-" (cond (eq (mod $i 2) 0) "light" "dark") ".png" -}}
-                            <img
-                              src="{{- $default_profile | absURL -}}"
-                              alt=""
-                            />
-                          {{- end -}}
-                        </div>
-                      </div>
-                      <div class="grid-col-9">
-                        <div class="details">
-                          <h5>
-                            <a
-                              href="{{- $link | absURL -}} "
-                              title="Posts by {{- $author.Params.display_name | default $i -}} "
-                              rel="author"
-                            >
-                              {{- $author.Params.display_name | default $i | markdownify -}}
-                            </a>
-                          </h5>
-
-                          {{- if $author.Params.agency -}}
-                            <p>
-                              {{- $author.Params.agency -}}{{- if $author.Params.location -}}
-                                &nbsp;|&nbsp;{{- $author.Params.location -}}
-                              {{- end -}}
-                            </p>
-                          {{- end -}}
-
-                        </div>
-                      </div>
-                    </div>
-                  {{ end }}
+          <div class="authors-list">
+            {{- range $i, $author := $authors -}}
+              {{ if .Params.slug }}
+                {{ $link := printf "authors/%s/" .Params.slug }}
+                {{ $path := "" }}{{ with .File }}
+                  {{ $path = .Path }}
+                {{ else }}
+                  {{ $path = .Path }}
                 {{ end }}
-              </div>
-            </div>
+                <div class="author grid-row" data-edit-this="{{- $path -}}">
+                  <div class="grid-col-auto">
+                    <div class="photo">
+                      {{- if $author.Params.github -}}
+                        <img
+                          src="https://github.com/{{- $author.Params.github -}}.png?size=50"
+                          alt=""
+                        />
+                      {{- else -}}
+                        {{- $default_profile := print "img/digit-" (cond (eq (mod $i 2) 0) "light" "dark") ".png" -}}
+                        <img src="{{- $default_profile | absURL -}}" alt="" />
+                      {{- end -}}
+                    </div>
+                  </div>
+                  <div class="grid-col-9">
+                    <div class="details">
+                      <a
+                        class="authors-list__title"
+                        href="{{- $link | absURL -}} "
+                        title="Posts by {{- $author.Params.display_name | default $i -}} "
+                        rel="author"
+                      >
+                        {{- $author.Params.display_name | default $i | markdownify -}}
+                      </a>
+
+                      {{- if $author.Params.agency -}}
+                        <p>
+                          {{- $author.Params.agency -}}{{- if $author.Params.location -}}
+                            &nbsp;|&nbsp;{{- $author.Params.location -}}
+                          {{- end -}}
+                        </p>
+                      {{- end -}}
+
+                    </div>
+                  </div>
+                </div>
+              {{ end }}
+            {{ end }}
           </div>
         </div>
       </section>

--- a/themes/digital.gov/layouts/home.html
+++ b/themes/digital.gov/layouts/home.html
@@ -5,9 +5,9 @@
         <div class="grid-row tablet-lg:grid-gap-4">
           <div class="grid-col-12 tablet-lg:grid-col-4">
             <div class="box">
-              <h2>
+              <h1 class="resources_featured__title">
                 Guidance on building better digital services in government.
-              </h2>
+              </h1>
             </div>
           </div>
 

--- a/themes/digital.gov/layouts/services/card-service.html
+++ b/themes/digital.gov/layouts/services/card-service.html
@@ -15,28 +15,30 @@
   {{/* Logos
     Get the "source" in the file and looks up the icon that is used there.
   */}}
+
+  {{ .Scratch.Set "logo_src" "" }}
   {{- $source := $.Site.GetPage "page" (print "source_" .Params.source ) -}}
+
+  {{/* Find the logo source. */}}
+  {{/* @TODO: Simplify even further. */}}
   {{- if $source -}}
-    {{- $src := (printf "/logos/%s%s" $source.Params.logo "-logo.png") -}}
-    {{- template "logo" dict "src" $src "alt" $source.Params.name "href" $href -}}
+    {{ .Scratch.Set "logo_src" (printf "/logos/%s%s" $source.Params.logo "-logo.png") }}
   {{- else if .Params.logo -}}
-
-    {{- $src := (printf "/logos/%s%s" .Params.logo "-logo.png") -}}
-    {{- template "logo" dict "src" $src "alt" .Params.name "href" $href -}}
-
+    {{ .Scratch.Set "logo_src" (printf "/logos/%s%s" .Params.logo "-logo.png") }}
   {{- else -}}
-
-    {{- template "logo" dict "src" "/logos/digit-gold.png" "alt" .Params.source "href" $href -}}
-
+    {{ .Scratch.Set "logo_src" "/logos/digit-gold.png" }}
   {{- end -}}
+
+  {{/* Call logo template once with new found source. */}}
+  {{- template "logo" dict "src" (.Scratch.Get "logo_src") "href" $href -}}
 
 
   <div class="copy">
-    <h3>
+    <h2 class="card__title">
       <a href="{{- $href -}}" title="{{- .Params.title -}}"
         >{{- .Params.title -}}</a
       >
-    </h3>
+    </h2>
 
     <p>{{- .Params.summary | markdownify -}}</p>
 

--- a/themes/digital.gov/layouts/shortcodes/hs-form-subscribe.html
+++ b/themes/digital.gov/layouts/shortcodes/hs-form-subscribe.html
@@ -1,4 +1,6 @@
-<h3>Subscribe to the Digital.gov Newsletter</h3>
-<button type="button" class="subscribe-button usa-button usa-button--outline">
-  Go to subscribe
-</button>
+<div class="margin-y-8">
+  <h2>Subscribe to the Digital.gov Newsletter</h2>
+  <button type="button" class="subscribe-button usa-button usa-button--outline">
+    Go to subscribe
+  </button>
+</div>

--- a/themes/digital.gov/src/scss/new/_authors-list.scss
+++ b/themes/digital.gov/src/scss/new/_authors-list.scss
@@ -2,49 +2,53 @@
 // NOTE: The authors-list is included twice on the page. Once for desktop, the other for mobile.
 @use "uswds-core" as *;
 
-.authors-list{
-	@include u-margin-top(0);
-	@include u-margin-bottom(7);
-	.author{
-		@include u-margin-bottom('105');
-		@include u-padding-top('105');
-		@include u-border-top('1px','solid', 'gray-10');
-		@include u-flex('no-wrap');
-		img{
-			@include u-border('1px','solid', 'indigo-30');
-		}
-		.photo{
-			@include u-margin-right(1);
-			@include u-height(5);
-			@include u-width(5);
-			@include u-display('flex');
-			@include u-flex('align-center');
-			@include u-flex('justify-center');
-			img{
-				@include u-circle(5);
-			}
-		}
-		.details{
-			h5{
-				@include u-margin-y('05');
-				@include u-font('sans', 'xs');
-				@include u-text('bold');
-				@include u-line-height('sans', 1);
-				a{
-					@include u-text('black');
-					@include u-text('no-underline');
-				}
-				a:hover{
-					@include u-border-bottom('2px', 'accent-warm', 'solid');
-				}
-			}
-			p{
-				@include u-margin(0);
-				@include u-font('sans', '3xs');
-			}
-		}
-		&:first-child{
-			@include u-border-top(0);
-		}
-	}
+.authors-list {
+  @include u-margin-top(0);
+  @include u-margin-bottom(7);
+
+  .author {
+    @include u-margin-bottom("105");
+    @include u-padding-top("105");
+    @include u-border-top("1px", "solid", "gray-10");
+    @include u-flex("no-wrap");
+
+    img {
+      @include u-border("1px", "solid", "indigo-30");
+    }
+
+    .photo {
+      @include u-margin-right(1);
+      @include u-height(5);
+      @include u-width(5);
+      @include u-display("flex");
+      @include u-flex("align-center");
+      @include u-flex("justify-center");
+
+      img {
+        @include u-circle(5);
+      }
+    }
+
+    .details {
+      .authors-list__title {
+        @include u-font("sans", "xs");
+        @include u-line-height("sans", 1);
+        @include u-margin-y("05");
+        @include u-text("bold", "black", "no-underline");
+
+        &:hover {
+          @include u-border-bottom("2px", "accent-warm", "solid");
+        }
+      }
+
+      p {
+        @include u-margin(0);
+        @include u-font("sans", "3xs");
+      }
+    }
+
+    &:first-child {
+      @include u-border-top(0);
+    }
+  }
 }

--- a/themes/digital.gov/src/scss/new/_card-service.scss
+++ b/themes/digital.gov/src/scss/new/_card-service.scss
@@ -1,61 +1,69 @@
 @use "uswds-core" as *;
 
-.card-service{
+.card-service {
   @include u-margin-y(1);
-  @include u-padding-y('205');
-  @include u-border-top('base-lighter', '1px', 'solid');
-  @include u-display('flex');
-  @include u-flex('justify-start');
-  @include u-flex('align-start');
-  &:first-child{
+  @include u-padding-y("205");
+  @include u-border-top("base-lighter", "1px", "solid");
+  @include u-display("flex");
+  @include u-flex("justify-start");
+  @include u-flex("align-start");
+
+  &:first-child {
     @include u-border-top(0);
   }
 
-  .logo{
-    @include u-margin-right('105');
+  .logo {
+    @include u-margin-right("105");
     @include u-square(6);
-    @include at-media('mobile-lg'){
+    @include at-media("mobile-lg") {
       @include u-margin-right(3);
       @include u-square(7);
     }
 
-    img{
+    img {
       @include u-circle(6);
-      @include at-media('mobile-lg'){
+      @include at-media("mobile-lg") {
         @include u-circle(7);
       }
-      @include u-border('1px', 'gray-cool-10', 'solid');
+      @include u-border("1px", "gray-cool-10", "solid");
     }
-    &:hover{
-      img{
-        @include u-border('1px', 'gray-cool-20', 'solid');
+
+    &:hover {
+      img {
+        @include u-border("1px", "gray-cool-20", "solid");
       }
     }
   }
-  .copy{
+
+  .copy {
     flex: 1;
-    h3{
-      @include u-margin-bottom(1);
-      @include u-font('sans', 'lg');
-      a{
-        @include u-text('black');
-        @include u-text('no-underline');
-        &:hover{
-          @include u-border-bottom('2px', 'accent-warm', 'solid');
-        }
-      }
+
+    p {
+      @include u-margin-top(0);
+      @include u-line-height("sans", 3);
+      @include u-display("flex");
     }
 
-    p{
-      @include u-margin-top(0);
-      @include u-line-height('sans', 3);
-      @include u-display('flex');
-    }
-    .list-topics{
+    .list-topics {
       @include u-margin-bottom(0);
     }
-    .authors-list{
+
+    .authors-list {
       @include u-margin-bottom(0);
+    }
+  }
+
+  .card__title {
+    @include u-margin-bottom(1);
+    @include u-font("sans", "lg");
+
+    a {
+      @include u-text("black");
+      @include u-text("no-underline");
+
+      &:hover {
+        @include u-border-bottom("2px", "accent-warm", "solid");
+      }
     }
   }
 }

--- a/themes/digital.gov/src/scss/new/_resources_featured.scss
+++ b/themes/digital.gov/src/scss/new/_resources_featured.scss
@@ -1,83 +1,86 @@
 @use "uswds-core" as *;
 
-#resources_featured{
-  @include u-bg('white');
+#resources_featured {
+  @include u-bg("white");
   @include u-padding-y(2);
   @include u-padding-top(4);
 }
 
-
-.home #resources_featured{
-  @include u-bg('primary-dark');
+.home #resources_featured {
+  @include u-bg("primary-dark");
   @include u-padding-y(0);
-  @include at-media('tablet-lg') {
+  @include at-media("tablet-lg") {
     @include u-padding-top(3);
   }
-  .box{
-    @include u-bg('transparent');
+  .box {
+    @include u-bg("transparent");
     @include u-margin(0);
     @include u-padding(0);
     @include u-radius(0);
-    @include at-media('tablet-lg') {
-      @include u-display('flex');
-      @include u-flex('align-center');
-      @include u-height('full');
-      @include u-padding-bottom(8);      
+    @include at-media("tablet-lg") {
+      @include u-display("flex");
+      @include u-flex("align-center");
+      @include u-height("full");
+      @include u-padding-bottom(8);
     }
 
-    h2{
+    .resources_featured__title {
       @include u-margin(0);
       @include u-padding(2);
       @include u-padding-right(4);
-      @include u-font('sans', 'xl');
-      @include u-line-height('sans', 2);
-      @include u-text('white');
-      @include u-text('thin');
-      @include at-media('tablet-lg') {
+      @include u-font("sans", "xl");
+      @include u-line-height("sans", 2);
+      @include u-text("white");
+      @include u-text("thin");
+      @include at-media("tablet-lg") {
         @include u-margin-bottom(0);
         @include u-padding(0);
-        @include u-font('sans', '2xl');
+        @include u-font("sans", "2xl");
       }
     }
-    p{
+
+    p {
       @include u-margin-top(0);
-      @include u-padding-y('105');
+      @include u-padding-y("105");
       @include u-padding-x(2);
-      @include u-border-bottom('1px', 'base-lightest', 'solid');
-      @include u-bg('primary-darkest');
-      @include u-text('white');
-      @include u-font('sans', 'xs');
-      @include u-line-height('sans', 2);
-      @include u-text('normal');
-      @include u-maxw('full');
-      @include at-media('tablet-lg') {
-        @include u-font('sans', 'sm');
+      @include u-border-bottom("1px", "base-lightest", "solid");
+      @include u-bg("primary-darkest");
+      @include u-text("white");
+      @include u-font("sans", "xs");
+      @include u-line-height("sans", 2);
+      @include u-text("normal");
+      @include u-maxw("full");
+
+      @include at-media("tablet-lg") {
+        @include u-font("sans", "sm");
         @include u-padding(2);
       }
-      a{
-        @include u-display('flex');
-        @include u-flex('align-center');
-        @include u-text('no-underline');
-        @include u-text('white');
-        img{
-          @include u-margin-right('105');
+
+      a {
+        @include u-display("flex");
+        @include u-flex("align-center");
+        @include u-text("no-underline");
+        @include u-text("white");
+
+        img {
+          @include u-margin-right("105");
           @include u-width(5);
           @include u-minw(5);
-          @include at-media('tablet-lg') {
+          @include at-media("tablet-lg") {
             @include u-width(7);
             @include u-minw(7);
           }
         }
-
       }
     }
   }
+
   .resources-content {
-    @include u-bg('white');
+    @include u-bg("white");
     @include u-padding-x(2);
     @include u-padding-y(3);
-    @include at-media('tablet-lg') {
-      @include u-radius-top('lg');
+    @include at-media("tablet-lg") {
+      @include u-radius-top("lg");
     }
   }
 }


### PR DESCRIPTION
## Summary

Heading order fixes for several DG pages.

### Additionally

- Simplified logo logic
- Formatted styles
- Removed redundant grid classes

### Preview

[Link to Preview]()


### Solution

### How To Test

1. First Step
2. Second Step
3. Third Step

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
