### PR TITLE
Add fresh featured resources to homepage

### DIFF
--- a/content/resources/21st-century-integrated-digital-experience-act.md
+++ b/content/resources/21st-century-integrated-digital-experience-act.md
@@ -24,7 +24,7 @@ authors:
 # 0 -- hidden
 # 1 -- visible
 # 2 -- highlighted
-weight: 1
+weight: 10
 
 # primary Image (for social media)
 primary_image: "21st-century-idea-resource-card"

--- a/content/resources/an-introduction-github.md
+++ b/content/resources/an-introduction-github.md
@@ -19,7 +19,7 @@ topics:
 # 0 -- hidden
 # 1 -- visible
 # 2 -- highlighted
-weight: 1
+weight: 6
 # Make it better ♥
 ---
 

--- a/content/resources/an-introduction-to-pronouns.md
+++ b/content/resources/an-introduction-to-pronouns.md
@@ -19,7 +19,7 @@ primary_image: "people-hold-pronoun-signs-ekaterina-tveitan-getty-images-1395383
 # 0 -- hidden
 # 1 -- visible
 # 2 -- highlighted
-weight: 1
+weight: 5
 
 ---
 

--- a/content/resources/checklist-of-requirements-for-federal-digital-services.md
+++ b/content/resources/checklist-of-requirements-for-federal-digital-services.md
@@ -11,7 +11,7 @@ aliases:
   - /resources/dot-gov-domain-freeze-and-waivers/
   - /resources/checklist/
   - /resources/policies-for-federal-agency-public-websites-m-05-04/
-weight: 5
+weight: 9
 topics:
   - product-management
   - policy

--- a/content/resources/intro-accessibility.md
+++ b/content/resources/intro-accessibility.md
@@ -25,6 +25,9 @@ primary_image: "accessibility-101-title-card"
 
 aliases:
   - /resources/intro-accessibility
+
+weight: 7
+
 # Make it better ♥
 
 ---

--- a/content/resources/required-web-content-and-links.md
+++ b/content/resources/required-web-content-and-links.md
@@ -17,7 +17,7 @@ topics:
   - cx
   - user-experience
 
-weight: 3
+weight: 8
 primary_image: "website-wireframes-ademay-istock-getty-images-plus-1235556451"
 
 ---


### PR DESCRIPTION
## Summary

This is to update the featured resources on the Digital.gov homepage. I took the resources we agreed to feature and added weights to each of them from 10... on down to 5 so that they would be weighted in order of appearance. Each commit changes one resource weight. 

### Preview

[Link to Preview]()

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

1. Check the featured content box on the home page
2. Confirm that the resources appear in this order: 
[21st Century Integrated Digital Experience Act](https://digital.gov/resources/21st-century-integrated-digital-experience-act/) 10
[Checklist of requirements for federal websites and digital services](https://digital.gov/resources/checklist-of-requirements-for-federal-digital-services/?dg) 9
[Required web content and link](https://digital.gov/resources/required-web-content-and-links/) 8
[An introduction to accessibility](https://digital.gov/resources/introduction-accessibility/) 7
[An introduction to GitHub](https://digital.gov/resources/an-introduction-github/) 6
[An introduction to pronouns](https://digital.gov/resources/an-introduction-to-pronouns/) 5
4. Check the links
5. Review formatting

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
