### PR TITLE
Updated path to use event date instead of creation date

### DIFF
--- a/themes/digital.gov/static/workflow/config.yml
+++ b/themes/digital.gov/static/workflow/config.yml
@@ -390,7 +390,16 @@ collections:
       - label: "Event Related CoP"
         name: "cop_events"
         widget: "select"
-        options: ["communicators", "multilingual", "plain-language", "web-managers", "web-analytics", "social-media", "user-experience"]
+        options:
+          [
+            "communicators",
+            "multilingual",
+            "plain-language",
+            "web-managers",
+            "web-analytics",
+            "social-media",
+            "user-experience",
+          ]
         collection: "events"
         default: ""
         multiple: true
@@ -475,6 +484,39 @@ collections:
         widget: "markdown"
         required: false
         <<: *editorComponents
+
+  # FUTURE EVENTS =======================
+  - <<: *defaults
+    name: "future-events"
+    label: "Future Events"
+    label_singular: "Future Event"
+    description: "This page will help create a new event on Digital.gov"
+    folder: "content/events"
+    summary: "{{title}} ({{year}}-{{month}}-{{day}})"
+    path: "{{fields.date | date('YYYY-MM')}}/{{slug}}"
+    slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
+    preview_path: event/{{year}}/{{month}}/{{day}}/{{title}}
+    preview_path_date_field: "date"
+    fields:
+      - label: "Event Title"
+        name: "title"
+        widget: "string"
+        hint: "Short, topical, no acronyms."
+        required: false
+      - label: "Start Date/Time"
+        name: "date"
+        widget: "datetime"
+        dateFormat: "YYYY-MM-DD" # e.g. 2021-11.23
+        timeFormat: "HH:mm" # e.g. 21:00
+        format: "YYYY-MM-DD HH:mm:00 -0500"
+        hint: "The start date and time of the event (Note: uses a 24hr clock, e.g. 13:00)"
+      - label: "End time"
+        name: "end_date"
+        widget: "datetime"
+        dateFormat: "YYYY-MM-DD" # e.g. 2021-11.23
+        timeFormat: "HH:mm" # e.g. 21:00
+        format: "YYYY-MM-DD HH:mm:00 -0500"
+        hint: "The end date and time of the event (Note: uses a 24hr clock, e.g. 14:00)"
 
   # NEWS =======================
   - <<: *defaults
@@ -786,7 +828,6 @@ collections:
         required: false
         <<: *editorComponents
 
-
   # SHORT LINK =======================
   - <<: *defaults
     name: "shortlink"
@@ -1047,11 +1088,15 @@ collections:
       - label: "File"
         name: "file"
         widget: "file"
-        pattern: ['.*\.(doc|docx|pdf|ppt|pptx|pptm|xls|xlsx)$', "Allowed files are .pdf, .xls/x, .doc/x, .ppt/x/m"]
+        pattern:
+          [
+            '.*\.(doc|docx|pdf|ppt|pptx|pptm|xls|xlsx)$',
+            "Allowed files are .pdf, .xls/x, .doc/x, .ppt/x/m",
+          ]
         media_library:
           config:
             multiple: true
-            
+
   # IMAGE UPLOAD =======================
   - <<: *defaults
     name: "image-upload"

--- a/themes/digital.gov/static/workflow/config.yml
+++ b/themes/digital.gov/static/workflow/config.yml
@@ -494,10 +494,10 @@ collections:
     folder: "content/events"
     summary: "{{title}} ({{year}}-{{month}}-{{day}})"
     # path: "{{year}}/{{month}}/{{slug}}"
-    path: "{{start_date | date('YYYY-MM')}}/{{slug}}"
+    path: "{{start_date | date('YYYY')}}/{{start_date | date('MM')}}/{{start_date | date('YYYY')}}-{{start_date | date('MM')}}-{{start_date | date('DD')}}-{{title}}"
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
     preview_path: "event/{{year}}/{{month}}/{{day}}/{{title}}"
-    preview_path_date_field: "date"
+    preview_path_date_field: "start_date"
     fields:
       - label: "Event Title"
         name: "title"

--- a/themes/digital.gov/static/workflow/config.yml
+++ b/themes/digital.gov/static/workflow/config.yml
@@ -494,7 +494,7 @@ collections:
     folder: "content/events"
     summary: "{{title}} ({{year}}-{{month}}-{{day}})"
     # path: "{{year}}/{{month}}/{{slug}}"
-    path: "{{fields.start_date}}/{{slug}}"
+    path: "{{start_date}}/{{slug}}"
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
     preview_path: "event/{{year}}/{{month}}/{{day}}/{{title}}"
     preview_path_date_field: "date"

--- a/themes/digital.gov/static/workflow/config.yml
+++ b/themes/digital.gov/static/workflow/config.yml
@@ -493,8 +493,8 @@ collections:
     description: "This page will help create a new event on Digital.gov"
     folder: "content/events"
     summary: "{{title}} ({{year}}-{{month}}-{{day}})"
-    # path: "{{year}}/{{month}}/{{slug}}"
-    path: "{{date | date('YYYY')}}/{{date | date('MM')}}/{{date | date('YYYY')}}-{{date | date('MM')}}-{{date | date('DD')}}-{{title}}"
+    # path: "{{date | date('YYYY')}}/{{date | date('MM')}}/{{date | date('YYYY')}}-{{date | date('MM')}}-{{date | date('DD')}}-{{title}}"
+    path: "{{date | date('YYYY-MM')}}/{{date | date('YYYY-MM-DD')}}-{{title}}"
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
     preview_path: "event/{{year}}/{{month}}/{{day}}/{{title}}"
     preview_path_date_field: "start_date"
@@ -507,15 +507,15 @@ collections:
       - label: "Start Date/Time"
         name: "date"
         widget: "datetime"
-        date_format: "YYYY-MM-DD" # e.g. 2021-11.23
-        time_format: "HH:mm" # e.g. 21:00
+        dateFormat: "YYYY-MM-DD" # e.g. 2021-11.23
+        timeFormat: "HH:mm" # e.g. 21:00
         format: "YYYY-MM-DD HH:mm:00 -0500"
         hint: "The start date and time of the event (Note: uses a 24hr clock, e.g. 13:00)"
       - label: "End time"
         name: "end_date"
         widget: "datetime"
-        date_format: "YYYY-MM-DD" # e.g. 2021-11.23
-        time_format: "HH:mm" # e.g. 21:00
+        dateFormat: "YYYY-MM-DD" # e.g. 2021-11.23
+        timeFormat: "HH:mm" # e.g. 21:00
         format: "YYYY-MM-DD HH:mm:00 -0500"
         hint: "The end date and time of the event (Note: uses a 24hr clock, e.g. 14:00)"
 

--- a/themes/digital.gov/static/workflow/config.yml
+++ b/themes/digital.gov/static/workflow/config.yml
@@ -494,7 +494,7 @@ collections:
     folder: "content/events"
     summary: "{{title}} ({{year}}-{{month}}-{{day}})"
     # path: "{{year}}/{{month}}/{{slug}}"
-    path: "{{start_date | date('YYYY')}}/{{start_date | date('MM')}}/{{start_date | date('YYYY')}}-{{start_date | date('MM')}}-{{start_date | date('DD')}}-{{title}}"
+    path: "{{date | date('YYYY')}}/{{date | date('MM')}}/{{date | date('YYYY')}}-{{date | date('MM')}}-{{date | date('DD')}}-{{title}}"
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
     preview_path: "event/{{year}}/{{month}}/{{day}}/{{title}}"
     preview_path_date_field: "start_date"
@@ -505,7 +505,7 @@ collections:
         hint: "Short, topical, no acronyms."
         required: false
       - label: "Start Date/Time"
-        name: "start_date"
+        name: "date"
         widget: "datetime"
         date_format: "YYYY-MM-DD" # e.g. 2021-11.23
         time_format: "HH:mm" # e.g. 21:00

--- a/themes/digital.gov/static/workflow/config.yml
+++ b/themes/digital.gov/static/workflow/config.yml
@@ -493,7 +493,7 @@ collections:
     description: "This page will help create a new event on Digital.gov"
     folder: "content/events"
     summary: "{{title}} ({{year}}-{{month}}-{{day}})"
-    path: "{{fields.date | date('YYYY-MM')}}/{{slug}}"
+    path: "{{fields.date | date('YYYY-MM-DD')}}/{{slug}}"
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
     preview_path: event/{{year}}/{{month}}/{{day}}/{{title}}
     preview_path_date_field: "date"
@@ -506,15 +506,15 @@ collections:
       - label: "Start Date/Time"
         name: "date"
         widget: "datetime"
-        dateFormat: "YYYY-MM-DD" # e.g. 2021-11.23
-        timeFormat: "HH:mm" # e.g. 21:00
+        date_format: "YYYY-MM-DD" # e.g. 2021-11.23
+        time_format: "HH:mm" # e.g. 21:00
         format: "YYYY-MM-DD HH:mm:00 -0500"
         hint: "The start date and time of the event (Note: uses a 24hr clock, e.g. 13:00)"
       - label: "End time"
         name: "end_date"
         widget: "datetime"
-        dateFormat: "YYYY-MM-DD" # e.g. 2021-11.23
-        timeFormat: "HH:mm" # e.g. 21:00
+        date_format: "YYYY-MM-DD" # e.g. 2021-11.23
+        time_format: "HH:mm" # e.g. 21:00
         format: "YYYY-MM-DD HH:mm:00 -0500"
         hint: "The end date and time of the event (Note: uses a 24hr clock, e.g. 14:00)"
 

--- a/themes/digital.gov/static/workflow/config.yml
+++ b/themes/digital.gov/static/workflow/config.yml
@@ -494,7 +494,7 @@ collections:
     folder: "content/events"
     summary: "{{title}} ({{year}}-{{month}}-{{day}})"
     # path: "{{date | date('YYYY')}}/{{date | date('MM')}}/{{date | date('YYYY')}}-{{date | date('MM')}}-{{date | date('DD')}}-{{title}}"
-    path: "{{date | date('YYYY-MM')}}/{{date | date('YYYY-MM-DD')}}-{{title}}"
+    path: "{{start_date | date('YYYY-MM')}}/{{start_date | date('YYYY-MM-DD')}}-{{title}}"
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
     preview_path: "event/{{year}}/{{month}}/{{day}}/{{title}}"
     preview_path_date_field: "start_date"
@@ -505,7 +505,7 @@ collections:
         hint: "Short, topical, no acronyms."
         required: false
       - label: "Start Date/Time"
-        name: "date"
+        name: "start_date"
         widget: "datetime"
         dateFormat: "YYYY-MM-DD" # e.g. 2021-11.23
         timeFormat: "HH:mm" # e.g. 21:00

--- a/themes/digital.gov/static/workflow/config.yml
+++ b/themes/digital.gov/static/workflow/config.yml
@@ -494,7 +494,7 @@ collections:
     folder: "content/events"
     summary: "{{title}} ({{year}}-{{month}}-{{day}})"
     # path: "{{year}}/{{month}}/{{slug}}"
-    path: "{{start_date}}/{{slug}}"
+    path: "{{start_date | date('YYYY-MM')}}/{{slug}}"
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
     preview_path: "event/{{year}}/{{month}}/{{day}}/{{title}}"
     preview_path_date_field: "date"

--- a/themes/digital.gov/static/workflow/config.yml
+++ b/themes/digital.gov/static/workflow/config.yml
@@ -487,15 +487,16 @@ collections:
 
   # FUTURE EVENTS =======================
   - <<: *defaults
-    name: "future-events"
+    name: "future_events"
     label: "Future Events"
     label_singular: "Future Event"
     description: "This page will help create a new event on Digital.gov"
     folder: "content/events"
     summary: "{{title}} ({{year}}-{{month}}-{{day}})"
-    path: "{{fields.date}}/{{slug}}"
+    # path: "{{year}}/{{month}}/{{slug}}"
+    path: "{{fields.start_date}}/{{slug}}"
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
-    preview_path: event/{{year}}/{{month}}/{{day}}/{{title}}
+    preview_path: "event/{{year}}/{{month}}/{{day}}/{{title}}""
     preview_path_date_field: "date"
     fields:
       - label: "Event Title"
@@ -504,7 +505,7 @@ collections:
         hint: "Short, topical, no acronyms."
         required: false
       - label: "Start Date/Time"
-        name: "date"
+        name: "start_date"
         widget: "datetime"
         date_format: "YYYY-MM-DD" # e.g. 2021-11.23
         time_format: "HH:mm" # e.g. 21:00

--- a/themes/digital.gov/static/workflow/config.yml
+++ b/themes/digital.gov/static/workflow/config.yml
@@ -493,7 +493,7 @@ collections:
     description: "This page will help create a new event on Digital.gov"
     folder: "content/events"
     summary: "{{title}} ({{year}}-{{month}}-{{day}})"
-    path: "{{fields.date | date('YYYY-MM-DD')}}/{{slug}}"
+    path: "{{fields.date}}/{{slug}}"
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
     preview_path: event/{{year}}/{{month}}/{{day}}/{{title}}
     preview_path_date_field: "date"

--- a/themes/digital.gov/static/workflow/config.yml
+++ b/themes/digital.gov/static/workflow/config.yml
@@ -496,7 +496,7 @@ collections:
     # path: "{{year}}/{{month}}/{{slug}}"
     path: "{{fields.start_date}}/{{slug}}"
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
-    preview_path: "event/{{year}}/{{month}}/{{day}}/{{title}}""
+    preview_path: "event/{{year}}/{{month}}/{{day}}/{{title}}"
     preview_path_date_field: "date"
     fields:
       - label: "Event Title"


### PR DESCRIPTION
- created future event collection
- set path to fields.date to test if we can use event date

## Summary

Basic description of work done. Closes [#issue_no].

### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-fix-future-events/workflow/)

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

1. First Step
2. Second Step
3. Third Step

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
