### PR TITLE
Fix for backtick bug within pages 

### DIFF
--- a/themes/digital.gov/layouts/events/single.html
+++ b/themes/digital.gov/layouts/events/single.html
@@ -144,7 +144,7 @@
               {{- end -}}
 
               {{/* Content */}}
-              <div class="content">
+              <div class="content usa-prose">
                 {{- .Content -}}
               </div>
 


### PR DESCRIPTION
## Summary

This Pr will address the issue with some code/content within backticks not being formated correctly. 

### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/bug/cm-backtick-fix//event/2023/06/15/uswds-monthly-call-june-2023/)

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution
Added the Class `usa prose` to the content section to be consistent with other layouts and templets 

**Before:**
 
![Screenshot 2023-11-27 at 3 28 37 PM](https://github.com/GSA/digitalgov.gov/assets/88721460/2933ef64-7192-455b-bfcc-04962bdb8694)

**After:** 

![Screenshot 2023-11-27 at 3 28 43 PM](https://github.com/GSA/digitalgov.gov/assets/88721460/aa510f87-d48b-4c39-b0f6-97fc42f0e101)

**Reference for correct look:**
 
![Screenshot 2023-11-27 at 3 28 50 PM](https://github.com/GSA/digitalgov.gov/assets/88721460/99172417-2321-4b2e-bdd8-2f39c810c431)



### How To Test

1. Visit [Preview Link](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/bug/cm-backtick-fix//event/2023/06/15/uswds-monthly-call-june-2023/) and verify that content is appearing correctly
2. Edit the `uswds-monthly-call-june-2023` file and add `THIS IS A TEST` or any content within backticks and ensure that format is correct

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
