### PR TITLE
Show first 10 topics on the resources page

### DIFF
--- a/themes/digital.gov/layouts/resources/list.html
+++ b/themes/digital.gov/layouts/resources/list.html
@@ -81,7 +81,8 @@
                       </div>
                       <div class="grid-row">
                         <div class="grid-col-12 tablet-lg:grid-col-10">
-                          {{/* Pass the $resources_by_topic to the collection template */}}
+                          {{/* Pass the $resources_by_topic to the collection template and display the first 10 */}}
+                          {{- $resources_by_topic := first 10 $resources_by_topic -}}
                           {{- partial "core/collection.html" (dict "list" $resources_by_topic) -}}
                         </div>
                       </div>


### PR DESCRIPTION
## Summary
Display the first 10 results for each topic on the resources page.
Some topics display 20+ entries that crowd out of the page.

### Solution
Limit the number of entries for each topic displayed on the resources page to the first 10.

**Before**
<img width="794" alt="Screen Shot 2023-05-02 at 11 16 33 AM" src="https://user-images.githubusercontent.com/104778659/235709767-b907d9fd-9059-418c-89e7-95a9db863aa9.png">

**After**
<img width="917" alt="Screen Shot 2023-05-03 at 10 34 24 AM" src="https://user-images.githubusercontent.com/104778659/235948324-92124d79-9864-4075-b82d-9bf369943732.png">


### How To Test
1. Visit the resources page 
https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-update-resources-topics/resources/ 

---

### Dev Checklist

- [x] PR has correct labels
- [x] A11y testing (voice over testing, meets WCAG, run axe tools)
- [x] Code is formatted properly
