### PR TITLE
Convert podcast topic page to topic collection

### DIFF
--- a/content/topics/podcast/_index.md
+++ b/content/topics/podcast/_index.md
@@ -15,11 +15,6 @@ Use podcasts to foster transparency, build trust, and inject a bit of humanity i
 # Weight
 weight: 2
 
-# Set the legislation card title and link
-legislation:
-  title: ""
-  link: ""
-
 # Featured resource to at the top of the page
 featured_resources:
   resources:

--- a/content/topics/podcast/_index.md
+++ b/content/topics/podcast/_index.md
@@ -6,14 +6,26 @@ slug: "podcast"
 
 # Topic Title
 title: "Podcast"
+deck: "Use podcasts to offer pre-recorded content your users can listen to anytime, anywhere."
 
-# description — keep it short and clear
-summary: ""
+summary: "Podcasts enable government agencies to connect with the public in a fresh, accessible way. More informal than press releases, podcasts can offer digestible insights into government work. For example, consider demystifying complex policies through engaging interviews, humanizing experts through storytelling, and addressing public concerns in candid conversations. 
 
+Use podcasts to foster transparency, build trust, and inject a bit of humanity into the public’s perception of government."
 
 # Weight
-weight: 1
+weight: 2
 
-# For more information on managing topics,
-# see https://github.com/GSA/digitalgov.gov/wiki
+# Set the legislation card title and link
+legislation:
+  title: ""
+  link: ""
+
+# Featured resource to at the top of the page
+featured_resources:
+  resources:
+    - link: "/how-to-start-and-sustain-a-federal-podcast"
+
+# Featured community to display at the top of the page
+featured_communities:
+  - "web-managers-forum"
 ---


### PR DESCRIPTION
## Summary

Uses short version of template. Converts podcast topic page to curated collection. No direct ties to legislation, so leaving that field blank.


### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/bc-convert-podcast-topic-page/topics/podcast/)

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

1. First Step
2. Second Step
3. Third Step

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
