### PR TITLE
Fixed pptx extension path for "supporting inclusive language through automation" event

### DIFF
--- a/content/events/2023/07/2023-07-05-supporting-inclusive-language-through-automation.md
+++ b/content/events/2023/07/2023-07-05-supporting-inclusive-language-through-automation.md
@@ -28,7 +28,7 @@ youtube_id:
 
 ---
 
-{{< asset-static file="2023-digitalgov-inclusive-language-support-through-automation-event-final-pptx" label="View the slides (PowerPoint presentation, 4 MB, 29 pages)" >}}
+{{< asset-static file="2023-digitalgov-inclusive-language-support-through-automation-event-final.pptx" label="View the slides (PowerPoint presentation, 4 MB, 29 pages)" >}}
 
 ---
 


### PR DESCRIPTION
## Summary

Fixed the url path for the `pptx` file, see https://github.com/GSA/digitalgov.gov/pull/6327/files for proper file path

