### PR TITLE
Fixes three author/location typos

### DIFF
--- a/content/authors/amin-mehr/_index.md
+++ b/content/authors/amin-mehr/_index.md
@@ -27,7 +27,7 @@ agency_full_name: "U.S. General Services Administration"
 agency: "GSA"
 
 # Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Washington D.C."
+location: "Washington, D.C."
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "AminPIC"

--- a/content/authors/amin-mehr/_index.md
+++ b/content/authors/amin-mehr/_index.md
@@ -27,7 +27,7 @@ agency_full_name: "U.S. General Services Administration"
 agency: "GSA"
 
 # Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Wasington D.C."
+location: "Washington D.C."
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "AminPIC"

--- a/content/authors/gray-brooks/_index.md
+++ b/content/authors/gray-brooks/_index.md
@@ -32,7 +32,7 @@ agency_full_name: "General Services Administration"
 agency: "GSA"
 
 # Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Washington D.C."
+location: "Washington, D.C."
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.

--- a/content/authors/gray-brooks/_index.md
+++ b/content/authors/gray-brooks/_index.md
@@ -32,7 +32,7 @@ agency_full_name: "General Services Administration"
 agency: "GSA"
 
 # Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Wasington D.C."
+location: "Washington D.C."
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.

--- a/content/authors/joseph-castle/_index.md
+++ b/content/authors/joseph-castle/_index.md
@@ -27,7 +27,7 @@ agency_full_name: "U.S. General Services Administration"
 agency: "GSA"
 
 # Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Wasington D.C."
+location: "Washington D.C."
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "jcastle"

--- a/content/authors/joseph-castle/_index.md
+++ b/content/authors/joseph-castle/_index.md
@@ -27,7 +27,7 @@ agency_full_name: "U.S. General Services Administration"
 agency: "GSA"
 
 # Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Washington D.C."
+location: "Washington, D.C."
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "jcastle"


### PR DESCRIPTION
## Summary

Fixes typo in `location` values for three author profiles (changes `Wasington D.C.` to `Washington D.C.`)


