### PR TITLE
remove extra resource

### DIFF
--- a/content/guides/hcd/introduction/next-steps.md
+++ b/content/guides/hcd/introduction/next-steps.md
@@ -16,5 +16,3 @@ You may also wish to review these additional research methods:
 - The Book Apart Series, specifically [Design for Real Life](https://abookapart.com/products/design-for-real-life) by Eric Meyer & Sara Wachter-Boettcher
 
 {{< /ring >}}
-
-{{< featured-resource resourcePath = "/guides/hcd/introduction" kicker = "Get Started">}}


### PR DESCRIPTION
## Summary

removed the extra/duplicative resource on hcd guides homepage. Chose to remove the bottom one since the others are automated and the grid looks nice as is. 

### Preview

[Preview here](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/bc-patch-hcd-guides/guides/hcd/)

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

1. First Step
2. Second Step
3. Third Step

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
