### PR TITLE
add kicker to community pages

### DIFF
--- a/content/communities/communicators.md
+++ b/content/communities/communicators.md
@@ -43,6 +43,9 @@ dg_highlight: true
 dg_shortname: Communicators
 dg_acronym: FCN
 
+kicker: "Join the Communicators Community"
+
+
 primary_image: "white-bg-digital-gov-card-community"
 
 ---

--- a/content/communities/multilingual.md
+++ b/content/communities/multilingual.md
@@ -43,6 +43,8 @@ community_list:
     members: 628
     join_cop_button: "Multilingual community members"
 
+kicker: "Join the Multilingual Community"
+
 primary_image: "white-bg-digital-gov-card-community"
 
 ---

--- a/content/communities/plain-language-community-of-practice.md
+++ b/content/communities/plain-language-community-of-practice.md
@@ -47,6 +47,8 @@ community_list:
     members: 1,823
     join_cop_button: "Plain Language community members"
 
+kicker: "Join the Plain Language Community"
+
 primary_image: "digital-gov-card-community"
 
 ---

--- a/content/communities/social-media.md
+++ b/content/communities/social-media.md
@@ -38,6 +38,8 @@ community_list:
     terms: "Government employees and contractors with an official .gov or .mil email are eligible to join."
     members: 1,332
     join_cop_button: "Social Media community members"
+    
+kicker: "Join the Social Media Community"
 
 primary_image: "white-bg-digital-gov-card-community"
 

--- a/content/communities/user-experience.md
+++ b/content/communities/user-experience.md
@@ -41,6 +41,8 @@ community_list:
 authors:
   - jean-fox
 
+kicker: "Join the User Experience Community"
+
 primary_image: "white-bg-digital-gov-card-community"
 
 ---

--- a/content/communities/web-analytics-and-optimization.md
+++ b/content/communities/web-analytics-and-optimization.md
@@ -45,6 +45,8 @@ community_list:
     members: 811
     join_cop_button: "Web Analytic community members"
 
+kicker: "Join the Web Analytics Community"
+
 primary_image: "digital-gov-card-community"
 
 ---

--- a/content/communities/web-managers-forum.md
+++ b/content/communities/web-managers-forum.md
@@ -51,6 +51,8 @@ community_list:
 
 primary_image: "white-on-gsa-blue-digital-gov-card-community"
 
+kicker: "Join the Web Managers Community"
+
 ---
 
 We are a group for those who create, manage, and contribute to government websites and digital services. We are working to create a trusted, seamless online experience for all. You do not need to be a “manager” to be a part of this community; we are all managing different aspects of the digital experience and all have something to contribute — and something to learn — from one another.


### PR DESCRIPTION
## Summary

Updating the community pages metadata so that we can pull them into the featured resource card component.


### Preview

[Link to Preview]()

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

I've added:

kicker: "Join the [X] Community" to the 7 communities of practice landing pages

### How To Test

1. Check for consistency
2. Confirm that this is the correct step to be able to include communities in the card component

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
