### PR TITLE
Updated file path for new resource page 

### DIFF
--- a/content/resources/an-introduction-to-trust.md
+++ b/content/resources/an-introduction-to-trust.md
@@ -38,7 +38,7 @@ There are practical steps you can take to meet the trust-related [federal web re
 3. **Correct and current content:** Knowledge and intention should inform the organization of the website, and users should feel that your site is knowledgeable  and supportive of what they are trying to do.
 4. **Connection to the rest of the web:** Present links to other government sources to be transparent and inspire confidence in the services your agency provides.<sup><a aria-describedby="footnote-label" href="#fn2" id="footnotes-ref2">[2]</a></sup>
 
-Trust is hard to earn, and even harder to regain once broken. Federal websites must demonstrate that they can be trusted by working well, meeting customer needs, and delivering real value. 
+Trust is hard to earn, and even harder to regain once broken. Federal websites must demonstrate that they can be trusted by working well, meeting customer needs, and delivering real value.
 
 ## Resources
 

--- a/content/resources/m-19-17-enabling-mission-delivery-through-improved-identity-credential-and-access-management.md
+++ b/content/resources/m-19-17-enabling-mission-delivery-through-improved-identity-credential-and-access-management.md
@@ -1,6 +1,6 @@
 ---
+slug: m-19-17-enabling-mission-delivery-through-improved-identity-credential-and-access-management
 date: 2023-09-06 11:30:00 -0500
-source: whitehouse
 title: M-19-17 Enabling Mission Delivery through Improved Identity, Credential, and Access Management
 summary: This 2019 memorandum sets forth the federal government's Identity, Credential, and Access Management (ICAM) policy.
 
@@ -15,7 +15,6 @@ topics:
 # 2 -- highlighted
 weight: 2
 
-slug: m-19-17-enabling-mission-delivery-through-improved-identity-credential-and-access-management
 
 ---
 


### PR DESCRIPTION
## Summary

This PR will fix the file path that was not taking users to the right page but leading them to the main resources page 

### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/cm-link-path-fix/)

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution
The template logic checks for `source` (external agency logo) and uses the `source_url` (external link) to set the link. In this case, we had the `source` field but not the `source_url` causing the link to not be set. The logic requires both fields to be set for an external link.

By removing the source, the path is fixed and the user is taken to the correct page


**External Links Need Both Fields**

When setting an external link, front matter fields `source_url` and `source` are required to set the external link and logo source respectively. 

```
source: whitehouse
source_url: https://https://www.whitehouse.gov/
```






### How To Test

1. Visit the follow paths `resources/#policy`, `topics/policy/`, `/resources/#security` and `/topics/security/`
2. Find the article listed `M-19-17 Enabling Mission Delivery through Improved Identity, Credential, and Access Management` and click on the link and verify that user is taken to the correct page 

---

### Dev Checklist

- [x] PR has correct labels
- [x] A11y testing (voice over testing, meets WCAG, run axe tools)
- [x] Code is formatted properly
