### PR TITLE
Topics default open graph image

### DIFF
--- a/content/topics/_index.md
+++ b/content/topics/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Topics"
 summary: ""
+primary_image: "topics-og-primary-image"
 ---

--- a/content/topics/_index.md
+++ b/content/topics/_index.md
@@ -1,5 +1,4 @@
 ---
 title: "Topics"
 summary: ""
-primary_image: "topics-og-primary-image"
 ---

--- a/content/topics/design/_index.md
+++ b/content/topics/design/_index.md
@@ -9,7 +9,7 @@ title: "Design"
 deck: "Understand how and why design impacts user experience"
 
 summary: "Guidance, resources, and community to help you use design to create government websites that meet customer needs, work well on any device, and follow federal web requirements."
-primary_image: "topics-og-primary-image"
+
 # Weight
 weight: 2
 

--- a/content/topics/primary-image.md
+++ b/content/topics/primary-image.md
@@ -1,0 +1,3 @@
+---
+primary_image: "topics-og-primary-image"
+---

--- a/content/topics/primary-image.md
+++ b/content/topics/primary-image.md
@@ -1,3 +1,0 @@
----
-primary_image: "topics-og-primary-image"
----

--- a/data/images/topics-og-primary-image.yml
+++ b/data/images/topics-og-primary-image.yml
@@ -1,0 +1,10 @@
+# https://s3.amazonaws.com/digitalgov/topics-og-primary-image.jpg
+# Image shortcode: {{< img src=topics-og-primary-image >}}'
+date: 2023-11-21 02:11:44 -0400
+uid: topics-og-primary-image
+width: 1200
+height: 630
+format: jpg
+credit:
+caption: "21st Century Integrated Digital Experience Act"
+alt: "Digital.gov Topics Resource"

--- a/themes/digital.gov/layouts/partials/core/head.html
+++ b/themes/digital.gov/layouts/partials/core/head.html
@@ -12,6 +12,16 @@
   {{- end -}}
 {{- end -}}
 
+{{/* Set primary_image from topics/_index.md if not set on individual topic */}}
+{{ if eq .Type "topics" }}
+  {{ if .Params.primary_image }}
+    {{ $primary_image = .Params.primary_image }}
+  {{ else }}
+    {{ $topics_page := .Site.GetPage "topics" }}
+    {{ $primary_image = $topics_page.Params.primary_image }}
+  {{ end }}
+{{ end }}
+
 {{- $cdnurl := .Site.Params.cdnurl -}}
 {{- $featImg := index $.Site.Data.images (default "digitalgov-2022-card-v3" $primary_image) -}}
 {{- $featImgBase := $featImg.uid -}}


### PR DESCRIPTION
## Summary
Adds a default open graph image for all topic pages and allows overrides for specific topics by setting `primary_image`.

### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-topic-open-graph/topics/agile)


### Solution

Updated logic in `head.html` to set the `primary_image` field from the default topic page.

**Default Site OG Image**

<details><summary>digitalgov-2022-card-v3</summary>
<img width="498" alt="Screen Shot 2023-11-21 at 4 16 38 PM" src="https://github.com/GSA/digitalgov.gov/assets/104778659/cf74d5ed-b1a5-4437-aa37-0921aa404e4d">
</details>

**Default Topic OG Image**

<details><summary>topic-og-primary-image</summary>
<img width="487" alt="Screen Shot 2023-11-21 at 4 18 04 PM" src="https://github.com/GSA/digitalgov.gov/assets/104778659/0633f7cb-f810-40fa-8eb0-865510408876">
</details>



### How To Test

1. Visit any [topic page](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-topic-open-graph/topics/agile)
2. Use https://www.opengraph.xyz to preview open graph image

### What To Test

1. All topics will display default topic OG image
2. Pick any topic and set `primary_image` to "10x-gold-x-logo" to override the default


---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
