### PR TITLE
Fix month for MC slides

### DIFF
--- a/content/events/2023/09/2023-09-18-uswds-monthly-call-september-2023.md
+++ b/content/events/2023/09/2023-09-18-uswds-monthly-call-september-2023.md
@@ -26,7 +26,7 @@ primary_image: 2023-uswds-monthly-call-september-title-card
 ---
 {{< asset-static file="uswds-monthly-call-september-2023.pptx" label="View the slides (PowerPoint presentation, 3.4 MB, 99 pages)" >}}
 
-{{< accordion kicker="Slide by Slide" title="USWDS Monthly Call - Presentation Script for August 2023" icon="content_copy" >}}**Slide 1:** Thanks Jeannie, and welcome, everyone, to the U.S. Web Design System monthly call for September 2023, where we've celebrated Labor Day, shown here with a USWDS logo in red white and blue. And if you squint perhaps you can see the form of Rosie the Riveter, with her bicep, blue shirt, and red bandana?
+{{< accordion kicker="Slide by Slide" title="USWDS Monthly Call - Presentation Script for September 2023" icon="content_copy" >}}**Slide 1:** Thanks Jeannie, and welcome, everyone, to the U.S. Web Design System monthly call for September 2023, where we've celebrated Labor Day, shown here with a USWDS logo in red white and blue. And if you squint perhaps you can see the form of Rosie the Riveter, with her bicep, blue shirt, and red bandana?
 
 And Saturday is the fall equinox, with the USWDS logo showing the seasons change: from green and gold, to brown and red.
 


### PR DESCRIPTION
## Summary

Teammate notified me that the slides heading said "august" instead of "september." PRing a quick fix

### Preview

[Link to Preview]()

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

1. Make sure the month is corrected
2. make sure formatting appears normally

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
