### PR TITLE
Homepage: Remove RPA guide from featured resources

### DIFF
--- a/content/resources/guide-robotic-process-automation.md
+++ b/content/resources/guide-robotic-process-automation.md
@@ -1,11 +1,11 @@
 ---
-# View this page at https://digital.gov/resources/eight-principles-mobilefriendliness
+# View this page at https://digital.gov/guides/rpa
 # Learn how to edit our pages at https://workflow.digital.gov
 
 slug: guide-to-robotic-process-automation
 date: 2020-11-03 14:000:00 -0500
 title: "Guide to Robotic Process Automation"
-deck: "Automate reptitive business processes without writing code"
+deck: "Automate repetitive business processes without writing code"
 summary: "Configure bots to execute repetitive tasks to save users from performing mundane tasks repeatedly for the same process."
 
 topics:
@@ -22,6 +22,6 @@ source: digitalgov
 authors:
   - james-geoghegan
 
-weight: 3
+weight: 1
 # Make it better ♥
 ---


### PR DESCRIPTION
## Summary

Removes the RPA guide from featured collection on homepage.

### Additional information

- Fix URL in comment
- Fix typo in `repetitive`
- Reduce resource weight so it doesn't show on homepage featured collection

### Preview

[Link to Preview]()

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

1. First Step
2. Second Step
3. Third Step

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
