### PR TITLE
Update federal-web-council.md

### DIFF
--- a/content/resources/federal-web-council.md
+++ b/content/resources/federal-web-council.md
@@ -67,7 +67,7 @@ Please reach out to your agency’s Web Council member with questions. If your a
 - Department of Justice (DOJ) — Ashley McGowan
 - Department of Labor — Ed McCarthy
 - Department of State — Monica Perry
-- Department of Transportation (DOT) — Kellie Korzen
+- Department of Transportation (DOT) — Bernetta Reese
 - Department of the Treasury — Teri Greene
 - Department of Veterans Affairs (VA) — Joshua Tuscher
 - Environmental Protection Agency (EPA) — Lin Darlington


### PR DESCRIPTION
Jee Kim’s last day at DOT was 9/9/2022. Bernetta Reese is the new DOT rep and Marina Fox approved this update in https://gsa-solutionshelp.zendesk.com/agent/tickets/14777

CURRENT:
Department of Transportation (DOT) — Kellie Korzen

NEW:
Department of Transportation (DOT) — Bernetta Reese

## Summary

Basic description of work done. Closes [#issue_no].

### Preview

[Link to Preview]()

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

1. First Step
2. Second Step
3. Third Step

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
