### PR TITLE
Add back button to HCD guide page

### DIFF
--- a/data/guidenav/hcd-design-concepts.yml
+++ b/data/guidenav/hcd-design-concepts.yml
@@ -1,6 +1,7 @@
 showNextPrevious: true
 showReadTime: true
 showInPageNav: true
+landingURL: "/guides/hcd"
 nav:
   - title: "Overview"
     path: "/guides/hcd/design-concepts/_index.md"

--- a/data/guidenav/hcd-design-operations.yml
+++ b/data/guidenav/hcd-design-operations.yml
@@ -1,6 +1,7 @@
 showNextPrevious: true
 showReadTime: true
 showInPageNav: true
+landingURL: "/guides/hcd"
 nav:
   - title: "Overview"
     path: "/guides/hcd/design-operations/_index.md"

--- a/data/guidenav/hcd-discovery-concepts.yml
+++ b/data/guidenav/hcd-discovery-concepts.yml
@@ -1,6 +1,7 @@
 showNextPrevious: true
 showReadTime: true
 showInPageNav: true
+landingURL: "/guides/hcd"
 nav:
   - title: "Overview"
     path: "/guides/hcd/discovery-concepts/_index.md"

--- a/data/guidenav/hcd-discovery-operations.yml
+++ b/data/guidenav/hcd-discovery-operations.yml
@@ -1,6 +1,7 @@
 showNextPrevious: true
 showReadTime: true
 showInPageNav: true
+landingURL: "/guides/hcd"
 nav:
   - title: "Overview"
     path: "/guides/hcd/discovery-operations/_index.md"

--- a/data/guidenav/hcd-introduction.yml
+++ b/data/guidenav/hcd-introduction.yml
@@ -1,6 +1,7 @@
 showNextPrevious: true
 showReadTime: true
 showInPageNav: false
+landingURL: "/guides/hcd"
 nav:
   - title: "Overview"
     path: "/guides/hcd/introduction/_index.md"

--- a/themes/digital.gov/layouts/partials/core/guides/guide-header.html
+++ b/themes/digital.gov/layouts/partials/core/guides/guide-header.html
@@ -4,7 +4,7 @@
 {{ end }}
 {{- $title := cond .IsNode .Title .Parent.Title -}}
 {{- $summary := cond .IsNode .Params.summary .Parent.Params.summary -}}
-{{- $kicker := cond .IsNode (cond (isset .Params "kicker") .Params.kicker "Digital.gov Guide") (cond (isset .Parent.Params "kicker") .Parent.Params.kicker "Digital.gov Guide") | markdownify -}}
+{{- $kicker := cond .IsNode (cond (isset .Params "kicker") .Params.kicker "Digital.gov Guide") (cond (isset .Parent.Params "kicker") .Parent.Params.kicker "Digital.gov Guide") -}}
 {{- $glossary := cond .IsNode .Params.glossary .Parent.Params.glossary -}}
 {{ $landingURL := $guideData.landingURL }}
 

--- a/themes/digital.gov/layouts/partials/core/guides/guide-header.html
+++ b/themes/digital.gov/layouts/partials/core/guides/guide-header.html
@@ -10,7 +10,9 @@
 
 <header class="dg-guide__header grid-container grid-container-desktop">
   <div class="dg-guide__header-title">
-    <p class="kicker">{{- $kicker | markdownify -}}</p>
+    <a class="usa-link kicker" href="/guides/hcd/?dg"
+      >{{- $kicker | markdownify -}}</a
+    >
     <h1>{{- $title | markdownify -}}</h1>
     <div class="deck">
       {{- $summary | markdownify -}}

--- a/themes/digital.gov/layouts/partials/core/guides/guide-header.html
+++ b/themes/digital.gov/layouts/partials/core/guides/guide-header.html
@@ -4,22 +4,20 @@
 {{ end }}
 {{- $title := cond .IsNode .Title .Parent.Title -}}
 {{- $summary := cond .IsNode .Params.summary .Parent.Params.summary -}}
-{{- $kicker := cond .IsNode (cond (isset .Params "kicker") .Params.kicker "Digital.gov Guide") (cond (isset .Parent.Params "kicker") .Parent.Params.kicker "Digital.gov Guide") -}}
+{{- $kicker := cond .IsNode (cond (isset .Params "kicker") .Params.kicker "Digital.gov Guide") (cond (isset .Parent.Params "kicker") .Parent.Params.kicker "Digital.gov Guide") | markdownify -}}
 {{- $glossary := cond .IsNode .Params.glossary .Parent.Params.glossary -}}
 {{ $landingURL := $guideData.landingURL }}
 
 
 <header class="dg-guide__header grid-container grid-container-desktop">
   <div class="dg-guide__header-title">
-    {{ if isset $guideData "landingURL" }}
-      <a class="usa-link kicker" href="{{ $landingURL | relURL }}"
-        >{{- $kicker | markdownify -}}</a
-      >
+    {{ if $landingURL }}
+      <a class="usa-link kicker" href="{{ $landingURL | relURL }}">
+        {{- $kicker -}}
+      </a>
     {{ else }}
-      <p class="kicker">{{- $kicker | markdownify -}}</p>
+      <p class="kicker">{{- $kicker -}}</p>
     {{ end }}
-
-
     <h1>{{- $title | markdownify -}}</h1>
     <div class="deck">
       {{- $summary | markdownify -}}

--- a/themes/digital.gov/layouts/partials/core/guides/guide-header.html
+++ b/themes/digital.gov/layouts/partials/core/guides/guide-header.html
@@ -6,13 +6,20 @@
 {{- $summary := cond .IsNode .Params.summary .Parent.Params.summary -}}
 {{- $kicker := cond .IsNode (cond (isset .Params "kicker") .Params.kicker "Digital.gov Guide") (cond (isset .Parent.Params "kicker") .Parent.Params.kicker "Digital.gov Guide") -}}
 {{- $glossary := cond .IsNode .Params.glossary .Parent.Params.glossary -}}
+{{ $landingURL := $guideData.landingURL }}
 
 
 <header class="dg-guide__header grid-container grid-container-desktop">
   <div class="dg-guide__header-title">
-    <a class="usa-link kicker" href="/guides/hcd/?dg"
-      >{{- $kicker | markdownify -}}</a
-    >
+    {{ if isset $guideData "landingURL" }}
+      <a class="usa-link kicker" href="{{ $landingURL | relURL }}"
+        >{{- $kicker | markdownify -}}</a
+      >
+    {{ else }}
+      <p class="kicker">{{- $kicker | markdownify -}}</p>
+    {{ end }}
+
+
     <h1>{{- $title | markdownify -}}</h1>
     <div class="deck">
       {{- $summary | markdownify -}}


### PR DESCRIPTION
## Summary

This Pr will update a bug/nice to have for the HCD page and guides.. it was expressed that a "go back" button was needed to allow users to go back to the landing page from any part of the guide. 

### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/cm-hcd-back-button/guides/hcd/)

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution
Update the p tag with the kicker class, turn it into a link element, and add the uswds `class="usa-link"` to keep it line with USWDS. 

The reason for changing the p tag into a link tag was to indicate to the user that the string is a link and the text inside gives context that it will take them back to the landing page for the HCD guides. 

### How To Test

1. Visit [Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/cm-hcd-back-button/guides/hcd/?dg)
2. click though the guides and check on the link `HCD GUIDE SERIES` and verify that you are taken back to the landing page for HCD (see screenshot below for reference)
3. remove the `hcd` and replace with `dap` and make sure that the kicker on that page is not linked and is just a string.

<img width="701" alt="Screenshot 2023-10-05 at 11 13 14 AM" src="https://github.com/GSA/digitalgov.gov/assets/88721460/2d83a173-0913-4e48-af2c-bacaab415bf8">


---

### Dev Checklist

- [x] PR has correct labels
- [x] A11y testing (voice over testing, meets WCAG, run axe tools)
- [x] Code is formatted properly
