### PR TITLE
Fix Guide Menu Bar Safari Bug

### DIFF
--- a/themes/digital.gov/src/scss/new/guides/_guide-menu-bar.scss
+++ b/themes/digital.gov/src/scss/new/guides/_guide-menu-bar.scss
@@ -73,6 +73,8 @@
 
     &-icon {
       margin-left: units(1);
+      // Set width explicitly for proper rendering on Safari browsers
+      width: units(5);
     }
   }
 }


### PR DESCRIPTION
## Summary

Found a small bug where the glossary icon does not display properly unless its width is set explicitly on Safari browsers :) 

### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/jtm-fix-safari-display-bug/guides/hcd/)

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

#### Before
![Screenshot 2023-08-29 at 2 37 55 PM](https://github.com/GSA/digitalgov.gov/assets/56370370/93123371-9dc9-41e2-9b27-6b089b53979f)

#### After
![Screenshot 2023-08-29 at 2 38 19 PM](https://github.com/GSA/digitalgov.gov/assets/56370370/74e6791c-0f6b-4e5f-97a3-1cc72299d20e)

### How To Test

1. Visit HCD guide pages on Safari browser
2. Ensure no regressions in mobile or desktop view

---

### Dev Checklist

- [x] PR has correct labels
- [x] A11y testing (voice over testing, meets WCAG, run axe tools)
- [x] Code is formatted properly
