### PR TITLE
Remove tags in front matter for DIA topic

### DIFF
--- a/content/news/2014/10/2014-10-30-cyber-house-of-horrors.md
+++ b/content/news/2014/10/2014-10-30-cyber-house-of-horrors.md
@@ -7,8 +7,6 @@ authors:
   - jordan-higgins
 topics:
   - social-media
-  - Defense Intelligence Agency
-  - DIA
   - internet-of-things
   - security
 ---

--- a/content/news/2014/10/2014-10-31-whats-happening-with-the-internet-of-things.md
+++ b/content/news/2014/10/2014-10-31-whats-happening-with-the-internet-of-things.md
@@ -10,8 +10,6 @@ topics:
   - mobile
   - monthly-theme
   - our-work
-  - Defense Intelligence Agency
-  - DIA
   - DOT
   - Federal Trade Commission
   - FTC

--- a/content/news/2014/12/2014-12-23-trends-on-tuesday-half-of-online-americans-dont-know-what-a-privacy-policy-is.md
+++ b/content/news/2014/12/2014-12-23-trends-on-tuesday-half-of-online-americans-dont-know-what-a-privacy-policy-is.md
@@ -8,8 +8,6 @@ authors:
 topics:
   - product-management
   - mobile
-  - Defense Intelligence Agency
-  - DIA
   - digitalgov-summit
   - Federal Trade Commission
   - FTC


### PR DESCRIPTION
In order to remove an old topic from the main Topics page https://digital.gov/topics/, we need to first remove the topic code from the front matter in each individual content page.

## Summary

The Topic page for DIA (Defense Intelligence Agency) https://digital.gov/topics/dia/ has 3 blogs that have the DIA tag:

https://digital.gov/2014/12/23/trends-on-tuesday-half-of-online-americans-dont-know-what-a-privacy-policy-is/ 
https://digital.gov/2014/10/31/whats-happening-with-the-internet-of-things/ 
https://digital.gov/2014/10/30/cyber-house-of-horrors/ 

1. Used mass search in a code editor to find and remove the `- DIA` line from the front matter code for each.
2. Save edits in a new branch in GitHub Desktop app, and publish to launch the create Pull Request page.
3. Create Pull Request (not a draft)
4. Add all live pages (DIA topic page, and the 3 blogs) to the [Wayback Machine/Internet Archive](https://web.archive.org/save)  
5. Merge the Pull Request

### Previews

- https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/remove-dia-topic-tags/2014/12/23/trends-on-tuesday-half-of-online-americans-dont-know-what-a-privacy-policy-is/ 
- https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/remove-dia-topic-tags/2014/10/31/whats-happening-with-the-internet-of-things/ 
- https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/remove-dia-topic-tags/2014/10/30/cyber-house-of-horrors/ 

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

1. Review each page in preview
2. See that `DIA` is no longer in the topic tags list

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
