### PR TITLE
Add alias to plain language topic page

### DIFF
--- a/content/topics/plain-language/_index.md
+++ b/content/topics/plain-language/_index.md
@@ -4,6 +4,9 @@
 
 slug: "plain-language"
 
+aliases:
+  - /topics/plain-language-community-of-practice/
+
 # Topic Title
 title: "Plain Language"
 


### PR DESCRIPTION
## Summary

This adds an alias `/topics/plain-language-community-of-practice/` to the `topics/plain-language` topic page. This should create a redirect for anyone visiting the archived `/topics/plain-language-community-of-practice/` page. 

### Preview

[Link to Preview]()

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

1. First Step
2. Second Step
3. Third Step

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
