### PR TITLE
Refactor future event logic

### DIFF
--- a/content/events/2023/06/2023-06-08-uswds-monthly-call-june-2023.md
+++ b/content/events/2023/06/2023-06-08-uswds-monthly-call-june-2023.md
@@ -7,6 +7,7 @@ host: U.S. Web Design System
 event_organizer: Digital.gov
 cop_events: ""
 registration_url: https://gsa.zoomgov.com/meeting/register/vJItceGprT0tHyOpdv40WB6ome7t20p6EHQ
+date: 2023-06-15 14:00:00 -0500
 end_date: 2023-06-15 15:00:00 -0500
 # See all topics at https://digital.gov/topics
 topics:
@@ -15,7 +16,6 @@ topics:
   - user-experience
 slug: uswds-monthly-call-june-2023
 captions: https://www.streamtext.net/player?event=
-date: 2023-06-15 14:00:00 -0500
 # zoom, youtube_live, adobe_connect, google
 event_platform: zoom
 primary_image: 2023-uswds-monthly-call-june-title-card

--- a/themes/digital.gov/layouts/partials/core/home/news_featured.html
+++ b/themes/digital.gov/layouts/partials/core/home/news_featured.html
@@ -24,8 +24,8 @@
         {{/* Future Events =========================== */}}
         {{/* gets the # of news items to display from the config.yml */}}
         {{- $events_count := .Site.Params.events_count -}}
-        {{- $events := where .Site.RegularPages "Section" "events" -}}
-        {{- $events := $events | first $events_count }}
+        {{- $events_future := where (where .Site.RegularPages "Section" "events") ".Date.Unix" ">" now.Unix -}}
+        {{- $events_future := $events_future | first $events_count }}
 
         {{/* Past Events =========================== */}}
         {{- $past_events := where (where .Site.RegularPages.ByDate.Reverse "Section" "events") ".Date.Unix" "<" now.Unix -}}
@@ -48,16 +48,16 @@
         {{- range $i, $el := first $stream_count $stream -}}
 
           {{/* Display first future event in 3 position of the stream */}}
-          {{- with $events -}}
+          {{- with $events_future -}}
             {{- if eq $i 2 -}}
-              {{- range first 1 $events -}}
+              {{- range first 1 $events_future -}}
                 {{- .Render "card-event" -}}
               {{- end -}}
             {{- end -}}
 
             {{/* Display second future event in 9 position of the stream */}}
             {{- if eq $i 8 -}}
-              {{- range first 1 (after 1 $events) -}}
+              {{- range first 1 (after 1 $events_future) -}}
                 {{- .Render "card-event" -}}
               {{- end -}}
             {{- end -}}


### PR DESCRIPTION
## Summary

Fixes duplicate future event bug.

### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-fix-future-events/)

### Solution

Refactored code to check for future dates greater than current day instead of filtering through all events that overlap with past events. This is a more explicit check.

### How To Test

1. Visit [homepage](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-fix-future-events/)
2. Should only see one future event displayed for each event, same for past events

---

### Dev Checklist

- [x] PR has correct labels
- [x] A11y testing (voice over testing, meets WCAG, run axe tools)
- [x] Code is formatted properly
