### PR TITLE
Fixed hugo logic to keep proper whitespace between class names

### DIFF
--- a/themes/digital.gov/layouts/shortcodes/note.html
+++ b/themes/digital.gov/layouts/shortcodes/note.html
@@ -38,7 +38,7 @@ Comment —
 
 */}}
 
-<div class="note {{- if .Get 0 -}}{{- .Get 0 -}}{{- end -}}">
+<div class="note {{ if .Get 0 }}{{- .Get 0 -}}{{ end }}">
   {{- if and (.Get 0) (eq (.Get 0) "activity") -}}
     <h4>
       <svg


### PR DESCRIPTION
## Summary
`<div class="note {{ if .Get 0 }}{{- .Get 0 -}}{{ end }}">` will keep whitespace between both class names. Using hypens in the `if` statement will remove the whitespace and combine `notegroup`. 

<img width="1406" alt="Screen Shot 2023-08-14 at 1 07 52 PM" src="https://github.com/GSA/digitalgov.gov/assets/104778659/8f6e9ea3-f728-48dd-a787-dd181879e2b0">

### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-fix-note-shortcode-classes/communities/community-guidelines/)


### Solution

Removed `-` hyphens in conditional logic to ensure proper whitespacing between for class names.

<img width="1261" alt="Screen Shot 2023-08-14 at 1 10 46 PM" src="https://github.com/GSA/digitalgov.gov/assets/104778659/aeb80e51-38ba-4dcc-86e3-a4255d408601">

### How To Test

1. Visit [communities/community-guidelines](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-fix-note-shortcode-classes/)
2. Should see proper `note` short code color and box styles.

---

### Dev Checklist

- [x] PR has correct labels
- [x] A11y testing (voice over testing, meets WCAG, run axe tools)
- [x] Code is formatted properly
