### PR TITLE
Convert content strategy topic page to topic collection

### DIFF
--- a/content/topics/content-strategy/_index.md
+++ b/content/topics/content-strategy/_index.md
@@ -21,7 +21,7 @@ legislation:
 # Featured resource to at the top of the page
 featured_resources:
   resources:
-    - link: "https://digital.gov/guides/site-scanning/"
+    - link: "/guides/site-scanning/"
 
 # Featured community to display at the top of the page
 featured_communities:

--- a/content/topics/content-strategy/_index.md
+++ b/content/topics/content-strategy/_index.md
@@ -5,15 +5,46 @@
 slug: "content-strategy"
 
 # Topic Title
-title: "Content Strategy"
+title: "Content strategy"
+deck: "Make use of content strategy to deliver great digital experiences."
 
-# description — keep it short and clear
-summary: ""
-
+summary: "Content strategy involves planning, creating, delivering, and governing content that meets the needs of its users and achieves an organization's goals. Content strategy is an essential element of effective digital web services and communication for government agencies."
 
 # Weight
 weight: 2
 
-# For more information on managing topics,
-# see https://github.com/GSA/digitalgov.gov/wiki
+# Set the legislation card title and link
+legislation:
+  title: "21st Century IDEA & M-23-22"
+  link: "https://digital.gov/resources/21st-century-integrated-digital-experience-act/"
+
+# Featured resource to at the top of the page
+featured_resources:
+  resources:
+    - link: "https://digital.gov/guides/site-scanning/"
+
+# Featured community to display at the top of the page
+featured_communities:
+  - "web-managers-forum"
+  - "user-experience"
+
+# Curated list of content, can be internal or external links
+featured_links:
+  title: "Content strategy: essential knowledge"
+  resources:
+  - title: "An introduction to structured content"
+    summary: "Learn how to transform how people find, understand, share, use, and reuse government information."
+    href: "https://digital.gov/resources/an-introduction-to-structured-content/"
+  - title: "An introduction to trust"
+    summary: "Learn how to create websites that people trust."
+    href: "https://digital.gov/resources/an-introduction-to-trust/"
+  - title: "Introduction to translation technology"
+    summary: "Learn how and why to use translation technology to create multilingual content."
+    href: "https://digital.gov/resources/introduction-to-translation-technology/"
+  - title: "An introduction to plain language"
+    summary: "Create communication that is clear and easy to understand for your target audience."
+    href: "https://digital.gov/resources/an-introduction-to-plain-language/"
+  - title: "Writing for the accessible web"
+    summary: "Learn how to write and design web content that is accessible for everyone."
+    href: "https://digital.gov/event/2020/03/20/writing-for-accessible-web/"
 ---


### PR DESCRIPTION
## Summary

Creates a topic collection page for content strategy. 
Add original page https://digital.gov/topics/content-strategy/ to [Wayback](https://web.archive.org/).

### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/bc-create-content-strategy-topic/topics/content-strategy/)

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

1. First Step
2. Second Step
3. Third Step

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
