### PR TITLE
Create reusable two column template

### DIFF
--- a/themes/digital.gov/layouts/_default/list.html
+++ b/themes/digital.gov/layouts/_default/list.html
@@ -4,56 +4,40 @@
   {{ else }}
     {{ $path = .Path }}
   {{ end }}
-  <main role="main" id="main-content">
-    <article>
-      <header>
-        <div
-          class="grid-container grid-container-desktop"
-          data-gh-edit-page="{{- $path -}}"
-        >
-          <div class="grid-row">
-            <div class="grid-col-12">
-              {{/* Breadcrumbs */}}
-              {{- if .Parent -}}
-                {{- partial "partials/core/usa-breadcrumbs.html" . -}}
-              {{- end -}}
+  <section id="main-content" class="grid-container-desktop">
+    <header data-gh-edit-page="{{- $path -}}">
+      {{- if .Parent -}}
+        {{- partial "partials/core/usa-breadcrumbs.html" . -}}
+      {{- end -}}
 
-              {{- if .Params.kicker -}}
-                <p class="kicker">{{- .Params.kicker -}}</p>
-              {{- end -}}
+      {{- if .Params.kicker -}}
+        <p class="kicker">{{- .Params.kicker -}}</p>
+      {{- end -}}
 
-              {{/* Page Title */}}
-              <h1>{{- .Title | markdownify -}}</h1>
 
-              {{/* Deck */}}
-              {{- if .Params.deck -}}
-                <div class="deck">{{- .Params.deck | markdownify -}}</div>
-              {{- end -}}
-            </div>
-          </div>
+      <h1>{{- .Title | markdownify -}}</h1>
+
+      {{- if .Params.deck -}}
+        <div class="deck">{{- .Params.deck | markdownify -}}</div>
+      {{- end -}}
+    </header>
+
+    <section class="usa-in-page-nav-container">
+      <main>
+        <div class="content usa-prose">
+          {{- .Content -}}
         </div>
-      </header>
-
-      <section class="grid-container grid-container-desktop">
-        <div class="usa-in-page-nav-container">
-          <!-- 
+        {{- partial "core/gh-commit-info.html" . -}}
+      </main>
+      <!-- 
         data-root-margin sets the observable "window" for the element, details here https://designsystem.digital.gov/components/in-page-navigation/#using-the-in-page-navigation-component-2
         the values ensure that the sidenav links highlight in order when there are multiple headers visible on the viewport, otherwise the highlight skips headers
-       -->
-          <aside
-            class="usa-in-page-nav"
-            data-title-heading-level="h3"
-            data-root-margin="-350px 0px -350px 0px"
-          ></aside>
-          <div class="">
-            {{/* Content */}}
-            <div class="content usa-prose">
-              {{- .Content -}}
-            </div>
-            {{- partial "core/gh-commit-info.html" . -}}
-          </div>
-        </div>
-      </section>
-    </article>
-  </main>
+      -->
+      <aside
+        class="usa-in-page-nav"
+        data-title-heading-level="h3"
+        data-root-margin="-350px 0px -350px 0px"
+      ></aside>
+    </section>
+  </section>
 {{- end -}}

--- a/themes/digital.gov/layouts/_default/single.html
+++ b/themes/digital.gov/layouts/_default/single.html
@@ -4,56 +4,40 @@
   {{ else }}
     {{ $path = .Path }}
   {{ end }}
-  <main role="main" id="main-content">
-    <article>
-      <header>
-        <div
-          class="grid-container grid-container-desktop"
-          data-gh-edit-page="{{- $path -}}"
-        >
-          <div class="grid-row">
-            <div class="grid-col-12">
-              {{/* Breadcrumbs */}}
-              {{- if .Parent -}}
-                {{- partial "partials/core/usa-breadcrumbs.html" . -}}
-              {{- end -}}
+  <section id="main-content" class="grid-container-desktop">
+    <header data-gh-edit-page="{{- $path -}}">
+      {{- if .Parent -}}
+        {{- partial "partials/core/usa-breadcrumbs.html" . -}}
+      {{- end -}}
 
-              {{- if .Params.kicker -}}
-                <p class="kicker">{{- .Params.kicker -}}</p>
-              {{- end -}}
+      {{- if .Params.kicker -}}
+        <p class="kicker">{{- .Params.kicker -}}</p>
+      {{- end -}}
 
-              {{/* Page Title */}}
-              <h1>{{- .Title | markdownify -}}</h1>
 
-              {{/* Deck */}}
-              {{- if .Params.deck -}}
-                <div class="deck">{{- .Params.deck | markdownify -}}</div>
-              {{- end -}}
-            </div>
-          </div>
+      <h1>{{- .Title | markdownify -}}</h1>
+
+      {{- if .Params.deck -}}
+        <div class="deck">{{- .Params.deck | markdownify -}}</div>
+      {{- end -}}
+    </header>
+
+    <section class="usa-in-page-nav-container">
+      <main data-gh-edit-page="{{- $path -}}">
+        <div class="content usa-prose">
+          {{- .Content -}}
         </div>
-      </header>
-
-      <section class="grid-container grid-container-desktop">
-        <div class="usa-in-page-nav-container">
-          <!-- 
-        data-root-margin sets the observable "window" for the element, details here https://designsystem.digital.gov/components/in-page-navigation/#using-the-in-page-navigation-component-2
-        the values ensure that the sidenav links highlight in order when there are multiple headers visible on the viewport, otherwise the highlight skips headers
-       -->
-          <aside
-            class="usa-in-page-nav"
-            data-title-heading-level="h3"
-            data-root-margin="-350px 0px -350px 0px"
-          ></aside>
-          <div class="">
-            {{/* Content */}}
-            <div class="content usa-prose">
-              {{- .Content -}}
-            </div>
-            {{- partial "core/gh-commit-info.html" . -}}
-          </div>
-        </div>
-      </section>
-    </article>
-  </main>
+        {{- partial "core/gh-commit-info.html" . -}}
+      </main>
+      <!-- 
+          data-root-margin sets the observable "window" for the element, details here https://designsystem.digital.gov/components/in-page-navigation/#using-the-in-page-navigation-component-2
+          the values ensure that the sidenav links highlight in order when there are multiple headers visible on the viewport, otherwise the highlight skips headers
+        -->
+      <aside
+        class="usa-in-page-nav"
+        data-title-heading-level="h3"
+        data-root-margin="-350px 0px -350px 0px"
+      ></aside>
+    </section>
+  </section>
 {{- end -}}

--- a/themes/digital.gov/layouts/communities/single.html
+++ b/themes/digital.gov/layouts/communities/single.html
@@ -20,8 +20,8 @@
       </div>
     </header>
 
-    <main class="usa-in-page-nav-container">
-      <section id="main-content">
+    <section class="usa-in-page-nav-container">
+      <main id="main-content">
         {{/* Summary */}}
         {{- if .Params.summary -}}
           <div class="content usa-prose" data-gh-edit-page="{{- $path -}}">
@@ -124,16 +124,12 @@
             </div>
           </div>
         {{- end -}}
-      </section>
-      <!--
-    data-root-margin sets the observable "window" for the element, details here https://designsystem.digital.gov/components/in-page-navigation/#using-the-in-page-navigation-component-2
-    the values ensure that the sidenav links highlight in order when there are multiple headers visible on the viewport, otherwise the highlight skips headers
-    -->
+      </main>
       <aside
         class="usa-in-page-nav dg-sidebar"
         data-title-heading-level="h3"
         data-root-margin="-350px 0px -350px 0px"
       ></aside>
-    </main>
+    </section>
   </section>
 {{ end }}

--- a/themes/digital.gov/layouts/communities/single.html
+++ b/themes/digital.gov/layouts/communities/single.html
@@ -1,34 +1,27 @@
 {{ define "content" }}
-  <main role="main" id="main-content" class="page main-content">
-    <article class="grid-container grid-container-desktop">
-      {{- partial "partials/core/usa-breadcrumbs.html" . -}}
-      <header>
-        {{ $path := "" }}{{ with .File }}
-          {{ $path = .Path }}
-        {{ else }}
-          {{ $path = .Path }}
-        {{ end }}
-        <div data-gh-edit-page="{{- $path -}}">
-          {{/* Page Title */}}
-          <h1>{{ .Title | markdownify }} Community</h1>
+  {{ $path := "" }}{{ with .File }}
+    {{ $path = .Path }}
+  {{ else }}
+    {{ $path = .Path }}
+  {{ end }}
 
-          {{/* Deck */}}
-          {{- if .Params.deck -}}
-            <div class="deck">{{- .Params.deck | markdownify -}}</div>
-          {{- end -}}
-        </div>
-      </header>
 
-      <div class="usa-in-page-nav-container">
-        <!--
-        data-root-margin sets the observable "window" for the element, details here https://designsystem.digital.gov/components/in-page-navigation/#using-the-in-page-navigation-component-2
-        the values ensure that the sidenav links highlight in order when there are multiple headers visible on the viewport, otherwise the highlight skips headers
-       -->
-        <aside
-          class="usa-in-page-nav"
-          data-title-heading-level="h3"
-          data-root-margin="-350px 0px -350px 0px"
-        ></aside>
+  <section class="grid-container-desktop">
+    {{- partial "partials/core/usa-breadcrumbs.html" . -}}
+
+
+    <header>
+      <div data-gh-edit-page="{{- $path -}}">
+        <h1>{{ .Title | markdownify }} Community</h1>
+
+        {{- if .Params.deck -}}
+          <div class="deck">{{- .Params.deck | markdownify -}}</div>
+        {{- end -}}
+      </div>
+    </header>
+
+    <main class="usa-in-page-nav-container">
+      <section id="main-content">
         {{/* Summary */}}
         {{- if .Params.summary -}}
           <div class="content usa-prose" data-gh-edit-page="{{- $path -}}">
@@ -110,7 +103,6 @@
                     </div>
                   </div>
                 {{- end -}}
-
               </section>
             {{- end -}}
             <div>
@@ -132,7 +124,16 @@
             </div>
           </div>
         {{- end -}}
-      </div>
-    </article>
-  </main>
+      </section>
+      <!--
+    data-root-margin sets the observable "window" for the element, details here https://designsystem.digital.gov/components/in-page-navigation/#using-the-in-page-navigation-component-2
+    the values ensure that the sidenav links highlight in order when there are multiple headers visible on the viewport, otherwise the highlight skips headers
+    -->
+      <aside
+        class="usa-in-page-nav dg-sidebar"
+        data-title-heading-level="h3"
+        data-root-margin="-350px 0px -350px 0px"
+      ></aside>
+    </main>
+  </section>
 {{ end }}

--- a/themes/digital.gov/layouts/events/single.html
+++ b/themes/digital.gov/layouts/events/single.html
@@ -16,77 +16,66 @@
   {{ end }}
 
 
-  <main role="main" id="main-content" class="event">
-    <article>
-      <header>
-        <div class="grid-container grid-container-desktop">
-          {{- partial "partials/core/usa-breadcrumbs.html" . -}}
-          <div class="grid-row">
-            <div class="grid-col-12" data-gh-edit-page="{{- $path -}}">
-              {{- if .Params.kicker -}}
-                <p class="kicker">{{- .Params.kicker -}}</p>
-              {{- end -}}
-              <h1>{{- .Title | markdownify -}}</h1>
-              {{/* Deck */}}
-              {{- if .Params.deck -}}
-                <div class="deck">{{- .Params.deck | markdownify -}}</div>
-              {{- end -}}
+  <section class="grid-container-desktop">
+    {{- partial "partials/core/usa-breadcrumbs.html" . -}}
 
 
-              <p class="datetime">
-                <svg
-                  class="usa-icon dg-icon dg-icon--standard margin-bottom-05"
-                  aria-hidden="true"
-                  focusable="false"
-                >
-                  <use
-                    xlink:href="{{ "uswds/img/sprite.svg#calendar_today" | relURL }}"
-                  ></use>
-                </svg>
-                {{ with .Date }}
-                  {{ . | dateFormat "Monday, January 02, 2006" }}
-                {{ end }}
-                <span>
-                  {{- with .Date -}}
-                    {{- . | dateFormat "3:04 PM" -}}
-                  {{- end }}
-                  –
-                  {{ with .Params.end_date -}}
-                    {{- . | dateFormat "3:04 PM ET" -}}
-                  {{- end -}}
-                </span>
-              </p>
+    <header class="event" data-gh-edit-page="{{- $path -}}">
+      {{- if .Params.kicker -}}
+        <p class="kicker">{{- .Params.kicker -}}</p>
+      {{- end -}}
+      <h1>{{- .Title | markdownify -}}</h1>
 
-              {{- if .Params.host -}}
-                <p class="host">
-                  Hosted by Digital.gov and the
-                  {{ .Params.host }}
-                </p>
-              {{- end -}}
+      {{- if .Params.deck -}}
+        <div class="deck">{{- .Params.deck | markdownify -}}</div>
+      {{- end -}}
 
-            </div>
-          </div>
-        </div>
-      </header>
 
+      <p class="datetime">
+        <svg
+          class="usa-icon dg-icon dg-icon--standard margin-bottom-05"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <use
+            xlink:href="{{ "uswds/img/sprite.svg#calendar_today" | relURL }}"
+          ></use>
+        </svg>
+        {{ with .Date }}
+          {{ . | dateFormat "Monday, January 02, 2006" }}
+        {{ end }}
+        <span>
+          {{- with .Date -}}
+            {{- . | dateFormat "3:04 PM" -}}
+          {{- end }}
+          –
+          {{ with .Params.end_date -}}
+            {{- . | dateFormat "3:04 PM ET" -}}
+          {{- end -}}
+        </span>
+      </p>
+
+      {{- if .Params.host -}}
+        <p class="host">
+          Hosted by Digital.gov and the
+          {{ .Params.host }}
+        </p>
+      {{- end -}}
+    </header>
+
+    <main id="main-content">
       {{/* EVENT Actions — REGISTER and Add to Calendar */}}
       {{/* If is a Future Event */}}
       {{- if eq $future_event true -}}
-        <div class="grid-container grid-container-desktop">
-          <div class="grid-row">
-            <div class="grid-col-12">
-              <div class="actions">
-                {{/* Register */}}
-                <a
-                  aria-label="Register for {{- .Params.title -}}"
-                  class="btn btn-register"
-                  href="{{- .Params.registration_url -}}"
-                  onclick="__gaTracker('send', 'event', 'outbound-article', '{{- .Params.registration_url -}}', 'REGISTER NOW');"
-                  >Register</a
-                >
-              </div>
-            </div>
-          </div>
+        <div class="actions">
+          {{/* Register */}}
+          <a
+            aria-label="Register for {{- .Params.title -}}"
+            class="btn btn-register"
+            href="{{- .Params.registration_url -}}"
+            onclick="__gaTracker('send', 'event', 'outbound-article', '{{- .Params.registration_url -}}', 'REGISTER NOW');"
+            >Register</a
+          >
         </div>
       {{- end -}}
 
@@ -112,82 +101,78 @@
       {{- end -}}
 
 
-      <section>
-        <div
-          class="grid-container grid-container-desktop"
-          data-gh-edit-page="{{- $path -}}"
-        >
-          <div class="grid-row tablet-lg:grid-gap-4">
-            <div class="grid-col-12 tablet:grid-col-9">
-              {{/* ZOOM Stage */}}
-              {{- if eq .Params.event_platform "zoom" -}}
-                {{/* If is a Future Event */}}
-                {{- if eq $future_event true -}}
-                  {{- .Render "stage-zoom" -}}
-                {{- end -}}
-              {{- end -}}
+      <section
+        class="grid-row tablet-lg:grid-gap-4 margin-bottom-4"
+        data-gh-edit-page="{{- $path -}}"
+      >
+        <div class="tablet:grid-col-9">
+          {{/* ZOOM Stage */}}
+          {{- if eq .Params.event_platform "zoom" -}}
+            {{/* If is a Future Event */}}
+            {{- if eq $future_event true -}}
+              {{- .Render "stage-zoom" -}}
+            {{- end -}}
+          {{- end -}}
 
-              {{/* Adobe Connect Stage */}}
-              {{- if eq .Params.event_platform "adobe_connect" -}}
-                {{/* If is a Future Event */}}
-                {{- if eq $future_event true -}}
-                  {{- .Render "stage-adobe_connect" -}}
-                {{- end -}}
-              {{- end -}}
+          {{/* Adobe Connect Stage */}}
+          {{- if eq .Params.event_platform "adobe_connect" -}}
+            {{/* If is a Future Event */}}
+            {{- if eq $future_event true -}}
+              {{- .Render "stage-adobe_connect" -}}
+            {{- end -}}
+          {{- end -}}
 
-              {{/* Google Stage */}}
-              {{- if eq .Params.event_platform "google" -}}
-                {{/* If is a Future Event */}}
-                {{- if eq $future_event true -}}
-                  {{- .Render "stage-google" -}}
-                {{- end -}}
-              {{- end -}}
+          {{/* Google Stage */}}
+          {{- if eq .Params.event_platform "google" -}}
+            {{/* If is a Future Event */}}
+            {{- if eq $future_event true -}}
+              {{- .Render "stage-google" -}}
+            {{- end -}}
+          {{- end -}}
 
-              {{/* Content */}}
-              <div class="content usa-prose">
-                {{- .Content -}}
-              </div>
-
-              {{- partial "core/gh-commit-info.html" . -}}
-
-              {{/* Touchpoints Form */}}
-              {{- partial "core/touchpoints-form.html" . -}}
-            </div>
-
-            <div class="dg-sidebar grid-col-12 tablet:grid-col-3">
-              {{/* Authors */}}
-              {{- if .Params.authors -}}
-                <h4>In this talk</h4>
-                {{- partial "core/get_authors.html" . -}}
-              {{- end -}}
-
-              {{- if eq .Params.event_platform "youtube_live" -}}
-                {{- if eq $future_event true -}}
-                  <div class="actions actions-stacked">
-                    {{/* Register */}}
-                    <a
-                      aria-label="Register for {{- .Params.title -}}"
-                      class="btn btn-register"
-                      href="{{- .Params.registration_url -}}"
-                      onclick="__gaTracker('send', 'event', 'outbound-article', '{{- .Params.registration_url -}}', 'REGISTER NOW');"
-                      >Register</a
-                    >
-                  </div>
-                {{- end -}}
-              {{- end -}}
-
-              {{/* Related Communities and Services */}}
-              {{- partial "core/get_related.html" . -}}
-
-              {{/* Topics */}}
-              {{- partial "core/list-topics.html" . -}}
-
-              {{/* Share Tools */}}
-              {{- partial "core/get_sharetools.html" . -}}
-            </div>
+          {{/* Content */}}
+          <div class="content usa-prose">
+            {{- .Content -}}
           </div>
+
+          {{- partial "core/gh-commit-info.html" . -}}
+
+          {{/* Touchpoints Form */}}
+          {{- partial "core/touchpoints-form.html" . -}}
         </div>
+
+        <aside class="dg-sidebar tablet:grid-col-3">
+          {{/* Authors */}}
+          {{- if .Params.authors -}}
+            <h4>In this talk</h4>
+            {{- partial "core/get_authors.html" . -}}
+          {{- end -}}
+
+          {{- if eq .Params.event_platform "youtube_live" -}}
+            {{- if eq $future_event true -}}
+              <div class="actions actions-stacked">
+                {{/* Register */}}
+                <a
+                  aria-label="Register for {{- .Params.title -}}"
+                  class="btn btn-register"
+                  href="{{- .Params.registration_url -}}"
+                  onclick="__gaTracker('send', 'event', 'outbound-article', '{{- .Params.registration_url -}}', 'REGISTER NOW');"
+                  >Register</a
+                >
+              </div>
+            {{- end -}}
+          {{- end -}}
+
+          {{/* Related Communities and Services */}}
+          {{- partial "core/get_related.html" . -}}
+
+          {{/* Topics */}}
+          {{- partial "core/list-topics.html" . -}}
+
+          {{/* Share Tools */}}
+          {{- partial "core/get_sharetools.html" . -}}
+        </aside>
       </section>
-    </article>
-  </main>
+    </main>
+  </section>
 {{- end -}}

--- a/themes/digital.gov/layouts/events/single.html
+++ b/themes/digital.gov/layouts/events/single.html
@@ -63,116 +63,117 @@
       {{- end -}}
     </header>
 
-    <main id="main-content">
-      {{/* EVENT Actions — REGISTER and Add to Calendar */}}
-      {{/* If is a Future Event */}}
-      {{- if eq $future_event true -}}
-        <div class="actions">
-          {{/* Register */}}
-          <a
-            aria-label="Register for {{- .Params.title -}}"
-            class="btn btn-register"
-            href="{{- .Params.registration_url -}}"
-            onclick="__gaTracker('send', 'event', 'outbound-article', '{{- .Params.registration_url -}}', 'REGISTER NOW');"
-            >Register</a
-          >
-        </div>
-      {{- end -}}
-
-      {{/* EVENT Stages —
-        Depending on the type of event, different "event stages" appear on the page.
-        - Only for upcomming events
-        ====================================
-      */}}
-
-      {{/* YouTube LIVE Stage */}}
-      {{- if eq .Params.event_platform "youtube_live" -}}
+    <section
+      class="grid-row tablet-lg:grid-gap-4 margin-bottom-4"
+      data-gh-edit-page="{{- $path -}}"
+    >
+      <main id="main-content" class="tablet-lg:grid-col-9">
+        {{/* EVENT Actions — REGISTER and Add to Calendar */}}
         {{/* If is a Future Event */}}
         {{- if eq $future_event true -}}
-          {{- .Render "stage-youtube-live" -}}
+          <div class="actions">
+            {{/* Register */}}
+            <a
+              aria-label="Register for {{- .Params.title -}}"
+              class="btn btn-register"
+              href="{{- .Params.registration_url -}}"
+              onclick="__gaTracker('send', 'event', 'outbound-article', '{{- .Params.registration_url -}}', 'REGISTER NOW');"
+              >Register</a
+            >
+          </div>
         {{- end -}}
 
-      {{- end -}}
+        {{/* EVENT Stages —
+          Depending on the type of event, different "event stages" appear on the page.
+          - Only for upcomming events
+          ====================================
+        */}}
 
-      {{/* PAST EVENT / Video  -------------------- */}}
-      {{/* If is NOT a Future Event (Past event) */}}
-      {{- if eq $future_event false -}}
-        {{- .Render "stage-youtube" -}}
-      {{- end -}}
-
-
-      <section
-        class="grid-row tablet-lg:grid-gap-4 margin-bottom-4"
-        data-gh-edit-page="{{- $path -}}"
-      >
-        <div class="tablet:grid-col-9">
-          {{/* ZOOM Stage */}}
-          {{- if eq .Params.event_platform "zoom" -}}
-            {{/* If is a Future Event */}}
-            {{- if eq $future_event true -}}
-              {{- .Render "stage-zoom" -}}
-            {{- end -}}
+        {{/* YouTube LIVE Stage */}}
+        {{- if eq .Params.event_platform "youtube_live" -}}
+          {{/* If is a Future Event */}}
+          {{- if eq $future_event true -}}
+            {{- .Render "stage-youtube-live" -}}
           {{- end -}}
 
-          {{/* Adobe Connect Stage */}}
-          {{- if eq .Params.event_platform "adobe_connect" -}}
-            {{/* If is a Future Event */}}
-            {{- if eq $future_event true -}}
-              {{- .Render "stage-adobe_connect" -}}
-            {{- end -}}
-          {{- end -}}
+        {{- end -}}
 
-          {{/* Google Stage */}}
-          {{- if eq .Params.event_platform "google" -}}
-            {{/* If is a Future Event */}}
-            {{- if eq $future_event true -}}
-              {{- .Render "stage-google" -}}
-            {{- end -}}
-          {{- end -}}
+        {{/* PAST EVENT / Video  -------------------- */}}
+        {{/* If is NOT a Future Event (Past event) */}}
+        {{- if eq $future_event false -}}
+          {{- .Render "stage-youtube" -}}
+        {{- end -}}
 
-          {{/* Content */}}
-          <div class="content usa-prose">
-            {{- .Content -}}
+
+        <section>
+          <div>
+            {{/* ZOOM Stage */}}
+            {{- if eq .Params.event_platform "zoom" -}}
+              {{/* If is a Future Event */}}
+              {{- if eq $future_event true -}}
+                {{- .Render "stage-zoom" -}}
+              {{- end -}}
+            {{- end -}}
+
+            {{/* Adobe Connect Stage */}}
+            {{- if eq .Params.event_platform "adobe_connect" -}}
+              {{/* If is a Future Event */}}
+              {{- if eq $future_event true -}}
+                {{- .Render "stage-adobe_connect" -}}
+              {{- end -}}
+            {{- end -}}
+
+            {{/* Google Stage */}}
+            {{- if eq .Params.event_platform "google" -}}
+              {{/* If is a Future Event */}}
+              {{- if eq $future_event true -}}
+                {{- .Render "stage-google" -}}
+              {{- end -}}
+            {{- end -}}
+
+            {{/* Content */}}
+            <div class="content usa-prose">
+              {{- .Content -}}
+            </div>
+
+            {{- partial "core/gh-commit-info.html" . -}}
+
+            {{/* Touchpoints Form */}}
+            {{- partial "core/touchpoints-form.html" . -}}
           </div>
+        </section>
+      </main>
+      <aside class="dg-sidebar tablet-lg:grid-col-3">
+        {{/* Authors */}}
+        {{- if .Params.authors -}}
+          <h4>In this talk</h4>
+          {{- partial "core/get_authors.html" . -}}
+        {{- end -}}
 
-          {{- partial "core/gh-commit-info.html" . -}}
-
-          {{/* Touchpoints Form */}}
-          {{- partial "core/touchpoints-form.html" . -}}
-        </div>
-
-        <aside class="dg-sidebar tablet:grid-col-3">
-          {{/* Authors */}}
-          {{- if .Params.authors -}}
-            <h4>In this talk</h4>
-            {{- partial "core/get_authors.html" . -}}
+        {{- if eq .Params.event_platform "youtube_live" -}}
+          {{- if eq $future_event true -}}
+            <div class="actions actions-stacked">
+              {{/* Register */}}
+              <a
+                aria-label="Register for {{- .Params.title -}}"
+                class="btn btn-register"
+                href="{{- .Params.registration_url -}}"
+                onclick="__gaTracker('send', 'event', 'outbound-article', '{{- .Params.registration_url -}}', 'REGISTER NOW');"
+                >Register</a
+              >
+            </div>
           {{- end -}}
+        {{- end -}}
 
-          {{- if eq .Params.event_platform "youtube_live" -}}
-            {{- if eq $future_event true -}}
-              <div class="actions actions-stacked">
-                {{/* Register */}}
-                <a
-                  aria-label="Register for {{- .Params.title -}}"
-                  class="btn btn-register"
-                  href="{{- .Params.registration_url -}}"
-                  onclick="__gaTracker('send', 'event', 'outbound-article', '{{- .Params.registration_url -}}', 'REGISTER NOW');"
-                  >Register</a
-                >
-              </div>
-            {{- end -}}
-          {{- end -}}
+        {{/* Related Communities and Services */}}
+        {{- partial "core/get_related.html" . -}}
 
-          {{/* Related Communities and Services */}}
-          {{- partial "core/get_related.html" . -}}
+        {{/* Topics */}}
+        {{- partial "core/list-topics.html" . -}}
 
-          {{/* Topics */}}
-          {{- partial "core/list-topics.html" . -}}
-
-          {{/* Share Tools */}}
-          {{- partial "core/get_sharetools.html" . -}}
-        </aside>
-      </section>
-    </main>
+        {{/* Share Tools */}}
+        {{- partial "core/get_sharetools.html" . -}}
+      </aside>
+    </section>
   </section>
 {{- end -}}

--- a/themes/digital.gov/layouts/news/single.html
+++ b/themes/digital.gov/layouts/news/single.html
@@ -5,98 +5,70 @@
     {{ $path = .Path }}
   {{ end }}
 
-
-  <main role="main" id="main-content">
-    {{ partial "core/blog-date-warning.html" . }}
-    <article
-      {{ if .Params.short_url -}}
-        data-short_url="{{- .Params.short_url -}}"
+  {{ partial "core/blog-date-warning.html" . }}
+  <article class="grid-container-desktop">
+    {{- partial "partials/core/usa-breadcrumbs.html" . -}}
+    <header data-gh-edit-page="{{- $path -}}">
+      {{- if .Params.kicker -}}
+        <p class="kicker">{{- .Params.kicker -}}</p>
       {{- end -}}
-    >
-      <header>
-        <div
-          class="grid-container grid-container-desktop"
-          data-gh-edit-page="{{- $path -}}"
-        >
-          {{- partial "partials/core/usa-breadcrumbs.html" . -}}
-          <div class="grid-row">
-            <div class="grid-col-12">
-              {{- if .Params.kicker -}}
-                <p class="kicker">{{- .Params.kicker -}}</p>
-              {{- end -}}
-              {{/* Page Title */}}
-              <h1>{{- .Title | markdownify -}}</h1>
+      {{/* Page Title */}}
+      <h1>{{- .Title | markdownify -}}</h1>
 
-              {{/* Deck */}}
-              {{- if .Params.deck -}}
-                <div class="deck">{{- .Params.deck | markdownify -}}</div>
-              {{- end -}}
+      {{/* Deck */}}
+      {{- if .Params.deck -}}
+        <div class="deck">{{- .Params.deck | markdownify -}}</div>
+      {{- end -}}
 
-              {{- partial "core/get_authors_short.html" . -}}
+      {{- partial "core/get_authors_short.html" . -}}
 
 
-              <div class="meta">
-                <div class="date">
-                  <span title="{{- .Title | markdownify -}} "
-                    >{{- .Date.Format "Jan _2, 2006" -}}</span
-                  >
-                </div>
-              </div>
-            </div>
+      <div class="meta">
+        <div class="date">
+          <span title="{{- .Title | markdownify -}} "
+            >{{- .Date.Format "Jan _2, 2006" -}}</span
+          >
+        </div>
+      </div>
+    </header>
+
+    <section class="grid-row tablet-lg:grid-gap-6">
+      <main
+        id="main-content"
+        class="tablet-lg:grid-col-9"
+        data-gh-edit-page="{{- $path -}}"
+      >
+        <div class="content usa-prose">
+          {{- .Content -}}
+        </div>
+
+        {{- partial "core/gh-commit-info.html" . -}}
+        {{- partial "core/touchpoints-form.html" . -}}
+      </main>
+
+      <aside class="dg-sidebar tablet-lg:grid-col-3">
+        {{- partial "core/get_authors.html" . -}}
+
+
+        <div class="meta">
+          <div class="date">
+            <span title="{{- .Title | markdownify -}} "
+              >{{- .Date.Format "Jan _2, 2006" -}}
+            </span>
           </div>
         </div>
-      </header>
 
-      <section>
-        <div
-          class="grid-container grid-container-desktop"
-          data-gh-edit-page="{{- $path -}}"
-        >
-          <div class="grid-row tablet-lg:grid-gap-6">
-            <div class="grid-col-12 tablet-lg:grid-col-9 tablet-lg:order-last">
-              {{/* Content */}}
-              <div class="content usa-prose">
-                {{- .Content -}}
-              </div>
+        {{/* Related Communities and Services */}}
+        {{- partial "core/get_related.html" . -}}
 
-              {{- partial "core/gh-commit-info.html" . -}}
+        {{/* Topics */}}
+        {{- partial "core/list-topics.html" . -}}
 
-              {{/* Touchpoints Form */}}
-              {{- partial "core/touchpoints-form.html" . -}}
-            </div>
-
-            <div class="dg-sidebar grid-col-12 tablet-lg:grid-col-3">
-              {{/* Authors */}}
-              {{- partial "core/get_authors.html" . -}}
-
-
-              <div class="meta">
-                {{/* Date */}}
-                <div class="date">
-                  <span title="{{- .Title | markdownify -}} "
-                    >{{- .Date.Format "Jan _2, 2006" -}}
-                  </span>
-                </div>
-              </div>
-
-              {{/* Last updated */}}
-              {{/* {{- partial "last-updated.html" . -}} */}}
-              {{/* Related Communities and Services */}}
-              {{- partial "core/get_related.html" . -}}
-
-              {{/* Topics */}}
-              {{- partial "core/list-topics.html" . -}}
-
-              {{/* Share Tools */}}
-              {{- partial "core/get_sharetools.html" . -}}
-
-            </div>
-          </div>
-        </div>
-      </section>
-    </article>
-  </main>
+        {{/* Share Tools */}}
+        {{- partial "core/get_sharetools.html" . -}}
+      </aside>
+    </section>
+  </article>
 
   {{- partial "core/overlay.html" . -}}
-
 {{- end -}}

--- a/themes/digital.gov/layouts/news/single.html
+++ b/themes/digital.gov/layouts/news/single.html
@@ -12,10 +12,8 @@
       {{- if .Params.kicker -}}
         <p class="kicker">{{- .Params.kicker -}}</p>
       {{- end -}}
-      {{/* Page Title */}}
       <h1>{{- .Title | markdownify -}}</h1>
 
-      {{/* Deck */}}
       {{- if .Params.deck -}}
         <div class="deck">{{- .Params.deck | markdownify -}}</div>
       {{- end -}}

--- a/themes/digital.gov/layouts/partials/core/blog-date-warning.html
+++ b/themes/digital.gov/layouts/partials/core/blog-date-warning.html
@@ -1,7 +1,7 @@
 {{- $fiveYearsFromToday := now.AddDate -5 0 0 -}}
 {{- if lt .Date $fiveYearsFromToday -}}
   <div
-    class="usa-alert usa-alert--warning dg-alert dg-alert--out-of-date"
+    class="usa-alert usa-alert--warning dg-alert dg-alert--out-of-date margin-top-0"
     role="alert"
   >
     <div class="usa-alert__body">

--- a/themes/digital.gov/layouts/resources/single.html
+++ b/themes/digital.gov/layouts/resources/single.html
@@ -4,48 +4,41 @@
   {{ else }}
     {{ $path = .Path }}
   {{ end }}
-  <main role="main" id="main-content">
-    <article class="grid-container grid-container-desktop">
-      {{- partial "partials/core/usa-breadcrumbs.html" . -}}
-      <header>
-        <div data-gh-edit-page="{{- $path -}}">
-          {{- if .Params.kicker -}}
-            <p class="kicker">{{- .Params.kicker -}}</p>
-          {{- end -}}
-          {{/* Page Title */}}
-          <h1>{{- .Title | markdownify -}}</h1>
+  <article id="main-content" class="grid-container-desktop">
+    {{- partial "partials/core/usa-breadcrumbs.html" . -}}
+    <header data-gh-edit-page="{{- $path -}}">
+      {{- if .Params.kicker -}}
+        <p class="kicker">{{- .Params.kicker -}}</p>
+      {{- end -}}
 
-          {{/* Deck */}}
-          {{- if .Params.deck -}}
-            <div class="deck">{{- .Params.deck | markdownify -}}</div>
-          {{- end -}}
+
+      <h1>{{- .Title | markdownify -}}</h1>
+
+      {{- if .Params.deck -}}
+        <div class="deck">{{- .Params.deck | markdownify -}}</div>
+      {{- end -}}
+    </header>
+
+    <section class="usa-in-page-nav-container">
+      <main data-gh-edit-page="{{- $path -}}">
+        <div class="content usa-prose">
+          {{- .Content -}}
         </div>
-      </header>
 
-      <div class="usa-in-page-nav-container">
-        <div data-gh-edit-page="{{- $path -}}">
-          {{/* Content */}}
-          <div class="content usa-prose">
-            {{- .Content -}}
-          </div>
-
-          {{- partial "core/gh-commit-info.html" . -}}
-
-          {{/* Touchpoints Form */}}
-          {{- partial "core/touchpoints-form.html" . -}}
+        {{- partial "core/gh-commit-info.html" . -}}
+        {{- partial "core/touchpoints-form.html" . -}}
+      </main>
+      <aside
+        class="dg-sidebar usa-in-page-nav"
+        data-title-heading-level="h4"
+        data-root-margin="-350px 0px -350px 0px"
+        aria-label="Related content"
+      >
+        <div class="dg-related-items" data-related-items>
+          {{/* Related Communities and Services */}}
+          {{- partial "core/get_related.html" . -}}
         </div>
-        <aside
-          class="dg-sidebar usa-in-page-nav"
-          data-title-heading-level="h4"
-          data-root-margin="-350px 0px -350px 0px"
-          aria-label="Related content"
-        >
-          <div class="dg-related-items" data-related-items>
-            {{/* Related Communities and Services */}}
-            {{- partial "core/get_related.html" . -}}
-          </div>
-        </aside>
-      </div>
-    </article>
-  </main>
+      </aside>
+    </section>
+  </article>
 {{- end -}}

--- a/themes/digital.gov/layouts/services/single.html
+++ b/themes/digital.gov/layouts/services/single.html
@@ -4,52 +4,45 @@
   {{ else }}
     {{ $path = .Path }}
   {{ end }}
-  <main role="main" id="main-content">
-    <article class="grid-container grid-container-desktop">
-      <header>
-        <div data-gh-edit-page="{{- $path -}}">
-          {{- if .Parent -}}
-            {{- partial "partials/core/usa-breadcrumbs.html" . -}}
-          {{- end -}}
+  <section id="main-content" class="grid-container-desktop">
+    {{- if .Parent -}}
+      {{- partial "partials/core/usa-breadcrumbs.html" . -}}
+    {{- end -}}
+    <header data-gh-edit-page="{{- $path -}}">
+      {{- if .Params.kicker -}}
+        <p class="kicker">{{- .Params.kicker -}}</p>
+      {{- end -}}
 
-          {{- if .Params.kicker -}}
-            <p class="kicker">{{- .Params.kicker -}}</p>
-          {{- end -}}
-          {{/* Page Title */}}
-          <h1>{{- .Title | markdownify -}}</h1>
 
-          {{/* Deck */}}
-          {{- if .Params.summary -}}
-            <div class="deck">{{- .Params.summary | markdownify -}}</div>
-          {{- end -}}
+      <h1>{{- .Title | markdownify -}}</h1>
 
-          {{- if .Params.source_url -}}
-            <p>
-              <a
-                href="{{- .Params.source_url -}}"
-                title="Go to: {{- .Title | markdownify -}}"
-                >{{- .Params.source_url -}}</a
-              >
-            </p>
-          {{- end -}}
+      {{- if .Params.summary -}}
+        <div class="deck">{{- .Params.summary | markdownify -}}</div>
+      {{- end -}}
+
+      {{- if .Params.source_url -}}
+        <p>
+          <a
+            href="{{- .Params.source_url -}}"
+            title="Go to: {{- .Title | markdownify -}}"
+            >{{- .Params.source_url -}}</a
+          >
+        </p>
+      {{- end -}}
+    </header>
+
+    <section class="usa-in-page-nav-container">
+      <main>
+        <div class="content" data-gh-edit-page="{{- $path -}}">
+          {{- .Content -}}
         </div>
-      </header>
-
-      <div class="usa-in-page-nav-container">
-        <aside
-          class="usa-in-page-nav"
-          data-title-heading-level="h3"
-          data-root-margin="-350px 0px -350px 0px"
-        ></aside>
-        <div>
-          {{/* Content */}}
-          <div class="content" data-gh-edit-page="{{- $path -}}">
-            {{- .Content -}}
-          </div>
-
-          {{- partial "core/gh-commit-info.html" . -}}
-        </div>
-      </div>
-    </article>
-  </main>
+        {{- partial "core/gh-commit-info.html" . -}}
+      </main>
+      <aside
+        class="usa-in-page-nav"
+        data-title-heading-level="h3"
+        data-root-margin="-350px 0px -350px 0px"
+      ></aside>
+    </section>
+  </section>
 {{- end -}}

--- a/themes/digital.gov/src/scss/new/_article.scss
+++ b/themes/digital.gov/src/scss/new/_article.scss
@@ -104,3 +104,14 @@ article {
     }
   }
 }
+
+// hides authors list on desktop, shows on mobile
+// header {
+//   .authors-list-short {
+//     @include u-display("flex");
+
+//     @include at-media("tablet-lg") {
+//       @include u-display("none");
+//     }
+//   }
+// }

--- a/themes/digital.gov/src/scss/new/_article.scss
+++ b/themes/digital.gov/src/scss/new/_article.scss
@@ -104,14 +104,3 @@ article {
     }
   }
 }
-
-// hides authors list on desktop, shows on mobile
-// header {
-//   .authors-list-short {
-//     @include u-display("flex");
-
-//     @include at-media("tablet-lg") {
-//       @include u-display("none");
-//     }
-//   }
-// }


### PR DESCRIPTION
## Summary
Refactor template markup into a re-usable two column template for several content pages.

### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-two-column-template/)

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

Created new `two-column-baseof.html` to replace template markup in multiple files.

- removed unnecessary `<div>'s`
- removed grid styles

Refactored to use a consistent markup structure:

```
section.grid-container-desktop
  nav.usa-breadcrumb
  header
  section.usa-in-page-nav-container || section.grid-row.tablet-lg:4
    main#main-content
    aside.dg-sidebar.usa-in-page-nav
```

**templates updated**

| template                | two col layout     |
| ----------------------- | ------------------ |
| services/single.html    | in page navigation |
| default/list.html       | in page navigation |
| default/single.html     | in page navigation |
| resources/single.html   | in page navigation |
| communities/single.html | in page navigation |
| events/single.html      | grid classes       |
| news/single.html        | grid classes       |


### How To Test

1. First Step
2. Second Step
3. Third Step

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
