### PR TITLE
Convert information collection topic page to topic collection

### DIFF
--- a/content/topics/information-collection/_index.md
+++ b/content/topics/information-collection/_index.md
@@ -6,12 +6,29 @@ slug: "information-collection"
 
 # Topic Title
 title: "Information collection"
+deck: "The process of gathering and documenting data from various sources to fulfill a specific purpose"
 
-# description — keep it short and clear
-summary: ""
+summary: "Information collection is the first step of many when conducting research, and it can involve diverse methods and technologies depending on the context. 
+
+It’s also the process by which federal agencies gather or ask for information about the people who need our services or want to participate in our communities. Collections may require the use of complex forms or sensitive questions, including personally identifiable information. 
+
+Make sure you follow best practices when collecting information to protect the identity of your users and respect their time."
 
 # Weight
-weight: 1
-# For more information on managing topics,
-# see https://github.com/GSA/digitalgov.gov/wiki
+weight: 2
+
+# Set the legislation card title and link
+legislation:
+  title: "Paperwork Reduction Act (44 U.S.C. Chapter 35, PDF, 451 KB, 47 Pages)"
+  link: "https://www.gpo.gov/fdsys/pkg/USCODE-2011-title44/pdf/USCODE-2011-title44-chap35.pdf"
+
+# Featured resource to at the top of the page
+featured_resources:
+  resources:
+    - link: "/guide-paperwork-reduction-act"
+
+# Featured community to display at the top of the page
+featured_communities:
+  - "web-managers-forum"
+  - "user-experience"
 ---


### PR DESCRIPTION
## Summary

Uses short version of template. Converts information collection topic page to curated collection


### Preview

https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/bc-convert-information-collection-topic-page/topics/information-collection/

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

1. First Step
2. Second Step
3. Third Step

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
