### PR TITLE
Updated accessibility statement to be in sync with uswds 3.5.0

### DIFF
--- a/data/usa_identifier.yml
+++ b/data/usa_identifier.yml
@@ -14,8 +14,8 @@ identifier_data:
     links:
       - label: About GSA
         url: https://www.gsa.gov/about-us
-      - label: Accessibility support
-        url: https://www.gsa.gov/website-information/accessibility-aids
+      - label: Accessibility statement
+        url: https://www.gsa.gov/website-information/accessibility-statement
       - label: FOIA requests
         url: https://www.gsa.gov/reference/freedom-of-information-act-foia
       - label: No FEAR Act data


### PR DESCRIPTION
## Summary
Updated `usa-identifier` to match [uswds 3.5.0](https://designsystem.digital.gov/components/identifier/)

## Solution

- Rename `Accessibility support` to `Accessibility statement`
- Updated url from `https://www.gsa.gov/website-information/accessibility-aids` to `https://www.gsa.gov/website-information/accessibility-statement`

## Preview

- [Preview](https://federalist-ed9ac7ce-8870-4699-95f8-e85f8b3c15b8.sites.pages.cloud.gov/preview/gsa/accessibility-for-teams/nl-update-identifier-a11y-statement/)

---

### Dev Checklist

- [x] PR has correct labels
- [x] A11y testing (voice over testing, meets WCAG, run axe tools)
- [x] Code is formatted properly
