### PR TITLE
Move from netlify to decap package for workflow dashboard

### DIFF
--- a/themes/digital.gov/static/workflow/index.html
+++ b/themes/digital.gov/static/workflow/index.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" type="text/css" href="styles.css" />
   </head>
   <body>
-    <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+    <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
     <script type="module">
       import editorComponents from "./js/editorComponents/index.js";
       import { slugify } from "./js/helpers.js";


### PR DESCRIPTION
## Summary

The workflow template references the old netlify CMS. Since this project has been transferred we should switch to the new name to avoid build issues.

[See Decap 3.0](https://decapcms.org/blog/2023/08/decap-3)

Update script in `/static/workflow/index.html`.

**Old Package**
`<script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>`

**New Package**
`<script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>`

## Preview

[Workflow Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/nl-migrate-to-decap/workflow)

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

## Solution


### How To Test

1. Create New Content Post
2. Copy Content from Existing Post
3. Publish on Workflow
4. Make An Edit/Update to Field in Workflow
5. Delete Post from Workflow (top right of workflow dashboard)

### What To Test

- [x] Preview Link works
- [x] Workflow publishing is same as before
- [x] Shortcodes Render As Expected
- [x] `View Preview` button displays Preview Page

**Testing**



| content type   | create                                                   | update/edit                                              | delete                                                   |
| -------------- | -------------------------------------------------------- | -------------------------------------------------------- | -------------------------------------------------------- |
| Authors        | [#7089](https://github.com/GSA/digitalgov.gov/pull/7089) | [#7090](https://github.com/GSA/digitalgov.gov/pull/7090) | [#7090](https://github.com/GSA/digitalgov.gov/pull/7090) |
| Communities    | [#7092](https://github.com/GSA/digitalgov.gov/pull/7092) | [#7093](https://github.com/GSA/digitalgov.gov/pull/7093) | [#7093](https://github.com/GSA/digitalgov.gov/pull/7093) |
| Events         | [#7094](https://github.com/GSA/digitalgov.gov/pull/7094) | [#7095](https://github.com/GSA/digitalgov.gov/pull/7095) | [#7095](https://github.com/GSA/digitalgov.gov/pull/7095) |
| News           | [#7096](https://github.com/GSA/digitalgov.gov/pull/7096) | [#7096](https://github.com/GSA/digitalgov.gov/pull/7096) | [#7096](https://github.com/GSA/digitalgov.gov/pull/7096) |
| Resources      | [#7102](https://github.com/GSA/digitalgov.gov/pull/7102) | [#7102](https://github.com/GSA/digitalgov.gov/pull/7102) | [#7102](https://github.com/GSA/digitalgov.gov/pull/7102) |
| Services       | [#7103](https://github.com/GSA/digitalgov.gov/pull/7103) | [#7103](https://github.com/GSA/digitalgov.gov/pull/7103) | [#7103](https://github.com/GSA/digitalgov.gov/pull/7103) |
| Short Link     | [#7104](https://github.com/GSA/digitalgov.gov/pull/7104) | [#7104](https://github.com/GSA/digitalgov.gov/pull/7104) | [#7104](https://github.com/GSA/digitalgov.gov/pull/7104) |
| Sources        | skip                                                     | skip                                                     | skip                                                     |
| Topics         | skip                                                     | skip                                                     | skip                                                     |
| Transcript     | skip                                                     | skip                                                     | skip                                                     |
| File upload    | [#7112](https://github.com/GSA/digitalgov.gov/pull/7112) | [#7112](https://github.com/GSA/digitalgov.gov/pull/7112) | [#7112](https://github.com/GSA/digitalgov.gov/pull/7112) |
| Image upload   | [#7111](https://github.com/GSA/digitalgov.gov/pull/7111) | [#7111](https://github.com/GSA/digitalgov.gov/pull/7111) | [#7111](https://github.com/GSA/digitalgov.gov/pull/7111) |
| Image metadata | skip                                                     | skip                                                     | skip                                                     |

---

> [!NOTE]
> This script is used for [netlify users to sign in](https://github.com/netlify/netlify-identity-widget) to their account to access `workflow`.

https://github.com/GSA/digitalgov.gov/blob/8e5f3fd138a28701066c58f9b9245d67f7bc900e/themes/digital.gov/static/workflow/index.html#L7

<details><summary>login script</summary>
<img width="1304" alt="Screen Shot 2023-12-06 at 4 10 20 PM" src="https://github.com/GSA/digitalgov.gov/assets/104778659/5ae52b49-3de3-45b5-8dff-b51762202901">
</details>

---

> [!NOTE]
> PR copy is updated to read `Automatically generated by Decap CMS`

<details><summary>screen shot</summary>
<img width="1046" alt="Screen Shot 2023-12-06 at 4 32 49 PM" src="https://github.com/GSA/digitalgov.gov/assets/104778659/11d4311f-a6de-442c-831e-485aebb233ee">
</details>



---

### Dev Checklist

- [x] PR has correct labels
- [x] A11y testing (voice over testing, meets WCAG, run axe tools)
- [x] Code is formatted properly
