### PR TITLE
Update formatting on third bullet

### DIFF
--- a/content/resources/guidance-for-agency-use-of-third-party-websites-and-applications.md
+++ b/content/resources/guidance-for-agency-use-of-third-party-websites-and-applications.md
@@ -15,9 +15,10 @@ This Memorandum requires Federal agencies to take specific steps to protect indi
 
 ## Related Links
 
+
 - [President’s Memorandum on Transparency and Open Government](https://www.whitehouse.gov/sites/whitehouse.gov/files/omb/memoranda/2009/m09-12.pdf)
 - [Open Government Directive]({{< ref "open-government-directive.md" >}})
-- [OMB’s Guidance for Online Use of Web Measurement and Customization Technologies]({{< ref "resources/m-10-22-guidance-for-online-use-of-web-measurement-and-customization-technologies/" >}})
+- [OMB’s Guidance for Online Use of Web Measurement and Customization Technologies]({{< ref "resources/m-10-22-guidance-for-online-use-of-web-measurement-and-customization-technologies.md" >}})
 - [Social Media, Web Based Technologies, and the Paperwork Reduction Act]({{< ref "social-media-web-based-interactive-technologies-and-the-paperwork-reduction-act.md" >}})
 
 ---

--- a/content/resources/guidance-for-agency-use-of-third-party-websites-and-applications.md
+++ b/content/resources/guidance-for-agency-use-of-third-party-websites-and-applications.md
@@ -17,7 +17,7 @@ This Memorandum requires Federal agencies to take specific steps to protect indi
 
 - [President’s Memorandum on Transparency and Open Government](https://www.whitehouse.gov/sites/whitehouse.gov/files/omb/memoranda/2009/m09-12.pdf)
 - [Open Government Directive]({{< ref "open-government-directive.md" >}})
-- [OMB’s Guidance for Online Use of Web Measurement and Customization Technologies]({{< ref "/resources" >}})m-10-22-guidance-for-online-use-of-web-measurement-and-customization-technologies/)
+- [OMB’s Guidance for Online Use of Web Measurement and Customization Technologies]({{< ref "resources/m-10-22-guidance-for-online-use-of-web-measurement-and-customization-technologies/" >}})
 - [Social Media, Web Based Technologies, and the Paperwork Reduction Act]({{< ref "social-media-web-based-interactive-technologies-and-the-paperwork-reduction-act.md" >}})
 
 ---


### PR DESCRIPTION
reported via Zendesk

## Summary

I fixed the broken link on the third bullet on [Guidance for Agency Use of Third-Party Websites and Applications](https://digital.gov/resources/guidance-for-agency-use-of-third-party-websites-and-applications/), which had been rendered like this: 

>[OMB’s Guidance for Online Use of Web Measurement and Customization Technologies](https://digital.gov/resources/)m-10-22-guidance-for-online-use-of-web-measurement-and-customization-technologies/)

The partial link incorrectly goes to the main Resources page. The full line, `OMB’s Guidance for Online Use of Web Measurement and Customization Technologies`, needs to be linked to the correct page: https://digital.gov/resources/m-10-22-guidance-for-online-use-of-web-measurement-and-customization-technologies. 

### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/bonnieAcameron-linkformatting-1/resources/guidance-for-agency-use-of-third-party-websites-and-applications/)

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

1. See the preview
2. Check whether the link looks appropriate in the third bullet
3. Test the link, which should go to the `M-10-22 Guidance for Online Use of Web Measurement and Customization Technologies` page -- [Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/bonnieAcameron-linkformatting-1/resources/m-10-22-guidance-for-online-use-of-web-measurement-and-customization-technologies/)


---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
