### PR TITLE
Footer column layout bug

### DIFF
--- a/themes/digital.gov/layouts/partials/core/footer.html
+++ b/themes/digital.gov/layouts/partials/core/footer.html
@@ -63,7 +63,6 @@
               </ul>
             </section>
           </div>
-
           <div class="mobile-lg:grid-col-6 tablet-lg:grid-col-3">
             <section
               class="usa-footer__primary-content usa-footer__primary-content--collapsible"


### PR DESCRIPTION
## Summary

Footer grid styles are overridden on desktop causing mobile grid styles to be applied on desktop viewport.
Mobile styles are fine.

> [!NOTE] 
> See https://github.com/uswds/uswds/pull/5289 for details about footer style changes

<details>
<summary>Screenshots</summary>

<img width="1679" alt="Screen Shot 2024-02-05 at 4 39 36 PM" src="https://github.com/GSA/digitalgov.gov/assets/104778659/d994a4b1-a2bf-4b6b-a604-518e48fb9325">

<img width="631" alt="Screen Shot 2024-02-05 at 4 39 44 PM" src="https://github.com/GSA/digitalgov.gov/assets/104778659/4f2ec940-1eb3-40f6-85e5-ab1111377136">

</details>

**styles.css**

Stylesheet order is correct.

```
@forward "usa-footer/src/styles";
...
@forward "usa-layout-grid/src/styles";
```


**Expected**

```css
@media (min-width: 55em) {
  .tablet-lg\:grid-col-3
{
    flex: 0 1 auto;
    width: 25%;
  }
}
```


**Actual**

```css
@media (min-width: 30em) {
  .usa-footer .grid-row .mobile-lg\:grid-col-6
{
    flex: 0 1 auto;
    width: 50%;
  }
}
```





### Preview

- [Build Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-footer-layout-bug/#newsletter-signup)


### Wayback Machine
- [Broken - 1/31/2024](https://web.archive.org/web/20240131171755/https://digital.gov/)
- [Broken - 1/30/2024](https://web.archive.org/web/20240130101916/https://digital.gov/)
- [Working - 1/29/2024](https://web.archive.org/web/20240129091941/https://digital.gov/)


<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

1. view [preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-footer-layout-bug/#newsletter-signup)
2. Styles are being applied out of order on desktop
