### PR TITLE
USA Footer: Fix style specificity issue

### DIFF
--- a/themes/digital.gov/layouts/partials/core/footer.html
+++ b/themes/digital.gov/layouts/partials/core/footer.html
@@ -63,7 +63,6 @@
               </ul>
             </section>
           </div>
-
           <div class="mobile-lg:grid-col-6 tablet-lg:grid-col-3">
             <section
               class="usa-footer__primary-content usa-footer__primary-content--collapsible"

--- a/themes/digital.gov/src/scss/new/_footer.scss
+++ b/themes/digital.gov/src/scss/new/_footer.scss
@@ -48,6 +48,7 @@ footer.usa-footer {
 
     .social-links {
       @include add-list-reset;
+      margin-top: units(1);
 
       li {
         i {

--- a/themes/digital.gov/src/scss/new/_uswds-overrides.scss
+++ b/themes/digital.gov/src/scss/new/_uswds-overrides.scss
@@ -60,7 +60,9 @@
 // overrides usa footer until 3.8.0 for uswds comes out and refactor footer into the uswds footer component.
 // turing off sylelint due to it flagging needing to be in BEM format
 /* stylelint-disable */
-.usa-footer .grid-row .mobile-lg\:grid-col-6 {
-  width: 25%;
+@media (min-width: 30em) {
+  .usa-footer .grid-row .mobile-lg\:grid-col-6 {
+      width: 25%;
+  }
 }
 /* stylelint-enable */

--- a/themes/digital.gov/src/scss/new/_uswds-overrides.scss
+++ b/themes/digital.gov/src/scss/new/_uswds-overrides.scss
@@ -57,8 +57,9 @@
   }
 }
 
-// overrides usa footer until uswds 3.8.0 comes out with a fix to refactor footer into the uswds footer component.
-// turing off sylelint due to it flagging needing to be in BEM format
+// Override USA footer until USWDS 3.8.0 is released
+// TODO: Reconfigure footer to match USWDS footer component
+// Disable stylelint BEM format check because we need the specificity.
 /* stylelint-disable */
 @include at-media("tablet-lg") {
   .usa-footer .grid-row .mobile-lg:grid-col-6 {

--- a/themes/digital.gov/src/scss/new/_uswds-overrides.scss
+++ b/themes/digital.gov/src/scss/new/_uswds-overrides.scss
@@ -62,7 +62,7 @@
 /* stylelint-disable */
 @media (min-width: 30em) {
   .usa-footer .grid-row .mobile-lg\:grid-col-6 {
-      width: 25%;
+    width: 25%;
   }
 }
 /* stylelint-enable */

--- a/themes/digital.gov/src/scss/new/_uswds-overrides.scss
+++ b/themes/digital.gov/src/scss/new/_uswds-overrides.scss
@@ -56,3 +56,11 @@
     mask-image: url("../img/svg-icons/material-icon-inventory_2.svg");
   }
 }
+
+// overrides usa footer until 3.8.0 for uswds comes out and refactor footer into the uswds footer component.
+// turing off sylelint due to it flagging needing to be in BEM format
+/* stylelint-disable */
+.usa-footer .grid-row .mobile-lg\:grid-col-6 {
+  width: 25%;
+}
+/* stylelint-enable */

--- a/themes/digital.gov/src/scss/new/_uswds-overrides.scss
+++ b/themes/digital.gov/src/scss/new/_uswds-overrides.scss
@@ -62,7 +62,7 @@
 // Disable stylelint BEM format check because we need the specificity.
 /* stylelint-disable */
 @include at-media("tablet-lg") {
-  .usa-footer .grid-row .mobile-lg:grid-col-6 {
+  .usa-footer .grid-row .tablet-lg\:grid-col-3 {
     width: 25%;
   }
 }

--- a/themes/digital.gov/src/scss/new/_uswds-overrides.scss
+++ b/themes/digital.gov/src/scss/new/_uswds-overrides.scss
@@ -57,11 +57,11 @@
   }
 }
 
-// overrides usa footer until 3.8.0 for uswds comes out and refactor footer into the uswds footer component.
+// overrides usa footer until uswds 3.8.0 comes out with a fix to refactor footer into the uswds footer component.
 // turing off sylelint due to it flagging needing to be in BEM format
 /* stylelint-disable */
-@media (min-width: 30em) {
-  .usa-footer .grid-row .mobile-lg\:grid-col-6 {
+@include at-media("tablet-lg") {
+  .usa-footer .grid-row .mobile-lg:grid-col-6 {
     width: 25%;
   }
 }


### PR DESCRIPTION
## Summary

This PR applies an override to the footer styles. Related to a USWDS update [uswds/uswds#5676] that caused Digital footer to have a regression. 

**Before**
<img width="500" alt="Screenshot 2024-02-06 at 4 16 40 PM" src="https://github.com/GSA/digitalgov.gov/assets/88721460/dade0ede-1ab2-4867-9a45-cfbc62a26ec3">

**After**
<img width="500" alt="Screenshot 2024-02-06 at 4 14 12 PM" src="https://github.com/GSA/digitalgov.gov/assets/88721460/c48983b6-cfa0-4e74-84a7-d3e71a0a2c3c">


### Preview
[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/cm-footer-fix/)

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

Added a more specific style than USWDS of the width being 50% to 25%. This allowed for the footer to return to the expected result. 

There'll need to be follow up to migrate the current footer to match USWDS component footer.

### How To Test

1. Visit [preview link](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/cm-footer-fix/) and 
1. Scroll to the footer
1. Verify that is looks the same as the [most recent wayback format](https://web.archive.org/web/20240129091941/https://digital.gov/). There should be four columns on large screen sizes.

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly

Tagging supervisor for reference - @rayestrada
