### PR TITLE
Added primary_image for Open Graph

### DIFF
--- a/content/topics/design/_index.md
+++ b/content/topics/design/_index.md
@@ -10,7 +10,7 @@ title: "Design"
 deck: "Understand how and why design impacts user experience"
 
 summary: "Guidance, resources, and community to help you use design to create government websites that meet customer needs, work well on any device, and follow federal web requirements."
-
+primary_image: "topics-og-primary-image"
 # Weight
 weight: 2
 


### PR DESCRIPTION
## Summary
This adds an Open Graph default image for the topics page.




### Todo

- [x] upload image to AWS — #6833
- [x] test with one of the approaches in the solutions section
- [x] include an override for a specific topic page

### Preview

[Link to Preview]()

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

Determine best approach to setting a default topics `primary_image`.

1. Set `primary_image` in `topics/_index.md`
2. Set on each `topic/**/_index.md`
3. Update code in `head.html` based on Section type to set primary image

### How To Test

1. First Step
2. Second Step
3. Third Step

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
