### PR TITLE
Convert domain management topic page to topic collection

### DIFF
--- a/content/topics/domain-management/_index.md
+++ b/content/topics/domain-management/_index.md
@@ -1,11 +1,43 @@
 ---
-title: Domain management
-summary: "Clear and consistent use of .gov and .mil domains is essential to
-  maintaining public trust. "
-# Controls how this page appears across the site
-# 0 -- hidden
-# 1 -- visible
-# 2 -- featured on the Resource page
+# This topic lives at
+# https://digital.gov/topics/domain-management
+
+slug: "domain-management"
+
+# Topic Title
+title: "Domain management"
+deck: "Clear and consistent use of .gov and .mil domains is essential to maintaining public trust."
+
+summary: "It should be easy to identify government websites on the internet. Using a .gov or .mil domain increases security, trust, and accountability, while ensuring the public can clearly identify official government services and information."
+
+# Weight
 weight: 2
-slug: domain-management
+
+# Set the legislation card title and link
+legislation:
+  title: " DOTGOV Act & M-23-10 (PDF, 96 KB, 3 pages, February 2023)"
+  link: "https://www.whitehouse.gov/wp-content/uploads/2023/02/M-23-10-DOTGOV-Act-Guidance.pdf"
+
+# Featured resource to at the top of the page
+featured_resources:
+  resources:
+    - link: "https://get.gov/"
+
+# Featured community to display at the top of the page
+featured_communities:
+  - "web-managers-forum"
+
+# Curated list of content, can be internal or external links
+featured_links:
+  title: "Domain management: essential knowledge"
+  resources:
+  - title: "Domain security best practices"
+    summary: "Follow these domain security best practices to ensure a safe experience for your organization and your users."
+    href: "https://get.gov/help/security-best-practices/"
+  - title: "How to prevent security certificates from expiring during a lapse in operations"
+    summary: "Learn what steps you can take to avoid security certificates from expiring during a lapse in operations."
+    href: "https://digital.gov/resources/how-to-prevent-security-certificates-from-expiring-during-a-lapse-in-operations/"
+  - title: "Building the elements that earn trust"
+    summary: "Government websites with official domain names help build trust with the public."
+    href: "https://digital.gov/2019/11/18/building-elements-that-earn-trust/"
 ---


### PR DESCRIPTION
## Summary

Converts domain management topic page to a topic collection. 
saved https://digital.gov/topics/domain-management/ to Wayback

### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/bc-create-domain-management-topic-collection/topics/domain-management/)

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

1. First Step
2. Second Step
3. Third Step

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
