### PR TITLE
Convert privacy topic page to topic collection

### DIFF
--- a/content/topics/privacy/_index.md
+++ b/content/topics/privacy/_index.md
@@ -8,7 +8,7 @@ slug: "privacy"
 title: "Privacy"
 deck: "As agencies carry out their diverse missions, they must also respect and protect personally identifiable information (PII)."
 
-summary: "For individuals to trust in government institutions, they need to know that their personal information is secure, and will be used only for legitimate purposes. By following federal rules and regulations regarding the collection, use, and disclosure of personal information, agencies can mitigate risks to the public."
+summary: "For the public to trust government institutions, they need to know that their personal information is secure, and will be used only for legitimate purposes. Some people may be especially vulnerable to privacy violations that can put them at risk of discrimination, harassment, or even physical harm. By following federal rules and regulations regarding the collection, use, and disclosure of personal information, agencies can mitigate risks to their customers."
 
 # Weight
 weight: 2

--- a/content/topics/privacy/_index.md
+++ b/content/topics/privacy/_index.md
@@ -8,7 +8,7 @@ slug: "privacy"
 title: "Privacy"
 deck: "As agencies carry out their diverse missions, they must also respect and protect personally identifiable information (PII)."
 
-summary: "For the public to trust government institutions, they need to know that their personal information is secure, and will be used only for legitimate purposes. Some people may be especially vulnerable to privacy violations that can put them at risk of discrimination, harassment, or even physical harm. By following federal rules and regulations regarding the collection, use, and disclosure of personal information, agencies can mitigate risks to their customers."
+summary: "For the public to trust government institutions, they need to know that their personal information is secure, and will be used only for legitimate purposes. Privacy violations can put people at risk for identity theft, fraud, discrimination, harassment, or even physical harm. By following federal rules and regulations regarding the collection, use, and disclosure of personal information, agencies can mitigate risks to their customers."
 
 # Weight
 weight: 2

--- a/content/topics/privacy/_index.md
+++ b/content/topics/privacy/_index.md
@@ -6,14 +6,26 @@ slug: "privacy"
 
 # Topic Title
 title: "Privacy"
+deck: "As agencies carry out their diverse missions, they also ensure that they honor and respect the personal information entrusted to the federal government by the public."
 
-# description — keep it short and clear
-summary: ""
+summary: "Trust in governmental and commercial institutions requires individuals to believe their personal information will be handled responsibly and used only for legitimate purposes. 
 
+Certain groups may be especially vulnerable to privacy violations that can put them at risk of discrimination, harassment, or even physical harm. Federal privacy protections can help mitigate these risks and ensure access to information and services for all individuals."
 
 # Weight
 weight: 2
 
-# For more information on managing topics,
-# see https://github.com/GSA/digitalgov.gov/wiki
+# Set the legislation card title and link
+legislation:
+  title: "Privacy Act of 1974 & various OMB memos"
+  link: "https://www.fpc.gov/resources/omb/"
+
+# Featured resource to at the top of the page
+featured_resources:
+  resources:
+    - link: "/an-introduction-to-privacy"
+
+# Featured community to display at the top of the page
+featured_communities:
+  - "web-managers-forum"
 ---

--- a/content/topics/privacy/_index.md
+++ b/content/topics/privacy/_index.md
@@ -8,7 +8,7 @@ slug: "privacy"
 title: "Privacy"
 deck: "As agencies carry out their diverse missions, they must also respect and protect personally identifiable information (PII)."
 
-summary: "For the public to trust in government institutions, they need to know that their personal information is secure and will be used only for legitimate purposes. Certain groups may be especially vulnerable to privacy violations that can put them at risk of discrimination, harassment, or even physical harm. By following federal privacy protections, agencies can help mitigate these risks to their customers."
+summary: "For individuals to trust in government institutions, they need to know that their personal information is secure, and will be used only for legitimate purposes. Certain groups may be especially vulnerable to privacy violations that can put them at risk of discrimination, harassment, or even physical harm. By following federal rules and regulations regarding the collection, use, and disclosure of personal information, agencies can mitigate these risks to the public."
 
 # Weight
 weight: 2

--- a/content/topics/privacy/_index.md
+++ b/content/topics/privacy/_index.md
@@ -6,11 +6,9 @@ slug: "privacy"
 
 # Topic Title
 title: "Privacy"
-deck: "As agencies carry out their diverse missions, they also ensure that they honor and respect the personal information entrusted to the federal government by the public."
+deck: "As agencies carry out their diverse missions, they must also respect and protect the personally identifiable information (PII) entrusted to the federal government by the public."
 
-summary: "Trust in governmental and commercial institutions requires individuals to believe their personal information will be handled responsibly and used only for legitimate purposes. 
-
-Certain groups may be especially vulnerable to privacy violations that can put them at risk of discrimination, harassment, or even physical harm. Federal privacy protections can help mitigate these risks and ensure access to information and services for all individuals."
+summary: "For individuals to trust in governmental institutions, they need to know that their personal information is secure, will be handled responsibly, and used only for legitimate purposes. Certain groups may be especially vulnerable to privacy violations that can put them at risk of discrimination, harassment, or even physical harm. Following federal privacy protections can help mitigate these risks."
 
 # Weight
 weight: 2

--- a/content/topics/privacy/_index.md
+++ b/content/topics/privacy/_index.md
@@ -8,7 +8,7 @@ slug: "privacy"
 title: "Privacy"
 deck: "As agencies carry out their diverse missions, they must also respect and protect personally identifiable information (PII)."
 
-summary: "For individuals to trust in government institutions, they need to know that their personal information is secure, and will be used only for legitimate purposes. Certain groups may be especially vulnerable to privacy violations that can put them at risk of discrimination, harassment, or even physical harm. By following federal rules and regulations regarding the collection, use, and disclosure of personal information, agencies can mitigate these risks to the public."
+summary: "For individuals to trust in government institutions, they need to know that their personal information is secure, and will be used only for legitimate purposes. By following federal rules and regulations regarding the collection, use, and disclosure of personal information, agencies can mitigate risks to the public."
 
 # Weight
 weight: 2

--- a/content/topics/privacy/_index.md
+++ b/content/topics/privacy/_index.md
@@ -6,9 +6,9 @@ slug: "privacy"
 
 # Topic Title
 title: "Privacy"
-deck: "As agencies carry out their diverse missions, they must also respect and protect the personally identifiable information (PII) entrusted to the federal government by the public."
+deck: "As agencies carry out their diverse missions, they must also respect and protect personally identifiable information (PII)."
 
-summary: "For individuals to trust in governmental institutions, they need to know that their personal information is secure, will be handled responsibly, and used only for legitimate purposes. Certain groups may be especially vulnerable to privacy violations that can put them at risk of discrimination, harassment, or even physical harm. Following federal privacy protections can help mitigate these risks."
+summary: "For the public to trust in government institutions, they need to know that their personal information is secure and will be used only for legitimate purposes. Certain groups may be especially vulnerable to privacy violations that can put them at risk of discrimination, harassment, or even physical harm. By following federal privacy protections, agencies can help mitigate these risks to their customers."
 
 # Weight
 weight: 2

--- a/content/topics/privacy/_index.md
+++ b/content/topics/privacy/_index.md
@@ -8,7 +8,7 @@ slug: "privacy"
 title: "Privacy"
 deck: "As agencies carry out their diverse missions, they must also respect and protect personally identifiable information (PII)."
 
-summary: "For the public to trust government institutions, they need to know that their personal information is secure, and will be used only for legitimate purposes. Privacy violations can put people at risk for identity theft, fraud, discrimination, harassment, or even physical harm. By following federal rules and regulations regarding the collection, use, and disclosure of personal information, agencies can mitigate risks to their customers."
+summary: "For the public to have trust in government institutions, they need to know that their personal information is secure, and will be used only for legitimate purposes. Privacy violations can put people at risk for identity theft, financial fraud, discrimination, harassment, or even physical harm. By following federal rules and regulations regarding the collection, use, and disclosure of personal information, agencies can mitigate such risks to their customers."
 
 # Weight
 weight: 2


### PR DESCRIPTION
## Summary

Uses short version of template. Converts privacy topic page to curated collection


### Preview

https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/bc-convert-privacy-topic-page/topics/privacy/

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

1. First Step
2. Second Step
3. Third Step

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
