### PR TITLE
Remove tag from 49 pages

### DIFF
--- a/content/news/2013/05/2013-05-21-developer-kit.md
+++ b/content/news/2013/05/2013-05-21-developer-kit.md
@@ -8,7 +8,7 @@ authors:
 topics:
   - code
   - api
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 These are the elements that make up a well-rounded developer hub.

--- a/content/news/2014/03/2014-03-27-u-s-customs-and-border-protection-launches-new-mobile-friendly-website.md
+++ b/content/news/2014/03/2014-03-27-u-s-customs-and-border-protection-launches-new-mobile-friendly-website.md
@@ -9,7 +9,7 @@ topics:
   - responsive-web-design
   - thursday-mobile-products
   - US Customs and Border Protection
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 {{< legacy-img src="2014/03/CPVgov-on-smart-phone-250-x-375.jpg" alt="CPVgov-on-smart-phone-250-x-375" >}}There&#8217;s a LOT going on at **U.S. Customs and Border Protection (CBP)**, and you don&#8217;t want to miss it: Seizures of illegal drug and counterfeit cash. Arrests of human smugglers. Even the interception of imported &#8220;pests&#8221; (most recently, a new slug found in the Washington area that goes by the name of _Pallifera sp)_ by CBP agriculture specialists.

--- a/content/news/2014/04/2014-04-10-department-of-treasurys-helpwithmybank-gov-goes-responsive.md
+++ b/content/news/2014/04/2014-04-10-department-of-treasurys-helpwithmybank-gov-goes-responsive.md
@@ -9,7 +9,7 @@ topics:
   - responsive-web-design
   - thursday-mobile-products
   - us-department-of-the-treasury
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 As the rapper Notorious B.I.G. aptly noted in his hit song, &#8220;Mo Money&#8221; brings &#8220;Mo Problems.&#8221; Especially when you run up against confusing policies or questionable actions by large national banks and financial institutions.

--- a/content/news/2014/04/2014-04-17-epa-mobile-projects-update.md
+++ b/content/news/2014/04/2014-04-17-epa-mobile-projects-update.md
@@ -13,7 +13,7 @@ topics:
   - mobile-apps
   - thursday-mobile-products
   - us-environmental-protection-agency
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 {{< legacy-img src="2014/04/EPA-Mobile-website-250-x-415-4-14-14-Toni-Samsung-Galaxy-SII-SC20140414-102209.jpg" alt="Screenshot from a smart phone of the E P A dot gov mobile website" >}}Earth Day is next week, so today instead of featuring one mobile product like we do every Thursday, we&#8217;re highlighting how the [U.S. Environmental Protection Agency](http://www.epa.gov/) is tackling mobile to help empower citizen environmental decisions.

--- a/content/news/2014/05/2014-05-01-operation-predator-app-from-ice-developed-to-help-rescue-children-capture-sexual-predators.md
+++ b/content/news/2014/05/2014-05-01-operation-predator-app-from-ice-developed-to-help-rescue-children-capture-sexual-predators.md
@@ -10,7 +10,7 @@ topics:
   - thursday-mobile-products
   - us-immigration-and-customs-enforcement
   - united-states-department-of-homeland-security
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 It&#8217;s disturbing to think about, but essential for all of us to know about: The sexual abuse and exploitation of children.

--- a/content/news/2014/05/2014-05-08-cdcs-new-app-answers-the-question-can-i-eat-this.md
+++ b/content/news/2014/05/2014-05-08-cdcs-new-app-answers-the-question-can-i-eat-this.md
@@ -9,7 +9,7 @@ topics:
   - centers-for-disease-control-and-prevention
   - mobile-apps
   - thursday-mobile-products
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 I&#8217;ll be honest: When I had only heard the name of the new mobile app from the **[Centers for Disease Control and Prevention](http://www.cdc.gov/)**, I thought, &#8220;Interesting — another dieting app to add to my phone.&#8221;

--- a/content/news/2014/06/2014-06-19-dot-safercar-app-goes-android.md
+++ b/content/news/2014/06/2014-06-19-dot-safercar-app-goes-android.md
@@ -7,7 +7,7 @@ topics:
   - mobile
   - DOT
   - National Highway Traffic Safety Administration
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 {{< legacy-img src="2014/06/250-x-440-SaferCar-Android-Apps-on-Google-Play.jpg" alt="Screen capture of the Android Safer Car app on Google Play" >}}With the [start of &#8220;astronomical summer&#8221;](http://www.ncdc.noaa.gov/news/meteorological-versus-astronomical-summer) later this week on June 21, that means two things: road trips and car buying.

--- a/content/news/2014/06/2014-06-26-broadcasting-board-of-governors-relay-tool.md
+++ b/content/news/2014/06/2014-06-26-broadcasting-board-of-governors-relay-tool.md
@@ -16,7 +16,7 @@ topics:
   - multilingual
   - open-source
   - thursday-mobile-products
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 World Cup fever, everyone&#8217;s got it—even the [Broadcasting Board of Governors](http://www.bbg.gov/)&#8216; (BBG) Voice of America has reporters covering the event.

--- a/content/news/2014/07/2014-07-03-appy-fourth-of-july.md
+++ b/content/news/2014/07/2014-07-03-appy-fourth-of-july.md
@@ -12,7 +12,7 @@ topics:
   - NPS
   - thursday-mobile-products
   - us-national-park-service
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 {{< legacy-img src="2014/07/600-x-410-July-4th-Fireworks-Washington-DC-by-Carol-M-Highsmith-2007-04460a.jpg" alt="Fireworks over Washington, D.C., July 4, 2007 by Carol M. Highsmith" caption="" >}}

--- a/content/news/2014/07/2014-07-10-mobile-remm-app-new-physicians-aid.md
+++ b/content/news/2014/07/2014-07-10-mobile-remm-app-new-physicians-aid.md
@@ -22,7 +22,7 @@ topics:
   - us-environmental-protection-agency
   - us-food-and-drug-administration
   - united-states-department-of-health-and-human-services
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 {{< legacy-img-right src="2014/07/250-x-333-REMM-HHS-app.jpg" alt="A screenshot of the REMM app on a mobile device" >}}The [Department of Health and Human Service’s Mobile REMM App](http://www.remm.nlm.gov/downloadmremm.htm) provides physicians and emergency medical staff with the latest and greatest information concerning radioactive and nuclear emergencies. Available on [iOS](https://itunes.apple.com/us/app/mobile-remm-radiation-emergency/id372600451?mt=8), [Android](https://play.google.com/store/apps/details?id=gov.nih.nlm.sis.remm), and [Blackberry](http://appworld.blackberry.com/webstore/content/45722/?lang=en&countrycode=US) platforms, the native application showcases comprehensive information concerning dose estimators and resources to initiate a variety of triages on site without requiring mobile connectivity.

--- a/content/news/2014/07/2014-07-31-swim-safe-this-summer-cdc-mobile-app.md
+++ b/content/news/2014/07/2014-07-31-swim-safe-this-summer-cdc-mobile-app.md
@@ -11,7 +11,7 @@ topics:
   - national-oceanic-and-atmospheric-administration
   - NOAA
   - thursday-mobile-products
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 {{< legacy-img src="2014/07/250-x-375-CDC-HTSW-healthy-swimming-screencap.jpg" alt="Screencapture of the CDC HTSW healthy swimming app" >}}You don&#8217;t have to try too hard to get people into the water during summer. But swimming the healthy and safe way? Well, everyone could use help on that.

--- a/content/news/2014/08/2014-08-14-census-pop-quiz-mobile-app-challenges-knowledge-of-state-statistics.md
+++ b/content/news/2014/08/2014-08-14-census-pop-quiz-mobile-app-challenges-knowledge-of-state-statistics.md
@@ -11,7 +11,7 @@ topics:
   - open-data
   - thursday-mobile-products
   - united-states-census-bureau
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 [{{< legacy-img src="2014/08/520-x-293-Census-App-Pop-Quiz-home-screen-301x212.jpg" alt="Start screen of Census App Pop Quiz" >}}](https://s3.amazonaws.com/digitalgov/_legacy-img/2014/08/520-x-293-Census-App-Pop-Quiz-home-screen.jpg)The U.S. Census Bureau today released [Census PoP Quiz](https://www.census.gov/mobile/censuspopquiz/), a new interactive mobile application that challenges users’ knowledge of demographic facts for all 50 states and the District of Columbia. The new app, which draws from the Census Bureau’s American Community Survey, aims to raise statistical literacy about the U.S. population.

--- a/content/news/2014/08/2014-08-28-usda-app-helps-id-your-potpourri.md
+++ b/content/news/2014/08/2014-08-28-usda-app-helps-id-your-potpourri.md
@@ -9,7 +9,7 @@ topics:
   - mobile-apps
   - thursday-mobile-products
   - US Department of Agriculture
-  - usa-gov-federal-mobile-apps-directory
+ 
   - USDA
 ---
 

--- a/content/news/2014/09/2014-09-04-census-promotes-mobile-apps-front-and-center.md
+++ b/content/news/2014/09/2014-09-04-census-promotes-mobile-apps-front-and-center.md
@@ -14,7 +14,7 @@ topics:
   - social-media
   - thursday-mobile-products
   - united-states-census-bureau
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 {{< legacy-img src="2014/09/600-x-390-Census-overlay-Screen-Shot-2014-09-04.jpg" alt="A screen capture of Census dot gov with an overlay displaying 3 of their mobile apps." >}}

--- a/content/news/2014/09/2014-09-11-prepareathon-2014-disaster-preparedness-in-the-palm-of-your-hand.md
+++ b/content/news/2014/09/2014-09-11-prepareathon-2014-disaster-preparedness-in-the-palm-of-your-hand.md
@@ -14,7 +14,7 @@ topics:
   - NOAA
   - NWS
   - thursday-mobile-products
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 [{{< legacy-img src="2014/09/250-x-306-FEMA\_PREPARE-POSTERS\_general\_small\_v4\_RELEASE\_508.jpg" alt="FEMA ad for National Preparedness Month; National PrepareAthon! Day, September 30, 2014." >}}](https://s3.amazonaws.com/digitalgov/_legacy-img/2014/09/600-x-735-FEMA_PREPARE-POSTERS_general_small_v4_RELEASE_508.jpg)If there was one thing we learned on September 11, 2001, it&#8217;s that you can never be too prepared for a disaster of any magnitude.

--- a/content/news/2014/09/2014-09-18-cdc-app-aids-in-prevention-of-neonatal-disease.md
+++ b/content/news/2014/09/2014-09-18-cdc-app-aids-in-prevention-of-neonatal-disease.md
@@ -9,7 +9,7 @@ topics:
   - centers-for-disease-control-and-prevention
   - native-app
   - thursday-mobile-products
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 [{{< legacy-img src="2014/09/250-x-400-CDC-Prevent-Group-B-Strep-GBS-App-for-Obstetric-and-Neonatal-Providers-Android-menu.jpg" alt="CDC Prevent Group B Strep GBS App for Obstetric and Neonatal Providers Android menu" >}}](https://s3.amazonaws.com/digitalgov/_legacy-img/2014/09/510-x-817-CDC-Prevent-Group-B-Strep-GBS-App-for-Obstetric-and-Neonatal-Providers-Android-menu.jpg)The [Centers for Disease Control](http://www.cdc.gov) has added another tool to its suite of mobile applications for healthcare providers and clinicians. The &#8220;[Prevent Group B Strep](http://www.cdc.gov/groupbstrep/guidelines/prevention-app.html)&#8221; app provides specific, timely guidance to obstetric and neonatal providers to aid in the prevention of perinatal Group B Strep disease.

--- a/content/news/2014/10/2014-10-02-no-more-beta-in-congress-govs-responsive-website.md
+++ b/content/news/2014/10/2014-10-02-no-more-beta-in-congress-govs-responsive-website.md
@@ -10,7 +10,7 @@ topics:
   - mobile
   - responsive-web-design
   - thursday-mobile-products
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 [Congress.gov](https://www.congress.gov/) ushered in the new fiscal year by [removing the beta label from its URL two years after it launched.](http://blogs.gov.gov/law/2014/09/congress-gov-removing-the-beta-label-and-new-enhancements/) During this period, the Library of Congress not only extensively tested how the site would display on any device, but in a series of releases and enhancements, completely transformed the ability to find legislative information as the successor to THOMAS.

--- a/content/news/2014/10/2014-10-09-bullying-help-prevent-and-protect-anytime-anywhere-on-any-device.md
+++ b/content/news/2014/10/2014-10-09-bullying-help-prevent-and-protect-anytime-anywhere-on-any-device.md
@@ -10,7 +10,7 @@ topics:
   - native-app
   - SAMHSA
   - thursday-mobile-products
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 [{{< legacy-img src="2014/10/600-x-400-Stop-Bullying-2014-what-you-need-to-know-full-cropped-infographic.jpg" alt="2014 infographic for: Bullying: What You Need to Know. Click for full image." caption="" >}}](https://s3.amazonaws.com/digitalgov/_legacy-img/2014/10/691-x-2200-Stop-Bullying-2014-what-you-need-to-know-full-infographic.jpg) 

--- a/content/news/2014/10/2014-10-29-open-and-api-driven-federal-mobile-app-registration.md
+++ b/content/news/2014/10/2014-10-29-open-and-api-driven-federal-mobile-app-registration.md
@@ -18,7 +18,7 @@ topics:
   - native-apps
   - open-data
   - thursday-mobile-products
-  - usa-gov-federal-mobile-apps-directory
+ 
 
 ---
 

--- a/content/news/2014/11/2014-11-06-rail-crossing-locator-app-now-available-on-a-second-platform.md
+++ b/content/news/2014/11/2014-11-06-rail-crossing-locator-app-now-available-on-a-second-platform.md
@@ -13,7 +13,7 @@ topics:
   - thursday-mobile-products
   - us-immigration-and-customs-enforcement
   - united-states-department-of-transportation
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 [{{< legacy-img src="2014/11/250-x-400-FRA-DOT-Rail-Crossing-Locator-Android-app.jpg" alt="250-x-400-FRA-DOT-Rail-Crossing-Locator-Android-app" >}}](https://s3.amazonaws.com/digitalgov/_legacy-img/2014/11/527-x-845-FRA-DOT-Rail-Crossing-Locator-Android-app.jpg)You don’t need to be a rail buff to want to download the [Federal Railroad Administration Rail Crossing Locator app]({{< ref "2014-01-23-rail-crossing-locator-app-from-dot.md" >}} "Rail Crossing Locator App from DOT"). Parents, outdoor enthusiasts, emergency responders, school officials, motorists and many others will find value in locating area highway-rail crossings. The aim of the app is public safety and the Department of Transportation (DOT) recently added an Android version of the app.

--- a/content/news/2015/01/2015-01-29-be-a-citizen-scientist-with-noaas-crowdmag-app.md
+++ b/content/news/2015/01/2015-01-29-be-a-citizen-scientist-with-noaas-crowdmag-app.md
@@ -11,7 +11,7 @@ topics:
   - mobile-apps
   - national-oceanic-and-atmospheric-administration
   - NOAA
-  - usa-gov-federal-mobile-apps-directory
+ 
 
 ---
 

--- a/content/news/2015/02/2015-02-05-focus-on-nutrition-with-dri-calculator-for-healthcare-professionals-app.md
+++ b/content/news/2015/02/2015-02-05-focus-on-nutrition-with-dri-calculator-for-healthcare-professionals-app.md
@@ -13,7 +13,7 @@ topics:
   - thursday-mobile-products
   - US Department of Agriculture
   - us-immigration-and-customs-enforcement
-  - usa-gov-federal-mobile-apps-directory
+ 
   - USDA
 ---
 

--- a/content/news/2015/02/2015-02-19-irs2go-app-provides-multi-symptom-relief-for-tax-anxiety.md
+++ b/content/news/2015/02/2015-02-19-irs2go-app-provides-multi-symptom-relief-for-tax-anxiety.md
@@ -15,7 +15,7 @@ topics:
   - native-app
   - thursday-mobile-products
   - us-immigration-and-customs-enforcement
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 {{< legacy-img src="2015/02/250-x-385-IRS2Go\_phone\_2.jpg" alt="New IRS2Go app design" >}}The digital equivalent of a cool rag and a spoonful of Pepto Bismol, the Internal Revenue Service updated their [IRS2Go app](http://www.irs.gov/uac/IRS2GoApp) to provide multi-symptom relief for tax anxiety this year.

--- a/content/news/2015/02/2015-02-26-keep-a-strong-job-search-game-with-usa-govs-federal-mobile-apps-directory.md
+++ b/content/news/2015/02/2015-02-26-keep-a-strong-job-search-game-with-usa-govs-federal-mobile-apps-directory.md
@@ -12,7 +12,7 @@ topics:
   - thursday-mobile-products
   - us-department-of-justice
   - us-department-of-state
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 {{< legacy-img src="2015/02/250-x-410-IRSgov-mobile-jobs-site-How-to-Apply.jpg" alt="IRSgov's mobile jobs site How to Apply page." >}}Scoping the fed scene for the best match to apply your very formidable skillset? Use your smartphone to cast a wider net on your job search with help from the [USA.gov Federal Mobile Apps Directory](http://www.usa.gov/mobileapps.shtml).

--- a/content/news/2015/03/2015-03-05-explore-iconic-overseas-world-war-ii-sites-with-abmc-apps.md
+++ b/content/news/2015/03/2015-03-05-explore-iconic-overseas-world-war-ii-sites-with-abmc-apps.md
@@ -13,7 +13,7 @@ topics:
   - american-battle-monuments-commission
   - mobile-apps
   - thursday-mobile-products
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 <div class="testimonial small">

--- a/content/news/2015/03/2015-03-19-drugshortages-app-accelerates-public-access-to-drug-shortage-information.md
+++ b/content/news/2015/03/2015-03-19-drugshortages-app-accelerates-public-access-to-drug-shortage-information.md
@@ -11,7 +11,7 @@ topics:
   - mobile
   - thursday-mobile-products
   - us-food-and-drug-administration
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 {{< legacy-img src="2015/03/250-x-444-FDA-Drug-Shortages-Apple-app-alphabetical-list-of-current-shortages.jpg" alt="250 x 444-FDA-Drug-Shortages-Apple-app-alphabetical-list-of-current-shortages" >}}The U.S. Food and Drug Administration&#8217;s new &#8220;DrugShortages&#8221; app gives the public access to important—and sometimes critical—drug shortage information easier and faster than ever before.

--- a/content/news/2015/03/2015-03-26-booking-a-discount-bus-ticket-check-carrier-safety-records-with-qcmobile.md
+++ b/content/news/2015/03/2015-03-26-booking-a-discount-bus-ticket-check-carrier-safety-records-with-qcmobile.md
@@ -12,7 +12,7 @@ topics:
   - mobile-apps
   - thursday-mobile-products
   - united-states-department-of-transportation
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 The new app from the Department of Transportation’s Federal Motor Carrier Safety Administration called “QCMobile” empowers U.S. motorists to make safety their highest priority on the roadways this spring. This is a continued theme in DOT&#8217;s mobile strategy, as they have also recently released the [SaferRide app]({{< ref "2015-01-22-saferride-app-could-save-your-life.md" >}}).

--- a/content/news/2015/04/2015-04-09-new-usgs-app-helps-save-the-piping-plovers.md
+++ b/content/news/2015/04/2015-04-09-new-usgs-app-helps-save-the-piping-plovers.md
@@ -13,7 +13,7 @@ topics:
   - native-app
   - thursday-mobile-products
   - united-states-geological-survey
-  - usa-gov-federal-mobile-apps-directory
+ 
   - USGS
 ---
 

--- a/content/news/2015/04/2015-04-23-checking-in-on-the-dod-mobile-apps-gallery.md
+++ b/content/news/2015/04/2015-04-23-checking-in-on-the-dod-mobile-apps-gallery.md
@@ -10,7 +10,7 @@ topics:
   - DoD
   - thursday-mobile-products
   - united-states-department-of-defense
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 {{< legacy-img src="2015/04/600-x-338-Screen-capture-of-a-design-schematic-from-the-Make-It-Fly-create-your-own-Air-Force-planes-Android-app.jpg" alt="Screen capture of a design schematic from Make It Fly: create your own Air Force planes Android app." >}}

--- a/content/news/2015/05/2015-05-14-from-startup-to-veteran-ceo-new-businessusa-app-has-you-covered.md
+++ b/content/news/2015/05/2015-05-14-from-startup-to-veteran-ceo-new-businessusa-app-has-you-covered.md
@@ -12,7 +12,7 @@ topics:
   - SBA
   - thursday-mobile-products
   - us-small-business-administration
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 [{{< legacy-img src="2015/05/250-x-429-BusinessUSA-menu-screen-Google-Play-for-Android.jpg" alt="Business U.S.A. menu screen" >}}BusinessUSA](http://business.usa.gov) is a centralized, one-stop platform to make it easy for businesses to access services to help them grow and hire. And with the release of a brand new smartphone app for [Android](https://play.google.com/store/apps/details?id=com.BusinessUSA.BusinessUSA) and [iOS](https://itunes.apple.com/us/app/businessusa/id905514958?mt=8) devices, BusinessUSA is fully functional no matter whether you visit by desktop, tablet or smartphone.

--- a/content/news/2015/05/2015-05-21-start-sleuthing-with-the-great-federal-mobile-product-hunt.md
+++ b/content/news/2015/05/2015-05-21-start-sleuthing-with-the-great-federal-mobile-product-hunt.md
@@ -14,7 +14,7 @@ topics:
   - mobile-gov-community-of-practice
   - mobile-friendly
   - thursday-mobile-products
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 {{< legacy-img src="2015/05/600-x-211-MobileGov-Shared-Tweet-Photo.jpg" alt="The Digital Gov Hunters of the Lost Apps Twitter promo graphic, inviting users to Join the Hunt and use the Lost Apps hashtag." caption="" >}} 

--- a/content/news/2015/05/2015-05-28-ice-wields-smartphones-in-fight-against-child-exploitation.md
+++ b/content/news/2015/05/2015-05-28-ice-wields-smartphones-in-fight-against-child-exploitation.md
@@ -16,7 +16,7 @@ topics:
   - thursday-mobile-products
   - Twitter
   - us-immigration-and-customs-enforcement
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 [{{< legacy-img src="2015/05/250-x-444-ICE-operation-predator-Android-app-Arrests-page.jpg" alt="Operation Predator Arrests page as seen on the Android app." >}}](https://s3.amazonaws.com/digitalgov/_legacy-img/2015/05/540-x-960-ICE-operation-predator-Android-app-Arrests-page.jpg)Armed with a smartphone instead of a badge, ordinary Americans are helping law enforcement officers capture child predators.

--- a/content/news/2015/06/2015-06-04-new-coast-guard-app-streamlines-boating-safety-to-maximize-summer-fun.md
+++ b/content/news/2015/06/2015-06-04-new-coast-guard-app-streamlines-boating-safety-to-maximize-summer-fun.md
@@ -13,7 +13,7 @@ topics:
   - native-app
   - thursday-mobile-products
   - us-coast-guard
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 {{< legacy-img src="2015/06/250-x-444-DHS-US-Coast-Guard-android-main-menu.jpg" alt="DHS US Coast Guard Android app main menu" >}}Just in time for the summer season, the U.S. Coast Guard launched a brand new app to give smartphone users easy, on-demand access to critical boating safety information and resources.

--- a/content/news/2015/06/2015-06-11-when-catastrophe-strikes-provide-support-samhsas-disaster-response-app.md
+++ b/content/news/2015/06/2015-06-11-when-catastrophe-strikes-provide-support-samhsas-disaster-response-app.md
@@ -11,7 +11,7 @@ topics:
   - SAMHSA
   - thursday-mobile-products
   - united-states-department-of-health-and-human-services
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 {{< legacy-img src="2015/06/600-x-325-SAMHSA-Behavioral-Health-Disaster-Response-Mobile-App-YouTube-screen-capture-FEMA-Corps.jpg" alt="600-x-325-SAMHSA-Behavioral-Health-Disaster-Response-Mobile-App-YouTube-screen-capture-FEMA-Corps" >}}

--- a/content/news/2015/06/2015-06-25-using-apps-for-mental-healthcare.md
+++ b/content/news/2015/06/2015-06-25-using-apps-for-mental-healthcare.md
@@ -15,7 +15,7 @@ topics:
   - native-app
   - thursday-mobile-products
   - united-states-department-of-defense
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 {{< legacy-img src="2015/06/250-x-417-T2-National-Center-for-Telehealth-and-Technology-PTSD-Coach-Android-app-Department-of-Veterans-Affairs.jpg" alt="PTSD Coach Android app menu screen" >}}Technology has opened new pathways for delivering health care, including mental health services.

--- a/content/news/2015/07/2015-07-02-celebrating-american-history-with-federal-apps.md
+++ b/content/news/2015/07/2015-07-02-celebrating-american-history-with-federal-apps.md
@@ -16,7 +16,7 @@ topics:
   - native-apps
   - smithsonian-institution
   - thursday-mobile-products
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 {{< legacy-img src="2015/06/600-x-400-Cake-with-American-flag-frosting-and-sparkling-candles-Jupiterimages-liquidlibrary-Thinkstock-87648597.jpg" alt="Cake with American flag frosting and sparkling candles" caption="" >}} 

--- a/content/news/2015/07/2015-07-09-day-50-the-great-federal-mobile-product-hunt.md
+++ b/content/news/2015/07/2015-07-09-day-50-the-great-federal-mobile-product-hunt.md
@@ -17,7 +17,7 @@ topics:
   - us-coast-guard
   - us-department-of-veterans-affairs
   - us-small-business-administration
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 {{< legacy-img src="2015/07/600-x-200-Day-50.jpg" alt="Day 50 banner" >}}{{< legacy-img src="2015/07/600-x-200-Tally-Graphic.jpg" alt="Leaderboard Tally" >}}

--- a/content/news/2015/07/2015-07-15-safe-travels-with-travwell.md
+++ b/content/news/2015/07/2015-07-15-safe-travels-with-travwell.md
@@ -12,7 +12,7 @@ topics:
   - ios
   - mobile-apps
   - thursday-mobile-products
-  - usa-gov-federal-mobile-apps-directory
+ 
 
 ---
 

--- a/content/news/2015/07/2015-07-30-usgs-is-asking-if-you-felt-it-latest-earthquakes.md
+++ b/content/news/2015/07/2015-07-30-usgs-is-asking-if-you-felt-it-latest-earthquakes.md
@@ -14,7 +14,7 @@ topics:
   - the-united-states-social-security-administration
   - thursday-mobile-products
   - united-states-geological-survey
-  - usa-gov-federal-mobile-apps-directory
+ 
   - USGS
 ---
 

--- a/content/news/2015/08/2015-08-06-usda-puts-hunger-on-vacation-this-summer.md
+++ b/content/news/2015/08/2015-08-06-usda-puts-hunger-on-vacation-this-summer.md
@@ -7,7 +7,7 @@ topics:
   - mobile
   - api
   - thursday-mobile-products
-  - usa-gov-federal-mobile-apps-directory
+ 
   - USDA
 ---
 

--- a/content/news/2015/08/2015-08-20-three-new-mobile-apps-honor-fallen-veterans-overseas.md
+++ b/content/news/2015/08/2015-08-20-three-new-mobile-apps-honor-fallen-veterans-overseas.md
@@ -10,7 +10,7 @@ topics:
   - mobile-apps
   - native-apps
   - thursday-mobile-products
-  - usa-gov-federal-mobile-apps-directory
+ 
 
 ---
 

--- a/content/news/2015/09/2015-09-03-congress-creates-the-bill-of-rights-from-national-archives.md
+++ b/content/news/2015/09/2015-09-03-congress-creates-the-bill-of-rights-from-national-archives.md
@@ -11,7 +11,7 @@ topics:
   - NARA
   - national-archives-and-records-administration
   - thursday-mobile-products
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 {{< legacy-img src="2015/08/480-x-351-NARA-Congress-Creates-the-Bill-of-Rights-app-Constitutional-Amendment.jpg" alt="The NARA app, Congress Creates the Bill of Rights, showing a Constitutional amendment screen on an iPad" >}}

--- a/content/news/2015/09/2015-09-10-day-100-the-great-federal-mobile-product-hunt.md
+++ b/content/news/2015/09/2015-09-10-day-100-the-great-federal-mobile-product-hunt.md
@@ -16,7 +16,7 @@ topics:
   - thursday-mobile-products
   - us-department-of-veterans-affairs
   - united-states-department-of-health-and-human-services
-  - usa-gov-federal-mobile-apps-directory
+ 
   - VA
 ---
 

--- a/content/news/2015/09/2015-09-24-track-time-and-wages-with-labors-timesheet-app.md
+++ b/content/news/2015/09/2015-09-24-track-time-and-wages-with-labors-timesheet-app.md
@@ -10,7 +10,7 @@ topics:
   - mobile-apps
   - native-apps
   - thursday-mobile-products
-  - usa-gov-federal-mobile-apps-directory
+ 
 
 ---
 

--- a/content/news/2015/10/2015-10-21-the-data-briefing-300-mobile-moments.md
+++ b/content/news/2015/10/2015-10-21-the-data-briefing-300-mobile-moments.md
@@ -11,7 +11,7 @@ topics:
   - data
   - mobile
   - the-data-briefing
-  - usa-gov-federal-mobile-apps-directory
+ 
 
 ---
 

--- a/content/news/2015/10/2015-10-26-texting-is-another-way-to-make-mobile-moments.md
+++ b/content/news/2015/10/2015-10-26-texting-is-another-way-to-make-mobile-moments.md
@@ -15,7 +15,7 @@ topics:
   - national-cancer-institute
   - NCI
   - responsive-web-design
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 {{< legacy-img src="2015/10/600-x-450-Modern-conversation-social-network-community-logo-icon-maximillion_studio-iStock-Thinkstock-485896583.jpg" alt="Modern conversation social network community logo icon" caption="" >}} 

--- a/content/news/2016/02/2016-02-29-is-your-federal-mobile-app-or-website-in-the-us-digital-registry.md
+++ b/content/news/2016/02/2016-02-29-is-your-federal-mobile-app-or-website-in-the-us-digital-registry.md
@@ -16,7 +16,7 @@ topics:
   - mobile-gov
   - social-media
   - us-digital-registry
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 We have received an amazing response to the [U.S. Digital Registry]({{< ref "service_us-digital-registry.md" >}}), our new API-generating repository for official third-party sites, social media platforms and mobile apps in the United States federal government.

--- a/content/news/2016/03/2016-03-10-check-your-refund-status-and-pay-your-taxes-with-irs2go.md
+++ b/content/news/2016/03/2016-03-10-check-your-refund-status-and-pay-your-taxes-with-irs2go.md
@@ -13,7 +13,7 @@ topics:
   - mobile-apps
   - thursday-mobile-products
   - us-digital-registry
-  - usa-gov-federal-mobile-apps-directory
+ 
 primary_image: irs2go-google-play-logo-1200
 
 ---

--- a/content/news/2016/09/2016-09-12-the-content-corner-using-social-media-to-promote-enhance-preparedness-for-the-public-we-serve.md
+++ b/content/news/2016/09/2016-09-12-the-content-corner-using-social-media-to-promote-enhance-preparedness-for-the-public-we-serve.md
@@ -25,7 +25,7 @@ topics:
   - social-media
   - the-content-corner
   - us-digital-registry
-  - usa-gov-federal-mobile-apps-directory
+ 
 ---
 
 _September is National Preparedness Month. FEMA&#8217;s [Ready.gov](https://www.ready.gov/) is encouraging everyone to plan how they would stay safe and communicate during disasters that can affect their communities. Additionally, Ready.gov is encouraging full participation in [America’s PrepareAthon!](https://community.fema.gov/) and the national day of action, National PrepareAthon! Day, which culminates National Preparedness Month on September 30._


### PR DESCRIPTION
This topic tag is no longer in use. 

## Summary

Closes [#issue_no].

### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/remove-usagov-app-directory-tag/2016/02/29/is-your-federal-mobile-app-or-website-in-the-us-digital-registry/)

⚠️ Significant visual changes require submitting previous design to wayback machine.

### Solution

1. Remove it from front matter in pages to remove tag from list on Topics page.
2. Saved its 3 pages to the Internet Archive/Wayback Machine before merging:

https://digital.gov/topics/usa-gov-federal-mobile-apps-directory/
https://digital.gov/topics/usa-gov-federal-mobile-apps-directory/page/2/
https://digital.gov/topics/usa-gov-federal-mobile-apps-directory/page/3/

### How To Test

1. topic tag no longer in topics list on individual content pages; example: https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/remove-usagov-app-directory-tag/2016/02/29/is-your-federal-mobile-app-or-website-in-the-us-digital-registry/ 
2. Topic is no longer listed on main Topics page https://digital.gov/topics/ (not available in Preview)

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
