### PR TITLE
Convert acquisition topic page to short version

### DIFF
--- a/content/topics/acquisition/_index.md
+++ b/content/topics/acquisition/_index.md
@@ -8,7 +8,7 @@ slug: "acquisition"
 title: "Acquisition"
 deck: "Learn about how to acquire supplies and services."
 
-summary: "Federal acquisition is governed by a complex web of laws, regulations, and policies. Following acquisition best practices helps minimize risk and improve the process. It  can lead to the selection of qualified vendors who deliver the best value for the government and the public — reducing risk and wasteful spending and improving outcomes for the public."
+summary: "Federal acquisition is governed by a complex web of laws, regulations, and policies. It can lead to the selection of qualified vendors who deliver the best value for the government and the public — reducing risk and wasteful spending, and improving outcomes for the public."
 
 # Weight
 weight: 2

--- a/content/topics/acquisition/_index.md
+++ b/content/topics/acquisition/_index.md
@@ -21,7 +21,7 @@ legislation:
 # Featured resource to at the top of the page
 featured_resources:
   resources:
-    - link: "tktk"
+    - link: "techfar-hub-get-started"
 
 # Featured community to display at the top of the page
 featured_communities:

--- a/content/topics/acquisition/_index.md
+++ b/content/topics/acquisition/_index.md
@@ -6,14 +6,23 @@ slug: "acquisition"
 
 # Topic Title
 title: "Acquisition"
+deck: "Learn about how to acquire supplies and services."
 
-# description — keep it short and clear
-summary: ""
-
+summary: "Federal acquisition is governed by a complex web of laws, regulations, and policies. Following acquisition best practices helps minimize risk and improve the process. It  can lead to the selection of qualified vendors who deliver the best value for the government and the public — reducing risk and wasteful spending and improving outcomes for the public."
 
 # Weight
-weight: 1
+weight: 2
 
-# For more information on managing topics,
-# see https://github.com/GSA/digitalgov.gov/wiki
----
+# Set the legislation card title and link
+legislation:
+  title: "Federal Acquisition Regulation"
+  link: "https://www.acquisition.gov/browse/index/far"
+
+# Featured resource to at the top of the page
+featured_resources:
+  resources:
+    - link: "tktk"
+
+# Featured community to display at the top of the page
+featured_communities:
+  - "web-managers-forum"

--- a/content/topics/acquisition/_index.md
+++ b/content/topics/acquisition/_index.md
@@ -21,8 +21,9 @@ legislation:
 # Featured resource to at the top of the page
 featured_resources:
   resources:
-    - link: "techfar-hub-get-started"
+    - link: "/resources/techfar-hub-get-started"
 
 # Featured community to display at the top of the page
 featured_communities:
   - "web-managers-forum"
+---


### PR DESCRIPTION
## Summary

Uses short version of topic template. Converts topic page to curated collection. 

### Preview

https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/bc-add-acquisition-topic-page/topics/acquisition/

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

1. First Step
2. Second Step
3. Third Step

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
