### PR TITLE
Updated weight sorting logic for topics and resources collection component

### DIFF
--- a/themes/digital.gov/layouts/partials/core/topics/topics-standard.html
+++ b/themes/digital.gov/layouts/partials/core/topics/topics-standard.html
@@ -30,6 +30,7 @@
 
       {{/* Gets the resource .Pages associated with this topic */}}
       {{- $resources := (where .Pages "Section" "resources") -}}
+      {{- $resources = (sort $resources "Weight" "desc") -}}
       {{- $resource_settings := ( dict "header_title" (print "Resources on " .Title) "header_size" 2 "variant" "media" "list_header" 3) -}}
       {{- partial "partials/core/collection/collection.html" (dict "collection_data" $resources "settings" $resource_settings ) -}}
 

--- a/themes/digital.gov/layouts/resources/list.html
+++ b/themes/digital.gov/layouts/resources/list.html
@@ -68,6 +68,7 @@
 
                   {{/* Get all resource pages with this current taxonomy */}}
                   {{- $resources_by_topic := (where .Pages "Section" "resources") -}}
+                  {{- $resources_by_topic = (sort $resources_by_topic "Weight" "desc") -}}
 
                   {{/* If there are resources... */}}
                   {{- if $resources_by_topic -}}


### PR DESCRIPTION
## Summary
The resources and topics landing pages now displays resources from highest to lowest weight ranking instead of lowest to highest. This will maintain consistency across the site for `featured-collection` and `collection` components.

### Preview

- [Resource Page](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-update-weight-function/resources/)
- [Topic Page](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-update-weight-function/topics/)

### Solution
Hugo by default sorts from lowest to highest. Featured resources sections on the topics and resources page sort from highest to lowest. This was causing resource links used in the regular `collection` component sections to not display while displayed in the `featured-collection` component.

Using the `sort` method with `desc` will sort the list of collection resources to be consistent with the featured resource sections.

```
(sort $resources "Weight" "desc") -}}
```

### How To Test

1. Visit the [resources](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-update-weight-function/topics/21st-century-idea/) or [topics](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-update-weight-function/topics/21st-century-idea/) landing page
2. Links are displayed from highest to lowest for both featured collections and regular collection components


### What To Test

- [ ] collection links are sorted highest to lowest, same as featured collection lists 

---

### Dev Checklist

- [x] PR has correct labels
- [x] A11y testing (voice over testing, meets WCAG, run axe tools)
- [x] Code is formatted properly
