### PR TITLE
Convert multimedia topic page to topic collection

### DIFF
--- a/content/topics/multimedia/_index.md
+++ b/content/topics/multimedia/_index.md
@@ -8,7 +8,7 @@ slug: "multimedia"
 title: "Multimedia"
 deck: "Use a combination of media formats to create impactful experiences."
 
-summary: "As a form of communication, multimedia involves a combination of content forms, such as text, audio, video, graphics, and animation. Multimedia approaches work best when they are created and distributed to deliver a well-rounded, interactive, and informative user experience."
+summary: "As a form of communication, multimedia involves a combination of content forms, like text, audio, video, graphics, and animation. Multimedia approaches work best when they are created and distributed to deliver a well-rounded, interactive, and informative user experience."
 
 # Weight
 weight: 2

--- a/content/topics/multimedia/_index.md
+++ b/content/topics/multimedia/_index.md
@@ -8,7 +8,7 @@ slug: "multimedia"
 title: "Multimedia"
 deck: "Use a combination of media formats to create impactful experiences."
 
-summary: "Multimedia approaches  involve a combination of text, audio, video, graphics, animation, and more. Rather than producing these things individually, multimedia approaches work best when they are created and distributed in concert to deliver a well-rounded and informative user experience."
+summary: "As a form of communication, multimedia involves a combination of content forms, such as text, audio, video, graphics, and animation. Multimedia approaches work best when they are created and distributed to deliver a well-rounded, interactive, and informative user experience."
 
 # Weight
 weight: 2

--- a/content/topics/multimedia/_index.md
+++ b/content/topics/multimedia/_index.md
@@ -14,9 +14,6 @@ summary: "Multimedia approaches  involve a combination of text, audio, video, gr
 weight: 2
 
 # Set the legislation card title and link
-legislation:
-  title: ""
-  link: ""
 
 # Featured resource to at the top of the page
 featured_resources:

--- a/content/topics/multimedia/_index.md
+++ b/content/topics/multimedia/_index.md
@@ -6,14 +6,25 @@ slug: "multimedia"
 
 # Topic Title
 title: "Multimedia"
+deck: "Use a combination of media formats to create impactful experiences."
 
-# description — keep it short and clear
-summary: ""
-
+summary: "Multimedia approaches  involve a combination of text, audio, video, graphics, animation, and more. Rather than producing these things individually, multimedia approaches work best when they are created and distributed in concert to deliver a well-rounded and informative user experience."
 
 # Weight
-weight: 1
+weight: 2
 
-# For more information on managing topics,
-# see https://github.com/GSA/digitalgov.gov/wiki
+# Set the legislation card title and link
+legislation:
+  title: ""
+  link: ""
+
+# Featured resource to at the top of the page
+featured_resources:
+  resources:
+    - link: ""
+
+# Featured community to display at the top of the page
+featured_communities:
+  - "communicators"
+  - "social-media"
 ---


### PR DESCRIPTION
## Summary

Uses short version of template. Converts multimedia topic page to curated collection. No direct ties to legislation, so leaving that field blank. 


### Preview

https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/bc-convert-multimedia-topic-page/topics/multimedia/

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

1. First Step
2. Second Step
3. Third Step

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
