### PR TITLE
remove evergreen tree emoji

### DIFF
--- a/content/resources/_index.md
+++ b/content/resources/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Guides and Resources"
-deck: ":evergreen_tree: Essential ‘how-to’ guidance for product managers in government."
+deck: "Essential ‘how-to’ guidance for product managers in government."
 summary: "Essential ‘how-to’ guidance from across government product managers in government."
 aliases:
   - /tools/


### PR DESCRIPTION
Proposing we remove this emoji until we can proactively decide in a style guide whether this fits in with our tone & style. Additionally, some of the resources are not evergreen, as indicated by the "out of date" banner when a resource is older.

## Summary

Removed 🌲 emoji at the start of the resources page.

### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/bc-remove-evergreen-emoji/resources/)

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

1. Review that the emoji is gone 
2. Confirm that the rest of the heading still aligns properly

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
