### PR TITLE
Create Call to Action Buttons on Home Page

### DIFF
--- a/themes/digital.gov/layouts/home.html
+++ b/themes/digital.gov/layouts/home.html
@@ -8,7 +8,11 @@
               <h1 class="resources-featured__title">
                 Guidance on building better digital services in government.
               </h1>
-              <a class="btn btn-home" href="/events" title="View events page">
+              <a
+                class="btn btn-home"
+                href="{{- "events" | relURL -}}"
+                title="View events page"
+              >
                 <span>View Events</span>
                 <svg
                   class="usa-icon dg-icon dg-icon--standard margin-bottom-05"
@@ -23,7 +27,7 @@
               </a>
               <a
                 class="btn btn-home"
-                href="/communities"
+                href="{{- "communities" | relURL -}}"
                 title="View communities page"
               >
                 <span>Join Communities</span>

--- a/themes/digital.gov/layouts/home.html
+++ b/themes/digital.gov/layouts/home.html
@@ -10,13 +10,27 @@
               </h1>
               <a class="btn btn-home" href="/events" title="View events page">
                 <span>View Events</span>
-                <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false" role="img">
+                <svg
+                  class="usa-icon dg-icon dg-icon--standard margin-bottom-05"
+                  aria-hidden="true"
+                  focusable="false"
+                  role="img"
+                >
                   <use xlink:href="/uswds/img/sprite.svg#arrow_forward"></use>
                 </svg>
               </a>
-              <a class="btn btn-home" href="/communities" title="View communities page">
+              <a
+                class="btn btn-home"
+                href="/communities"
+                title="View communities page"
+              >
                 <span>Join Communities</span>
-                <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false" role="img">
+                <svg
+                  class="usa-icon dg-icon dg-icon--standard margin-bottom-05"
+                  aria-hidden="true"
+                  focusable="false"
+                  role="img"
+                >
                   <use xlink:href="/uswds/img/sprite.svg#arrow_forward"></use>
                 </svg>
               </a>

--- a/themes/digital.gov/layouts/home.html
+++ b/themes/digital.gov/layouts/home.html
@@ -8,6 +8,18 @@
               <h1 class="resources-featured__title">
                 Guidance on building better digital services in government.
               </h1>
+              <a class="btn btn-home" href="/events" title="View events page">
+                <span>View Events</span>
+                <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false" role="img">
+                  <use xlink:href="/uswds/img/sprite.svg#arrow_forward"></use>
+                </svg>
+              </a>
+              <a class="btn btn-home" href="/communities" title="View communities page">
+                <span>Join Communities</span>
+                <svg class="usa-icon dg-icon dg-icon--standard margin-bottom-05" aria-hidden="true" focusable="false" role="img">
+                  <use xlink:href="/uswds/img/sprite.svg#arrow_forward"></use>
+                </svg>
+              </a>
             </div>
           </div>
 

--- a/themes/digital.gov/layouts/home.html
+++ b/themes/digital.gov/layouts/home.html
@@ -16,7 +16,9 @@
                   focusable="false"
                   role="img"
                 >
-                  <use xlink:href="/uswds/img/sprite.svg#arrow_forward"></use>
+                  <use
+                    xlink:href="{{ "uswds/img/sprite.svg#arrow_forward" | relURL }}"
+                  ></use>
                 </svg>
               </a>
               <a
@@ -31,7 +33,9 @@
                   focusable="false"
                   role="img"
                 >
-                  <use xlink:href="/uswds/img/sprite.svg#arrow_forward"></use>
+                  <use
+                    xlink:href="{{ "uswds/img/sprite.svg#arrow_forward" | relURL }}"
+                  ></use>
                 </svg>
               </a>
             </div>

--- a/themes/digital.gov/src/scss/new/_buttons.scss
+++ b/themes/digital.gov/src/scss/new/_buttons.scss
@@ -55,6 +55,21 @@ a.btn {
   }
 }
 
+a.btn-home {
+  @include u-bg("transparent");
+  @include u-border("2px");
+  @include u-margin(2);
+
+  @include at-media("tablet-lg") {
+    @include u-margin-x(0);
+  }
+
+  &:hover {
+    @include u-bg("primary-vivid");
+    @include u-border("primary-vivid");
+  }
+}
+
 a.btn-sm {
   @include u-padding-y("05");
   @include u-padding-x(1);

--- a/themes/digital.gov/src/scss/new/_buttons.scss
+++ b/themes/digital.gov/src/scss/new/_buttons.scss
@@ -60,14 +60,18 @@ a.btn-home {
   background-color: transparent;
   margin: units(2);
 
+  &:first-of-type {
+    margin-bottom: units(0);
+  }
+
   @include at-media("tablet-lg") {
     @include u-margin-x(0);
   }
 
   &:hover {
-    background-color: white;
-    border-color: white;
-    color: black;
+    background-color: color("white");
+    border-color: color("white");
+    color: color("black");
     span {
       @include u-border-bottom("2px", "black", "solid");
     }

--- a/themes/digital.gov/src/scss/new/_buttons.scss
+++ b/themes/digital.gov/src/scss/new/_buttons.scss
@@ -65,8 +65,12 @@ a.btn-home {
   }
 
   &:hover {
-    @include u-bg("primary-vivid");
-    @include u-border("primary-vivid");
+    @include u-bg("white");
+    @include u-border("white");
+    @include u-text("black");
+    span {
+      @include u-border-bottom("2px", "black", "solid");
+    }
   }
 }
 

--- a/themes/digital.gov/src/scss/new/_buttons.scss
+++ b/themes/digital.gov/src/scss/new/_buttons.scss
@@ -56,18 +56,18 @@ a.btn {
 }
 
 a.btn-home {
-  @include u-bg("transparent");
   @include u-border("2px");
-  @include u-margin(2);
+  background-color: transparent;
+  margin: units(2);
 
   @include at-media("tablet-lg") {
     @include u-margin-x(0);
   }
 
   &:hover {
-    @include u-bg("white");
-    @include u-border("white");
-    @include u-text("black");
+    background-color: white;
+    border-color: white;
+    color: black;
     span {
       @include u-border-bottom("2px", "black", "solid");
     }

--- a/themes/digital.gov/src/scss/new/_resources_featured.scss
+++ b/themes/digital.gov/src/scss/new/_resources_featured.scss
@@ -1,14 +1,14 @@
 @use "uswds-core" as *;
 
 #resources_featured {
-  @include u-padding-y(2);
   background-color: color("white");
+  padding: units(2) 0;
   padding-top: units(4);
 }
 
 .home #resources_featured {
-  @include u-padding-y(0);
   background-color: color("primary-dark");
+  padding: 0;
 
   @include at-media("tablet-lg") {
     padding-top: units(3);
@@ -28,17 +28,16 @@
       padding: units(2) units(4) 0 units(2);
 
       @include at-media("tablet-lg") {
-        @include u-margin-y(4);
-        @include u-font("sans", "2xl");
+        margin: units(4) 0;
         padding: 0;
+        @include u-font("sans", "2xl");
       }
     }
   }
 
   .resources-content {
-    @include u-padding-x(2);
-    @include u-padding-y(3);
     background-color: color("white");
+    padding: units(3) units(2);
 
     @include at-media("tablet-lg") {
       @include u-radius-top("lg");

--- a/themes/digital.gov/src/scss/new/_resources_featured.scss
+++ b/themes/digital.gov/src/scss/new/_resources_featured.scss
@@ -20,15 +20,7 @@
     @include u-padding(0);
     @include u-radius(0);
 
-    @include at-media("tablet-lg") {
-      @include u-display("flex");
-      @include u-flex("align-center");
-      @include u-height("full");
-      @include u-padding-bottom(8);
-    }
-
     .resources-featured__title {
-      @include u-margin(0);
       @include u-padding(2);
       @include u-padding-right(4);
       @include u-font("sans", "xl");
@@ -37,7 +29,7 @@
       @include u-text("thin");
 
       @include at-media("tablet-lg") {
-        @include u-margin-bottom(0);
+        @include u-margin-y(4);
         @include u-padding(0);
         @include u-font("sans", "2xl");
       }

--- a/themes/digital.gov/src/scss/new/_resources_featured.scss
+++ b/themes/digital.gov/src/scss/new/_resources_featured.scss
@@ -21,8 +21,8 @@
     @include u-radius(0);
 
     .resources-featured__title {
-      @include u-padding(2);
-      @include u-padding-right(4);
+      padding: units(2) units(4) 0 units(2);
+      margin: 0;
       @include u-font("sans", "xl");
       @include u-line-height("sans", 2);
       @include u-text("white");

--- a/themes/digital.gov/src/scss/new/_resources_featured.scss
+++ b/themes/digital.gov/src/scss/new/_resources_featured.scss
@@ -34,42 +34,6 @@
         @include u-font("sans", "2xl");
       }
     }
-
-    p {
-      @include u-margin-top(0);
-      @include u-padding-y("105");
-      @include u-padding-x(2);
-      @include u-border-bottom("1px", "base-lightest", "solid");
-      @include u-bg("primary-darkest");
-      @include u-text("white");
-      @include u-font("sans", "xs");
-      @include u-line-height("sans", 2);
-      @include u-text("normal");
-      @include u-maxw("full");
-
-      @include at-media("tablet-lg") {
-        @include u-font("sans", "sm");
-        @include u-padding(2);
-      }
-
-      a {
-        @include u-display("flex");
-        @include u-flex("align-center");
-        @include u-text("no-underline");
-        @include u-text("white");
-
-        img {
-          @include u-margin-right("105");
-          @include u-width(5);
-          @include u-minw(5);
-
-          @include at-media("tablet-lg") {
-            @include u-width(7);
-            @include u-minw(7);
-          }
-        }
-      }
-    }
   }
 
   .resources-content {

--- a/themes/digital.gov/src/scss/new/_resources_featured.scss
+++ b/themes/digital.gov/src/scss/new/_resources_featured.scss
@@ -21,8 +21,8 @@
     @include u-radius(0);
 
     .resources-featured__title {
-      padding: units(2) units(4) 0 units(2);
       margin: 0;
+      padding: units(2) units(4) 0 units(2);
       @include u-font("sans", "xl");
       @include u-line-height("sans", 2);
       @include u-text("white");


### PR DESCRIPTION
## Summary

Created call to action buttons highlighting events and communities on the digital.gov home page. 

### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/jtm-create-ctas/)

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

#### Before
<img width="1440" alt="Screenshot 2023-07-14 at 4 17 24 PM" src="https://github.com/GSA/digitalgov.gov/assets/56370370/0bb90451-f426-40ac-968c-b70b23e81635">

#### After
<img width="1440" alt="Screenshot 2023-07-14 at 4 17 45 PM" src="https://github.com/GSA/digitalgov.gov/assets/56370370/0f409586-f9de-4725-b3d4-ccee21eae5d8">

### How To Test

1. Visit the home page
2. Verify that both call to action buttons function correctly

---

### Dev Checklist

- [x] PR has correct labels
- [x] A11y testing (voice over testing, meets WCAG, run axe tools)
- [x] Code is formatted properly
