### PR TITLE
Update link on policies.md

### DIFF
--- a/content/about/policies.md
+++ b/content/about/policies.md
@@ -22,7 +22,7 @@ The U.S. General Services Administration (GSA) will not share or sell any of you
 
 DigitalGov uses single-session cookies to serve technical purposes, like providing seamless navigation through the platform. These cookies do not permanently record data, and they are not stored on your computer&#8217;s hard drive. DigitalGov&#8217;s session cookies are only available during an active browser session. When you close your browser, the session cookie disappears.
 
-DigitalGov also uses multi-session cookies to help us understand how people use the platform, and how we can make it better. We use Google Analytics Web analytics software. We do not collect any personally identifiable information (PII). Traffic statistics are collected anonymously and aggregated, and no information is traceable to any specific individual. [You can change the setting of your browser to block cookies by following these instructions](http://www.usa.gov/optout-instructions.shtml).
+DigitalGov also uses multi-session cookies to help us understand how people use the platform, and how we can make it better. We use Google Analytics Web analytics software. We do not collect any personally identifiable information (PII). Traffic statistics are collected anonymously and aggregated, and no information is traceable to any specific individual. [You can change the setting of your browser to block cookies by following these instructions](https://www.usa.gov/optout-instructions).
 
 ## Linking Policy and Endorsement
 


### PR DESCRIPTION
## Summary

Update 2nd link at the end of https://digital.gov/policies/#privacy 

"[You can change the setting of your browser to block cookies by following these instructions](http://www.usa.gov/optout-instructions.shtml)."

Original URL 
`http://www.usa.gov/optout-instructions.shtml` 
does not redirect to its new one 
`http://www.usa.gov/optout-instructions`.  

### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nick-mon1-patch-1/policies/#privacy)

