### PR TITLE
Convert governance topic page to topic collection

### DIFF
--- a/content/topics/governance/_index.md
+++ b/content/topics/governance/_index.md
@@ -41,7 +41,7 @@ featured_links:
     summary: "Learn about the various roles your agency could include on your web teams."
     href: "https://digital.gov/2020/05/27/whos-on-your-digital-dream-team/"
   - title: "Required web content and links"
-    summary: "Learn what links and text are required and the purposes they serve."
+    summary: "For executive branch websites, various policies require us to provide certain content, and provide links to content from specific places."
     href: "https://digital.gov/resources/required-web-content-and-links/"
   - title: "Checklist of requirements for federal websites and digital services"
     summary: "Learn about high-level policies that cover basic requirements for all websites and digital services."

--- a/content/topics/governance/_index.md
+++ b/content/topics/governance/_index.md
@@ -8,7 +8,7 @@ slug: "governance"
 title: "Governance"
 deck: "Good digital governance leads to better internal team performance as well as better public digital experiences."
 
-summary: "Governance clarifies roles and responsibilities, establishes standards and procedures, and provides a framework for decision-making. Digital governance encompasses all aspects of website management and operation, including content, design, technical infrastructure, security, funding, and product, project, and program management."
+summary: "Governance provides a framework for decision-making by establishing standards and procedures and clarifying roles and responsibilities. Digital governance encompasses all aspects of website management and operation, including content, design, technical infrastructure, security, funding, and product, project, and program management."
 
 # Weight
 weight: 2
@@ -16,7 +16,7 @@ weight: 2
 # Set the legislation card title and link
 legislation:
   title: "21st Century IDEA & M-23-22"
-  link: "https://digital.gov/resources/delivering-digital-first-public-experience/"
+  link: "/resources/delivering-digital-first-public-experience/"
 
 # Featured resource to at the top of the page
 featured_resources:
@@ -32,7 +32,7 @@ featured_links:
   title: "Governance: essential knowledge"
   resources:
   - title: "An introduction to digital governance"
-    summary: " Get an overview of the internal systems and processes used to manage digital presence."
+    summary: "Get an overview of the internal systems and processes used to manage digital presence."
     href: "https://digital.gov/resources/an-introduction-to-digital-governance/"
   - title: "What are agency reporting requirements?"
     summary: "Learn what the Office of Management and Budget (OMB) requires federal executive agencies to complete by September 2024 (one year after  M-23-22 issuance)."

--- a/content/topics/governance/_index.md
+++ b/content/topics/governance/_index.md
@@ -35,7 +35,7 @@ featured_links:
     summary: "Get an overview of the internal systems and processes used to manage digital presence."
     href: "https://digital.gov/resources/an-introduction-to-digital-governance/"
   - title: "What are agency reporting requirements?"
-    summary: "Learn what the Office of Management and Budget (OMB) requires federal executive agencies to complete by September 2024 (one year after  M-23-22 issuance)."
+    summary: "Learn what the Office of Management and Budget (OMB) requires federal executive agencies to complete by September 2024; one year after  M-23-22 issuance."
     href: "https://digital.gov/resources/21st-century-integrated-digital-experience-act/#what-are-the-agency-reporting-requirements"
   - title: "Who’s on your digital dream team?"
     summary: "Learn about the various roles your agency could include on your web teams."

--- a/content/topics/governance/_index.md
+++ b/content/topics/governance/_index.md
@@ -6,14 +6,44 @@ slug: "governance"
 
 # Topic Title
 title: "Governance"
+deck: "Good digital governance leads to better internal team performance as well as better public digital experiences."
 
-# description — keep it short and clear
-summary: ""
-
+summary: "Governance clarifies roles and responsibilities, establishes standards and procedures, and provides a framework for decision-making. Digital governance encompasses all aspects of website management and operation, including content, design, technical infrastructure, security, funding, and product, project, and program management."
 
 # Weight
 weight: 2
 
-# For more information on managing topics,
-# see https://github.com/GSA/digitalgov.gov/wiki
+# Set the legislation card title and link
+legislation:
+  title: "21st Century IDEA & M-23-22"
+  link: "https://digital.gov/resources/delivering-digital-first-public-experience/"
+
+# Featured resource to at the top of the page
+featured_resources:
+  resources:
+    - link: ""
+
+# Featured community to display at the top of the page
+featured_communities:
+  - "web-managers-forum"
+
+# Curated list of content, can be internal or external links
+featured_links:
+  title: "Governance: essential knowledge"
+  resources:
+  - title: "An introduction to digital governance"
+    summary: " Get an overview of the internal systems and processes used to manage digital presence."
+    href: "https://digital.gov/resources/an-introduction-to-digital-governance/"
+  - title: "What are agency reporting requirements?"
+    summary: "Learn what the Office of Management and Budget (OMB) requires federal executive agencies to complete by September 2024 (one year after  M-23-22 issuance)."
+    href: "https://digital.gov/resources/21st-century-integrated-digital-experience-act/#what-are-the-agency-reporting-requirements"
+  - title: "Who’s on your digital dream team?"
+    summary: "Learn about the various roles your agency could include on your web teams."
+    href: "https://digital.gov/2020/05/27/whos-on-your-digital-dream-team/"
+  - title: "Required web content and links"
+    summary: "Learn what links and text are required and the purposes they serve."
+    href: "https://digital.gov/resources/required-web-content-and-links/"
+  - title: "Checklist of requirements for federal websites and digital services"
+    summary: "Learn about high-level policies that cover basic requirements for all websites and digital services."
+    href: "https://digital.gov/resources/checklist-of-requirements-for-federal-digital-services/"
 ---


### PR DESCRIPTION
## Summary

converts the Governance topic page. 
https://digital.gov/topics/governance/ added to Wayback 

### Preview

[[Link to Preview]()
](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/bc-create-governance-topic/topics/governance/)
<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

1. First Step
2. Second Step
3. Third Step

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
