### PR TITLE
Replaced kicker with a link to go back to main hcd guides landing page

### DIFF
--- a/themes/digital.gov/layouts/partials/core/guides/guide-header.html
+++ b/themes/digital.gov/layouts/partials/core/guides/guide-header.html
@@ -10,7 +10,9 @@
 
 <header class="dg-guide__header grid-container grid-container-desktop">
   <div class="dg-guide__header-title">
-    <p class="kicker">{{- $kicker | markdownify -}}</p>
+    <a href="{{ "/guides/hcd" | relURL }}" class="usa-link kicker"
+      >{{- $kicker | markdownify -}}</a
+    >
     <h1>{{- $title | markdownify -}}</h1>
     <div class="deck">
       {{- $summary | markdownify -}}


### PR DESCRIPTION
## Summary

Adds link back to the HCD Guide page to make it easier for readers to go back to the guide homepage.
This was a request from users to find the home page faster.

### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-add-hcd-back-link/guides/hcd/introduction/)


### Solution

**Before**
<img width="1083" alt="Screen Shot 2023-10-04 at 5 13 13 PM" src="https://github.com/GSA/digitalgov.gov/assets/104778659/9e407136-06ea-4587-837c-8d98383f52a8">

**After**
<img width="1050" alt="Screen Shot 2023-10-04 at 5 31 07 PM" src="https://github.com/GSA/digitalgov.gov/assets/104778659/a221d57e-bce0-4e73-8e05-7e7261cc03e4">




### How To Test

1. Visit [HCD Guides](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-add-hcd-back-link/guides/hcd/) 
2. Visit any Featured Resources sub-guides
2. "HCD Guide Series" above the page header links to back HCD Guide homepage

### What to Test

- "HCD Guide Series" is a link and jumps back to HCD guide homepage



| hcd guides                                                                                                                                                          |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| [Introduction to human-centered design](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-add-hcd-back-link/guides/hcd/introduction/) |
| [Discovery concepts guide](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-add-hcd-back-link/guides/hcd/discovery-concepts/) |
| [Discovery operations guide](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-add-hcd-back-link/guides/hcd/discovery-operations/) |
| [Design concepts guide](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-add-hcd-back-link/guides/hcd/design-concepts/) |
| [Design operations guide](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-add-hcd-back-link/guides/hcd/design-operations/) |                                                                                                                                                                |




---

### Dev Checklist

- [x] PR has correct labels
- [x] A11y testing (voice over testing, meets WCAG, run axe tools)
- [x] Code is formatted properly
