### PR TITLE
Fix "social share" links on sidebar

### DIFF
--- a/themes/digital.gov/layouts/partials/core/get_sharetools.html
+++ b/themes/digital.gov/layouts/partials/core/get_sharetools.html
@@ -16,7 +16,7 @@
       <a
         class="twitter"
         aria-label="Share on Twitter"
-        href="http://twitter.com/share?url=https://digital.gov{{ (urls.Parse .Permalink) }}{{ $path }}&amp;text={{ .Title }}"
+        href="http://twitter.com/share?url=https://digital.gov{{ (urls.Parse .Permalink) }}&amp;text={{ .Title }}"
       >
         <svg
           class="usa-icon dg-icon dg-icon--large margin-bottom-05"
@@ -31,7 +31,7 @@
       <a
         class="facebook"
         aria-label="Share on Facebook"
-        href="http://www.facebook.com/sharer.php?u=https://digital.gov{{ (urls.Parse .Permalink) }}{{ $path }}&t={{ .Title | urlize }}"
+        href="http://www.facebook.com/sharer.php?u=https://digital.gov{{ (urls.Parse .Permalink) }}&t={{ .Title | urlize }}"
       >
         <svg
           class="usa-icon dg-icon dg-icon--large margin-bottom-05"
@@ -48,7 +48,7 @@
       <a
         class="linkedin"
         aria-label="Share on LinkedIn"
-        href="https://www.linkedin.com/shareArticle?mini=true&url=https://digital.gov{{ (urls.Parse .Permalink) }}{{ $path }}&title={{ .Title | urlize }}&summary={{ .Params.summary | urlize }}&source={{ "Digital.gov" | urlize }}"
+        href="https://www.linkedin.com/shareArticle?mini=true&url=https://digital.gov{{ (urls.Parse .Permalink) }}&title={{ .Title | urlize }}&summary={{ .Params.summary | urlize }}&source={{ "Digital.gov" | urlize }}"
       >
         <svg
           class="usa-icon dg-icon dg-icon--large margin-bottom-05"
@@ -68,7 +68,7 @@
         target="_blank"
         title="Email this page"
         class="email"
-        href="mailto:?subject={{ .Title }}%20%7C%20Digital.gov&body=%20%20%0A-------%0A{{ .Title }}%0Ahttps://digital.gov{{ (urls.Parse .Permalink) }}{{ $path }}%3Fem%0A-------%0A%0A&#9829; Sign-up%20for%20the%20Digital.gov%20newsletter%3A%20https%3A%2F%2Fdigital.gov%2Fsubscribe%2F"
+        href="mailto:?subject={{ .Title }}%20%7C%20Digital.gov&body=%20%20%0A-------%0A{{ .Title }}%0Ahttps://digital.gov{{ (urls.Parse .Permalink) }}%3Fem%0A-------%0A%0A&#9829; Sign-up%20for%20the%20Digital.gov%20newsletter%3A%20https%3A%2F%2Fdigital.gov%2Fsubscribe%2F"
         data-proofer-ignore
       >
         <svg

--- a/themes/digital.gov/layouts/partials/core/get_sharetools.html
+++ b/themes/digital.gov/layouts/partials/core/get_sharetools.html
@@ -4,15 +4,12 @@
 {{ else }}
   {{ $path = .Path }}
 {{ end }}
-{{ printf "%#v" $path }}
 
 
 <!-- Test syntax -->
 <section class="share-tools">
   <div class="grid-row">
     <div class="grid-col-4">
-      {{ $urls := .Permalink }}
-      {{ printf "%#v" $urls }}
       <a
         class="twitter"
         aria-label="Share on Twitter"

--- a/themes/digital.gov/layouts/partials/core/get_sharetools.html
+++ b/themes/digital.gov/layouts/partials/core/get_sharetools.html
@@ -1,16 +1,18 @@
 {{/* Share tools */}}
-
 {{ $path := "" }}{{ with .File }}
   {{ $path = .Path }}
 {{ else }}
   {{ $path = .Path }}
 {{ end }}
+{{ printf "%#v" $path }}
 
 
 <!-- Test syntax -->
 <section class="share-tools">
   <div class="grid-row">
     <div class="grid-col-4">
+      {{ $urls := .Permalink }}
+      {{ printf "%#v" $urls }}
       <a
         class="twitter"
         aria-label="Share on Twitter"


### PR DESCRIPTION
## Summary

Looks like the `$path` is setting the filename (`2023-06-20-10-ways-to-recognize-employees-at-work.md`) in the social media link with the file extension, we should be using the link url with `.Permalink` to make the link work.


### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-fix-social-media-links/2023/06/21/10-ways-to-recognize-employees-at-work/)

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

Removed `$path` in the social share link and use `.Permalink` to set a proper link url for the page.


### How To Test

1. Login to social media accounts @ToniBonittoGSA 
	1. LinkedIn
	2. Facebook
	3. Twitter
2. Visit [10-ways-to-recognize-employees-at-work](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-fix-social-media-links/2023/06/21/10-ways-to-recognize-employees-at-work/)
3. Click on each link
	1. LinkedIn share link should link to page URL
	2. Facebook share link should link to page URL and social share displays page preview image
	3. Twitter share link should link to page URL


| Social Media | Link Works | Preview Image |
| ------------ | ---------- | ------------- |
| Facebook     |                   |                        |
| LinkedIn       |                  |                         |
| Twitter          |                   |                        |


---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
