### PR TITLE
Remove broken Youtube link from customer experiencetoolkit

### DIFF
--- a/content/resources/customer-experience-toolkit.md
+++ b/content/resources/customer-experience-toolkit.md
@@ -16,7 +16,7 @@ weight: 3
 
 ---
 
-Customer Experience (CX) is defined as the sum of all experiences a customer has with your organization. Since government is often a sole-source service provider (e.g., there’s only one place to pay taxes, or get a driver’s license), CX is even more important in the public sector than in other organizations. If that’s not enough to convince you, view this [webinar on why federal agencies must improve CX](https://www.youtube.com/watch?v=JFJg-8KwR9I).
+Customer Experience (CX) is defined as the sum of all experiences a customer has with your organization. Since government is often a sole-source service provider (e.g., there’s only one place to pay taxes, or get a driver’s license), CX is even more important in the public sector than in other organizations.
 
 This Toolkit is intended to help government agencies improve how we deliver services and information to the public.
 


### PR DESCRIPTION
Touchpoints feedback indicated the youtube link was broken and I confirmed. Removing it since it's not critical to the content in this page.

## Summary

I have removed the sentence and suggested a crawl for other broken youtube links on the site. 

### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/bc-remove-broken-youtube-link/resources/customer-experience-toolkit/)

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

1. First Step
2. Second Step
3. Third Step

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
