### PR TITLE
Enable Read Time by Default

### DIFF
--- a/data/guidenav/dap.yml
+++ b/data/guidenav/dap.yml
@@ -1,5 +1,4 @@
 showNextPrevious: true
-showReadTime: true
 nav:
 - title  : 'Overview'
   path   : '/guides/dap/_index.md'

--- a/data/guidenav/mobile-principles.yml
+++ b/data/guidenav/mobile-principles.yml
@@ -1,5 +1,4 @@
 showNextPrevious: true
-showReadTime: true
 nav:
 - title  : 'Overview'
   path   : '/guides/mobile-principles/_index.md'

--- a/data/guidenav/public-participation.yml
+++ b/data/guidenav/public-participation.yml
@@ -1,6 +1,5 @@
 # Navigation YML file for public participation guide
 showNextPrevious: true
-showReadTime: true
 nav:
 - title    : 'Overview'
   path     : '/guides/public-participation/_index.md'

--- a/data/guidenav/rpa.yml
+++ b/data/guidenav/rpa.yml
@@ -1,5 +1,4 @@
 showNextPrevious: true
-showReadTime: true
 nav:
 - title  : 'Overview'
   path   : '/guides/rpa/_index.md'

--- a/data/guidenav/site-scanning.yml
+++ b/data/guidenav/site-scanning.yml
@@ -1,5 +1,4 @@
 showNextPrevious: true
-showReadTime: true
 nav:
 - title  : 'Overview'
   path   : '/guides/site-scanning/_index.md'

--- a/data/guidenav/web-analytics-playbook.yml
+++ b/data/guidenav/web-analytics-playbook.yml
@@ -1,6 +1,5 @@
 # Navigation YML file for web analytics guide guide
 showNextPrevious: true
-showReadTime: true
 nav:
 - title    : 'Overview'
   path     : '/guides/web-analytics-playbook/_index.md'

--- a/themes/digital.gov/layouts/partials/core/read-time.html
+++ b/themes/digital.gov/layouts/partials/core/read-time.html
@@ -1,21 +1,17 @@
 {{- $guide_data := index $.Site.Data.guidenav (.Params.guide) -}}
-
-{{- if and $guide_data $guide_data.showReadTime -}}
-
-  {{- $readTime := 0 -}}
-
+{{- $readTime := 0 -}}
+{{- /* Show read time by default. Only disable read time if parameter is set explicitly in guidenav file */ -}}
+{{- if or (not (and $guide_data (eq $guide_data.showReadTime false))) (not $guide_data) -}}
   {{ if isset .Params "readtime" }}
     {{- $readTime = .Params.readTime -}}
   {{- else -}}
     {{- $readTime = .ReadingTime -}}
   {{- end -}}
 
-  {{ if $readTime }}
-    {{ $readTimeMinutes := cond (gt $readTime 1) "minutes" "minute" }}
-    <p class="dg-read-time">
-      Reading time:
-      {{ $readTime }}
-      {{ $readTimeMinutes }}
-    </p>
-  {{- end -}}
+  {{ $readTimeMinutes := cond (gt $readTime 1) "minutes" "minute" }}
+  <p class="dg-read-time">
+    Reading time:
+    {{ $readTime }}
+    {{ $readTimeMinutes }}
+  </p>
 {{- end -}}

--- a/themes/digital.gov/layouts/partials/core/read-time.html
+++ b/themes/digital.gov/layouts/partials/core/read-time.html
@@ -1,6 +1,8 @@
 {{- $guide_data := index $.Site.Data.guidenav (.Params.guide) -}}
 {{- $readTime := 0 -}}
+
 {{- /* Show read time by default. Only disable read time if parameter is set explicitly in guidenav file */ -}}
+
 {{- if or (not (and $guide_data (eq $guide_data.showReadTime false))) (not $guide_data) -}}
   {{ if isset .Params "readtime" }}
     {{- $readTime = .Params.readTime -}}


### PR DESCRIPTION
## Summary

Reading time on guides feature currently requires a parameter to be set manually. Updated so that read time displays by default unless explicitly turned off. 

### Preview

[Link to Preview]()

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### How To Test

1. Delete a `data/guidenav` file—the read time for that guide should be displayed
2. Delete the showReadTime parameter from a `data/guidenav` file—the read time for that guide should be displayed
3. Set the showReadTime parameter to `true` on a `data/guidenav` file—the read time for that guide should be displayed
4. Set the showReadTime parameter to `false` on a `data/guidenav` file—the read time for that guide should **not** be displayed

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
