### PR TITLE
POAM: Updated link security

### DIFF
--- a/themes/digital.gov/layouts/partials/core/notice-bar.html
+++ b/themes/digital.gov/layouts/partials/core/notice-bar.html
@@ -10,7 +10,9 @@
             <div>
               <strong>This is a PREVIEW of a Digital.gov page.</strong> Visit
               our current site at
-              <a href="{{ $current }}" target="_blank">{{- $current -}}</a>
+              <a href="{{ $current }}" target="_blank" rel="noopener noreferrer"
+                >{{- $current -}}</a
+              >
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Updated `notice-bar.html` with `rel="noopener noreferrer"` for `a`.

### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-poam-feb-2024-link-fix/)


### How To Test

1. Click preview link
2. `rel="noopener noreferrer"` is now present on `a` tag

---

### Dev Checklist

- [x] PR has correct labels
- [x] A11y testing (voice over testing, meets WCAG, run axe tools)
- [x] Code is formatted properly
