### PR TITLE
Rename front matter field blurb to join_cop_button

### DIFF
--- a/content/communities/communicators.md
+++ b/content/communities/communicators.md
@@ -31,7 +31,7 @@ community_list:
     subscribe_email_subject: "Join the Communicators Community"
     terms: "Government employees and contractors with an official .gov or .mil email are eligible to join."
     members: 2,086
-    blurb: "Communicators community members"
+    join_cop_button: "Communicators community members"
 
 # Controls how this page appears across the site
 # 0 -- hidden

--- a/content/communities/devops.md
+++ b/content/communities/devops.md
@@ -29,7 +29,7 @@ community_list:
     type: government
     subscribe_email: "devops-today-subscribe-request@listserv.gsa.gov"
     subscribe_email_subject: "Subscribe to DevOps"
-    blurb: "DevOps community members"
+    join_cop_button: "DevOps community members"
 ---
 
 The DevOps Community of Practice (CoP) provides information technology and development staff and leadership throughout government the opportunity to share lessons learned, successes, benefits, and know how related to DevOps.

--- a/content/communities/multilingual.md
+++ b/content/communities/multilingual.md
@@ -41,7 +41,7 @@ community_list:
     subscribe_email_subject: "Join the Multilingual Community"
     terms: "Government employees and contractors with an official .gov or .mil email are eligible to join."
     members: 593
-    blurb: "Multilingual community members"
+    join_cop_button: "Multilingual community members"
 
 primary_image: "white-bg-digital-gov-card-community"
 

--- a/content/communities/open-data.md
+++ b/content/communities/open-data.md
@@ -35,7 +35,7 @@ community_list:
     subscribe_email_body: "Subscribe Open-Data"
     members: 925
     emails_per_week: 1
-    blurb: "Open Data community members"
+    join_cop_button: "Open Data community members"
 
 ---
 

--- a/content/communities/plain-language-community-of-practice.md
+++ b/content/communities/plain-language-community-of-practice.md
@@ -45,7 +45,7 @@ community_list:
     subscribe_email_subject: "Join the Plain Language Community"
     terms: "Government employees and contractors with an official .gov or .mil email are eligible to join."
     members: 1,732
-    blurb: "Plain Language community members"
+    join_cop_button: "Plain Language community members"
 
 primary_image: "digital-gov-card-community"
 

--- a/content/communities/social-media.md
+++ b/content/communities/social-media.md
@@ -37,7 +37,7 @@ community_list:
     subscribe_email_subject: "Join the Social Media Community"
     terms: "Government employees and contractors with an official .gov or .mil email are eligible to join."
     members: 1,261
-    blurb: "Social Media community members"
+    join_cop_button: "Social Media community members"
 
 primary_image: "white-bg-digital-gov-card-community"
 

--- a/content/communities/user-experience.md
+++ b/content/communities/user-experience.md
@@ -35,7 +35,7 @@ community_list:
     subscribe_email_subject: "Join the User Experience Community"
     terms: "Government employees and contractors with an official .gov or .mil email are eligible to join."
     members: 1,863
-    blurb: "User Experience community members"
+    join_cop_button: "User Experience community members"
 
 # see all authors at https://digital.gov/authors
 authors:

--- a/content/communities/video.md
+++ b/content/communities/video.md
@@ -35,7 +35,7 @@ community_list:
     subscribe_email: "VIDEO-PRODUCTION-subscribe-request@listserv.gsa.gov"
     terms: "Anyone with a .gov or .mil email address is eligible to join."
     members: 510   
-    blurb: "Video Producers"
+    join_cop_button: "Video Producers"
     
 
 ---

--- a/content/communities/web-analytics-and-optimization.md
+++ b/content/communities/web-analytics-and-optimization.md
@@ -42,7 +42,7 @@ community_list:
     subscribe_email_subject: "Join the Web Analytics Community"
     terms: "Government employees and contractors with an official .gov or .mil email are eligible to join."
     members: 774
-    blurb: "Web Analytic community members"
+    join_cop_button: "Web Analytic community members"
 
 primary_image: "digital-gov-card-community"
 

--- a/content/communities/web-managers-forum.md
+++ b/content/communities/web-managers-forum.md
@@ -47,7 +47,7 @@ community_list:
     subscribe_email_subject: "Join the Web Managers Community"
     terms: "Government employees and contractors with an official .gov or .mil email are eligible to join."
     members: 1,853
-    blurb: "Web Manager community members"
+    join_cop_button: "Web Manager community members"
 
 primary_image: "white-on-gsa-blue-digital-gov-card-community"
 

--- a/themes/digital.gov/layouts/partials/core/community-join-without-form.html
+++ b/themes/digital.gov/layouts/partials/core/community-join-without-form.html
@@ -32,5 +32,5 @@
 >
   Join
   {{ if .e.subscribe_email_subject }}{{ .e.members }}{{ end }}
-  {{ .e.blurb }}
+  {{ .e.join_cop_button }}
 </a>

--- a/themes/digital.gov/src/scss/new/_join-community-form.scss
+++ b/themes/digital.gov/src/scss/new/_join-community-form.scss
@@ -11,7 +11,7 @@
   @include u-radius("sm");
   @include u-text("light");
   @include u-text("gray-90");
-  
+
   &__header {
     @include u-font("sans", "lg");
     @include u-margin-bottom("105");

--- a/themes/digital.gov/src/scss/new/_join-community-form.scss
+++ b/themes/digital.gov/src/scss/new/_join-community-form.scss
@@ -28,10 +28,10 @@
     @include u-padding-bottom(2);
   }
   &__body-form-button {
-    @include u-bg("cyan-50v");
+    @include u-bg("cyan-60v");
     @include u-text("gray-warm-1");
     &:hover {
-      @include u-bg("cyan-60v");
+      @include u-bg("cyan-70v");
       @include u-text("gray-warm-1");
     }
   }


### PR DESCRIPTION
## Summary
Rename `blurb` to `join_cop_button` for communities pages.

### Solution
Update the front matter fields to use a better naming convention.

### How To Test

1. [Communicators Page](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-rename-front-matter/communities/communicators/)

---

### Dev Checklist

- [x] PR has correct labels
- [x] A11y testing (voice over testing, meets WCAG, run axe tools)
- [x] Code is formatted properly
