### PR TITLE
Guides: Improve specificity of guide selectors

### DIFF
--- a/themes/digital.gov/layouts/guides/list.html
+++ b/themes/digital.gov/layouts/guides/list.html
@@ -23,7 +23,7 @@
               {{- partial "core/guides/guide-page-head.html" . -}}
 
               {{- if .Params.summary_box -}}
-                {{- partial "core/usa-summary-box.html" . -}}
+                {{- partial "core/usa-summary-box.html" (dict "modifier" "dg-guide-summary") -}}
               {{- end -}}
 
               {{- .Content -}}

--- a/themes/digital.gov/layouts/guides/single.html
+++ b/themes/digital.gov/layouts/guides/single.html
@@ -26,7 +26,7 @@
               {{- partial "core/guides/guide-page-head.html" . -}}
 
               {{- if .Params.summary_box -}}
-                {{- partial "core/usa-summary-box.html" . -}}
+                {{- partial "core/usa-summary-box.html" (dict "modifier" "dg-guide-summary") -}}
               {{- end -}}
 
               {{ .Content }}

--- a/themes/digital.gov/layouts/partials/core/usa-summary-box.html
+++ b/themes/digital.gov/layouts/partials/core/usa-summary-box.html
@@ -1,5 +1,5 @@
 <div
-  class="usa-summary-box"
+  class="usa-summary-box {{ .modifier }}"
   role="region"
   aria-labelledby="summary-box-key-information"
 >

--- a/themes/digital.gov/src/js/guide-sidenav.js
+++ b/themes/digital.gov/src/js/guide-sidenav.js
@@ -1,8 +1,11 @@
 document.addEventListener("DOMContentLoaded", () => {
+  const guideNav = document.querySelector(".guide-nav-box");
+
+  if (!guideNav) return;
+
   // add class to current sidenav list item
-  const guideCurrentListItem = document.querySelector(
-    ".usa-sidenav .usa-current"
-  );
+  const guideCurrentListItem = guideNav.querySelector(".usa-current");
+
   guideCurrentListItem.parentNode.classList.add("current");
 
   // apply style to previous list item to display guide progress

--- a/themes/digital.gov/src/js/summary-box.js
+++ b/themes/digital.gov/src/js/summary-box.js
@@ -4,7 +4,11 @@
 
 // eslint-disable-next-line func-names
 (function () {
-  const guideSummaryList = document.querySelector(".usa-list");
+  const guideSummary = document.querySelector(".dg-guide-summary");
+
+  if (!guideSummary) return;
+
+  const guideSummaryList = guideSummary.querySelector(".usa-list");
   const pageHeaders = document.querySelectorAll("h2");
 
   function createSummaryBox() {


### PR DESCRIPTION
## Summary

Bug fix for unwanted sidenav items.

- Add modifier class to summary box
- Use more specific selector for guide sidenav and summary box
- Target new guide selectors in JS

<details><summary>Unexpected links in sidenav</summary>
<p></p>

![image](https://github.com/GSA/digitalgov.gov/assets/3385219/a16fd038-feb2-4c9d-bdd8-fb1d5f44589c)
</details> 


### Preview

- [public-participation](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/jm-refactor-guides-hotfix/guides/public-participation/)
- [public-participation/design-participation](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/jm-refactor-guides-hotfix/guides/public-participation/design-participation/)
- [public-participation/understand](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/jm-refactor-guides-hotfix/guides/public-participation/understand/)
- [rpa/rpa-use-case-inventory](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/jm-refactor-guides-hotfix/guides/rpa/rpa-use-case-inventory/)
- [latinx-identity-in-design-tech-and-government](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/jm-refactor-guides-hotfix/2022/10/14/latinx-identity-in-design-tech-and-government/)
 
<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

- Dynamic links in sidenav stay in guides
- No regressions in guide sidenav
- No regressions in guide summary box

