### PR TITLE
fix broken memo link

### DIFF
--- a/content/resources/guidance-for-agency-use-of-third-party-websites-and-applications.md
+++ b/content/resources/guidance-for-agency-use-of-third-party-websites-and-applications.md
@@ -2,7 +2,7 @@
 slug: guidance-for-agency-use-of-third-party-websites-and-applications
 date: 2015-11-23 2:48:38 -0400
 title: Guidance for Agency Use of Third-Party Websites and Applications
-summary: "This Memorandum requires Federal agencies to take specific steps to protect individual privacy whenever they use third-party websites and applications to engage with the public. View Guidance for Agency Use of Third-Party Websites and Applications   Related Links President&rsquo;s Memorandum on Transparency and Open Government Open Government Directive OMB&rsquo;s Guidance for Online Use of Web"
+summary: "This Memorandum requires Federal agencies to take specific steps to protect individual privacy whenever they use third-party websites and applications to engage with the public."
 topics:
   - policy
 authors:
@@ -11,7 +11,7 @@ authors:
 
 This Memorandum requires Federal agencies to take specific steps to protect individual privacy whenever they use third-party websites and applications to engage with the public.
 
-<a class="button" style="color: #000000" href="https://obamawhitehouse.archives.gov/sites/default/files/omb/assets/memoranda_2010/m10-23.pdf">View Guidance for Agency Use of Third-Party Websites and Applications</a>
+<a class="button" style="color: #000000" href="https://www.whitehouse.gov/wp-content/uploads/legacy_drupal_files/omb/memoranda/2010/m10-23.pdf">View Guidance for Agency Use of Third-Party Websites and Applications</a>
 
 ## Related Links
 

--- a/content/resources/guidance-for-agency-use-of-third-party-websites-and-applications.md
+++ b/content/resources/guidance-for-agency-use-of-third-party-websites-and-applications.md
@@ -11,7 +11,7 @@ authors:
 
 This Memorandum requires Federal agencies to take specific steps to protect individual privacy whenever they use third-party websites and applications to engage with the public.
 
-<a class="button" style="color: #000000" href="https://www.whitehouse.gov/sites/whitehouse.gov/files/omb/memoranda/2010/m10-23.pdf">View Guidance for Agency Use of Third-Party Websites and Applications</a>
+<a class="button" style="color: #000000" href="https://obamawhitehouse.archives.gov/sites/default/files/omb/assets/memoranda_2010/m10-23.pdf">View Guidance for Agency Use of Third-Party Websites and Applications</a>
 
 ## Related Links
 


### PR DESCRIPTION
## Summary

I updated the link to memo M-10-37. Closes [#6357].

### Preview

None, there are no visual changes on the website.

### Solution

I found a link to the M10-23 website and updated the page

### How To Test

Click the changed link and verify that the M10-23 memo is available.

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
