### PR TITLE
set addthis TOS to inactive

### DIFF
--- a/config/gulp/file-prep.js
+++ b/config/gulp/file-prep.js
@@ -248,7 +248,7 @@ function imageData(format, uid, dimensions) {
   format   :  ${format}
   credit   :  
   caption  :  
-  alt      :
+  alt      :  
   `;
 }
 

--- a/data/termsofservice.yml
+++ b/data/termsofservice.yml
@@ -23,7 +23,7 @@ termsofservice:
 
   - name          : "AddThis"
     url           : 'http://www.addthis.com/'
-    description   : 'Bookmarking & sharing'
+    description   : 'Bookmarking & sharing. Closed down May 31, 2023.'
     uri           : '2014/07/addthis-updated-tos-amendment.pdf'
     type          : 'PDF'
     updated       : 07-2014

--- a/data/termsofservice.yml
+++ b/data/termsofservice.yml
@@ -27,7 +27,7 @@ termsofservice:
     uri           : '2014/07/addthis-updated-tos-amendment.pdf'
     type          : 'PDF'
     updated       : 07-2014
-    status        :
+    status        : inactive
 
   - name          : 'Asana'
     url           : 'https://www.asana.com/'


### PR DESCRIPTION
set addthis TOS to inactive

## Summary

Basic description of work done. Closes [#issue_no].

### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/set-addthis-TOS-to-inactive/resources/negotiated-terms-of-service-agreements/)

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

1. item is now located in Inactive list


---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
