### PR TITLE
Fix monthly call script link

### DIFF
--- a/content/events/2023/06/2023-06-08-uswds-monthly-call-june-2023.md
+++ b/content/events/2023/06/2023-06-08-uswds-monthly-call-june-2023.md
@@ -24,7 +24,7 @@ primary_image: 2023-uswds-monthly-call-june-title-card
 
 {{< asset-static file="uswds-monthly-call-june-2023.pptx" label="View the slides (PowerPoint presentation, 2.0 MB, 79 pages)" >}}
 
-{{< accordion kicker="Slide by Slide" title="USWDS Monthly Call - Presentation Script for May 2023" icon="content_copy" >}}**Slide 1:** Hi there and welcome to the U.S. Web Design System monthly call for June 2023, home to Pride month, Fathers Day, Flag Day, Kamehameha Day, and the Summer Solstice — as well as Juneteenth, this coming Monday, with the USWDS logo in red, white, and blue.
+{{< accordion kicker="Slide by Slide" title="USWDS Monthly Call - Presentation Script for June 2023" icon="content_copy" >}}**Slide 1:** Hi there and welcome to the U.S. Web Design System monthly call for June 2023, home to Pride month, Fathers Day, Flag Day, Kamehameha Day, and the Summer Solstice — as well as Juneteenth, this coming Monday, with the USWDS logo in red, white, and blue.
 
 **Slide 2:** My name is Dan Williams, he/him, and I'm the USWDS product lead — and here on-screen is my avatar: dark hair, blue sweater, collared shirt. Today my physical self is wearing a blue T-shirt and a brown sweater. We're back to the 40s in the morning out here on the west coast! I'd like to mention that when we introduce ourselves in these calls, you'll hear things like self-descriptions and pronouns — these help everyone share the same context and know a bit more about who we are, whether or not you can see us.
 


### PR DESCRIPTION
## Summary

The Monthly Call page for June links to the June slides, but the link text says May. I updated from 'May' to 'June'

### Preview

[Link to Preview]()

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

1. Check that the link now says "May" and that no other formatting was affected

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
