### PR TITLE
Bug fix javascript images stream

### DIFF
--- a/config/gulp/scripts.js
+++ b/config/gulp/scripts.js
@@ -34,12 +34,9 @@ function copyJquery() {
  */
 function compile() {
   // Stream images is imported by itself in `content/images/_index.md`.
-  return src(
-    [`${PROJECT_JS_SRC}/*.js`, `!${PROJECT_JS_SRC}/stream-images.js`],
-    {
-      sourcemaps: true,
-    }
-  )
+  return src([`${PROJECT_JS_SRC}/*.js`], {
+    sourcemaps: true,
+  })
     .pipe(uglify())
     .pipe(concat("common.js"))
     .pipe(dest(JS_DEST, { sourcemaps: true }));

--- a/themes/digital.gov/layouts/_default/baseof.html
+++ b/themes/digital.gov/layouts/_default/baseof.html
@@ -81,7 +81,7 @@
   <!-- Set the Images API as a variable -->
 <script type="text/javascript">
   var root_url = {{ "" | absURL }};
-  var all_images_json = {{ "images/v1/json/" | absURL }};
+  var all_imagesJson = {{ "images/v1/json/" | absURL }};
 </script> {{/* Custom JS */}}
   {{- if $.Params.js -}}
     {{- range $.Params.js -}}

--- a/themes/digital.gov/layouts/_default/baseof.html
+++ b/themes/digital.gov/layouts/_default/baseof.html
@@ -85,7 +85,7 @@
 </script> {{/* Custom JS */}}
   {{- if $.Params.js -}}
     {{- range $.Params.js -}}
-      {{- $path := (printf "dist/js/%s" .) | absURL -}}
+      {{- $path := (printf "dist/%s" .) | absURL -}}
       <!-- CUSTOM JS -->
       <script src="{{ $path }}" type="text/javascript" charset="utf-8"></script>
     {{- end -}}

--- a/themes/digital.gov/layouts/_default/baseof.html
+++ b/themes/digital.gov/layouts/_default/baseof.html
@@ -85,7 +85,7 @@
 </script> {{/* Custom JS */}}
   {{- if $.Params.js -}}
     {{- range $.Params.js -}}
-      {{- $path := (printf "dist/%s" .) | absURL -}}
+      {{- $path := (printf "dist/js/%s" .) | absURL -}}
       <!-- CUSTOM JS -->
       <script src="{{ $path }}" type="text/javascript" charset="utf-8"></script>
     {{- end -}}


### PR DESCRIPTION
## Summary

Fix for [images stream](https://digital.gov/images/).

### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-refactor-images-stream/images/)

### Solution

Reverted back to old `stream-images.js` code and made a slight edit to the `gulp/script.js` to get the images loading.


### How To Test

1. Visit [images stream](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-refactor-images-stream/images/)
2. Should not see the error message:

`Refused to execute script from 'https://digital.gov/dist/stream-images.js' because its MIME type ('text/html') is not executable, and strict MIME type checking is enabled.`

---

### Dev Checklist

- [x] PR has correct labels
- [x] A11y testing (voice over testing, meets WCAG, run axe tools)
- [x] Code is formatted properly
