### PR TITLE
Add roadmap to about page

### DIFF
--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -23,7 +23,6 @@ Find out how to [connect with us](https://digital.gov/about/contact/) across dif
 
 Our roadmap is an up-to-date report on the work we’re doing to improve Digital.gov. We regularly update this roadmap to share what we have done recently and what we are planning to do in the coming months.
 
-
 <table class="usa-table">
   <thead>
     <tr>
@@ -34,13 +33,35 @@ Our roadmap is an up-to-date report on the work we’re doing to improve Digital
   <tbody>
     <tr>
       <th scope="row">Prepare and equip members for change related to M-23-22 policy guidance through regular, ongoing communications</th>
-      <td>Complete</td>
+      <td>
+        Complete
+      </td>
+    </tr>
+    <tr>
       <th scope="row">Publish a resource page to summarize the requirements for [delivering a digital first public experience](https://digital.gov/resources/delivering-digital-first-public-experience/)</th>
-      <td>Complete</td>
+      <td>
+        Complete
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">Publish a resource page to summarize the requirements for [delivering a digital first public experience](https://digital.gov/resources/delivering-digital-first-public-experience/)</th>
+      <td>
+        Complete
+      </td>
+    </tr>
+    <tr>
       <th scope="row">Redesign [topic pages](https://digital.gov/topics/) to enable active content curation instead of auto-generation</th>
-      <td>Complete</td>
+      <td>
+        Complete.
+      </td>
+    </tr>
+    <tr>
       <th scope="row">Publish introductory resources to support users’ implementation of M-23-22</th>
-      <td>Complete</td>
+      <td>
+        Complete.
+      </td>
+    </tr>
   </tbody>
 </table>
+
 

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -38,19 +38,13 @@ Our roadmap is an up-to-date report on the work we’re doing to improve Digital
       </td>
     </tr>
     <tr>
-      <th scope="row">Publish a resource page to summarize the requirements for [delivering a digital first public experience](https://digital.gov/resources/delivering-digital-first-public-experience/)</th>
+      <th scope="row">Publish a resource page to summarize the requirements for <a href="https://digital.gov/resources/delivering-digital-first-public-experience/">delivering a digital first public experience</a></th>
       <td>
         Complete
       </td>
     </tr>
     <tr>
-      <th scope="row">Publish a resource page to summarize the requirements for [delivering a digital first public experience](https://digital.gov/resources/delivering-digital-first-public-experience/)</th>
-      <td>
-        Complete
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">Redesign [topic pages](https://digital.gov/topics/) to enable active content curation instead of auto-generation</th>
+      <th scope="row">Redesign <a href="https://digital.gov/topics/">topic pages</a> to enable active content curation instead of auto-generation</th>
       <td>
         Complete
       </td>

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -38,121 +38,121 @@ Our roadmap is an up-to-date report on the work we’re doing to improve Digital
       </td>
     </tr>
     <tr>
-      <th scope="row">Publish a resource page to summarize the requirements for <a href="https://digital.gov/resources/delivering-digital-first-public-experience/">delivering a digital first public experience</a></th>
+      <td>Publish a resource page to summarize the requirements for <a href="https://digital.gov/resources/delivering-digital-first-public-experience/">delivering a digital first public experience</a></th>
       <td>
         Complete
       </td>
     </tr>
     <tr>
-      <th scope="row">Redesign <a href="https://digital.gov/topics/">topic pages</a> to enable active content curation instead of auto-generation</th>
+      <td>Redesign <a href="https://digital.gov/topics/">topic pages</a> to enable active content curation instead of auto-generation</th>
       <td>
         Complete
       </td>
     </tr>
     <tr>
-      <th scope="row">Publish introductory resources to support users’ implementation of M-23-22</th>
+      <td>Publish introductory resources to support users’ implementation of M-23-22</th>
       <td>
         Complete
       </td>
     </tr>
     <tr>
-      <th scope="row">Formalize Digital.gov’s network of volunteers and contributors</th>
+      <td>Formalize Digital.gov’s network of volunteers and contributors</th>
       <td>
         Complete
       </td>
     </tr>
     <tr>
-      <th scope="row">Conduct user research with web and digital practitioners to better understand user needs</th>
+      <td>Conduct user research with web and digital practitioners to better understand user needs</th>
       <td>
         Complete
       </td>
     </tr>
     <tr>
-      <th scope="row">Create user types based on research to identify a broad grouping of different types of customers and users</th>
+      <td>Create user types based on research to identify a broad grouping of different types of customers and users</th>
       <td>
         Complete.
       </td>
     </tr>
     <tr>
-      <th scope="row">Plan for infrastructure modernization</th>
+      <td>Plan for infrastructure modernization</th>
       <td>
         Complete
       </td>
     </tr>
     <tr>
-      <th scope="row">Publish roadmap on Digital.gov</th>
+      <td>Publish roadmap on Digital.gov</th>
       <td>
         Complete
       </td>
     </tr>
     <tr>
-      <th scope="row">Migrate the accessibility.digital.gov microsite to Digital.gov as a guide</th>
+      <td">Migrate the accessibility.digital.gov microsite to Digital.gov as a guide</th>
       <td>
         In progress
       </td>
     </tr>
     <tr>
-      <th scope="row">Plan and host the Spring 2024 Digital.gov Community Summit</th>
+      <td>Plan and host the Spring 2024 Digital.gov Community Summit</th>
       <td>
         In progress
       </td>
     </tr>
     <tr>
-      <th scope="row">Share more agency case studies and success stories with community members</th>
+      <td>Share more agency case studies and success stories with community members</th>
       <td>
         In progress
       </td>
     </tr>
     <tr>
-      <th scope="row">Publish more evergreen content, including topic and policy pages</th>
+      <td">Publish more evergreen content, including topic and policy pages</th>
       <td>
         In progress
       </td>
     </tr>
     <tr>
-      <th scope="row">Publish short, actionable, accessible video content</th>
+      <td>Publish short, actionable, accessible video content</th>
       <td>
         In progress
       </td>
     </tr>
     <tr>
-      <th scope="row">Increase engagement and create space for more community members to participate</th>
+      <td>Increase engagement and create space for more community members to participate</th>
       <td>
         In progress
       </td>
     </tr>
     <tr>
-      <th scope="row">Grow collaboration with web and digital executives across government</th>
+      <td>Grow collaboration with web and digital executives across government</th>
       <td>
         In progress
       </td>
     </tr>
     <tr>
-      <th scope="row">Update federal plain language guidelines</th>
+      <td>Update federal plain language guidelines</th>
       <td>
         Upcoming
       </td>
     </tr>
     <tr>
-      <th scope="row">Conduct pilot workshops with community members to identify problems and overcome challenges</th>
+      <td>Conduct pilot workshops with community members to identify problems and overcome challenges</th>
       <td>
         Upcoming
       </td>
     </tr>
     <tr>
-      <th scope="row">Host the Fall 2024 Digital.gov Community Summit</th>
+      <td>Host the Fall 2024 Digital.gov Community Summit</th>
       <td>
         Upcoming
       </td>
     </tr>
     <tr>
-      <th scope="row">Roll out a modern content management system</th>
+      <td>Roll out a modern content management system</th>
       <td>
         Upcoming
       </td>
     </tr>
     <tr>
-      <th scope="row">Roll out a modern platform for member engagement and communication</th>
+      <td>Roll out a modern platform for member engagement and communication</th>
       <td>
         Upcoming
       </td>

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -52,16 +52,116 @@ Our roadmap is an up-to-date report on the work we’re doing to improve Digital
     <tr>
       <th scope="row">Redesign [topic pages](https://digital.gov/topics/) to enable active content curation instead of auto-generation</th>
       <td>
-        Complete.
+        Complete
       </td>
     </tr>
     <tr>
       <th scope="row">Publish introductory resources to support users’ implementation of M-23-22</th>
       <td>
+        Complete
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">Formalize Digital.gov’s network of volunteers and contributors</th>
+      <td>
+        Complete
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">Conduct user research with web and digital practitioners to better understand user needs</th>
+      <td>
+        Complete
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">Create user types based on research to identify a broad grouping of different types of customers and users</th>
+      <td>
         Complete.
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">Plan for infrastructure modernization</th>
+      <td>
+        Complete
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">Publish roadmap on Digital.gov</th>
+      <td>
+        Complete
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">Migrate the accessibility.digital.gov microsite to Digital.gov as a guide</th>
+      <td>
+        In progress
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">Plan and host the Spring 2024 Digital.gov Community Summit</th>
+      <td>
+        In progress
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">Share more agency case studies and success stories with community members</th>
+      <td>
+        In progress
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">Publish more evergreen content, including topic and policy pages</th>
+      <td>
+        In progress
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">Publish short, actionable, accessible video content</th>
+      <td>
+        In progress
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">Increase engagement and create space for more community members to participate</th>
+      <td>
+        In progress
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">Grow collaboration with web and digital executives across government</th>
+      <td>
+        In progress
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">Update federal plain language guidelines</th>
+      <td>
+        Upcoming
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">Conduct pilot workshops with community members to identify problems and overcome challenges</th>
+      <td>
+        Upcoming
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">Host the Fall 2024 Digital.gov Community Summit</th>
+      <td>
+        Upcoming
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">Roll out a modern content management system</th>
+      <td>
+        Upcoming
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">Roll out a modern platform for member engagement and communication</th>
+      <td>
+        Upcoming
       </td>
     </tr>
   </tbody>
 </table>
-
-

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -18,3 +18,29 @@ We envision a world where the U.S. government leads in creating world-class digi
 ## Contact us
 
 Find out how to [connect with us](https://digital.gov/about/contact/) across different channels.
+
+## Roadmap
+
+Our roadmap is an up-to-date report on the work we’re doing to improve Digital.gov. We regularly update this roadmap to share what we have done recently and what we are planning to do in the coming months.
+
+
+<table class="usa-table">
+  <thead>
+    <tr>
+      <th scope="col">Activity</th>
+      <th scope="col">Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">Prepare and equip members for change related to M-23-22 policy guidance through regular, ongoing communications</th>
+      <td>Complete</td>
+      <th scope="row">Publish a resource page to summarize the requirements for [delivering a digital first public experience](https://digital.gov/resources/delivering-digital-first-public-experience/)</th>
+      <td>Complete</td>
+      <th scope="row">Redesign [topic pages](https://digital.gov/topics/) to enable active content curation instead of auto-generation</th>
+      <td>Complete</td>
+      <th scope="row">Publish introductory resources to support users’ implementation of M-23-22</th>
+      <td>Complete</td>
+  </tbody>
+</table>
+

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -23,7 +23,7 @@ Find out how to [connect with us](https://digital.gov/about/contact/) across dif
 
 Our roadmap is an up-to-date report on the work we’re doing to improve Digital.gov. We regularly update this roadmap to share what we have done recently and what we are planning to do in the coming months.
 
-<table class="usa-table">
+<table class="usa-table usa-table--striped">
   <thead>
     <tr>
       <th scope="col">Activity</th>

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -23,7 +23,7 @@ Find out how to [connect with us](https://digital.gov/about/contact/) across dif
 
 Our roadmap is an up-to-date report on the work we’re doing to improve Digital.gov. We regularly update this roadmap to share what we have done recently and what we are planning to do in the coming months.
 
-<table class="usa-table usa-table--striped">
+<table class="usa-table usa-table--striped usa-table--borderless">
   <thead>
     <tr>
       <th scope="col">Activity</th>

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -32,130 +32,88 @@ Our roadmap is an up-to-date report on the work we’re doing to improve Digital
   </thead>
   <tbody>
     <tr>
-      <td>Prepare and equip members for change related to M-23-22 policy guidance through regular, ongoing communications</th>
-      <td>
-        Complete
-      </td>
+      <th scope="row">Prepare and equip members for change related to M-23-22 policy guidance through regular, ongoing communications</th>
+      <td>Complete</td>
     </tr>
     <tr>
-      <td>Publish a resource page to summarize the requirements for <a href="https://digital.gov/resources/delivering-digital-first-public-experience/">delivering a digital first public experience</a></th>
-      <td>
-        Complete
-      </td>
+      <th scope="row">Publish a resource page to summarize the requirements for <a href="https://digital.gov/resources/delivering-digital-first-public-experience/">delivering a digital first public experience</a></th>
+      <td>Complete</td>
     </tr>
     <tr>
-      <td>Redesign <a href="https://digital.gov/topics/">topic pages</a> to enable active content curation instead of auto-generation</th>
-      <td>
-        Complete
-      </td>
+      <th scope="row">Redesign <a href="https://digital.gov/topics/">topic pages</a> to enable active content curation instead of auto-generation</th>
+      <td>Complete</td>
     </tr>
     <tr>
-      <td>Publish introductory resources to support users’ implementation of M-23-22</th>
-      <td>
-        Complete
-      </td>
+      <th scope="row">Publish introductory resources to support users’ implementation of M-23-22</th>
+      <td>Complete</td>
     </tr>
     <tr>
-      <td>Formalize Digital.gov’s network of volunteers and contributors</th>
-      <td>
-        Complete
-      </td>
+      <th scope="row">Formalize Digital.gov’s network of volunteers and contributors</th>
+      <td>Complete</td>
     </tr>
     <tr>
-      <td>Conduct user research with web and digital practitioners to better understand user needs</th>
-      <td>
-        Complete
-      </td>
+      <th scope="row">Conduct user research with web and digital practitioners to better understand user needs</th>
+      <td>Complete</td>
     </tr>
     <tr>
-      <td>Create user types based on research to identify a broad grouping of different types of customers and users</th>
-      <td>
-        Complete
-      </td>
+      <th scope="row">Create user types based on research to identify a broad grouping of different types of customers and users</th>
+      <td>Complete</td>
     </tr>
     <tr>
-      <td>Plan for infrastructure modernization</th>
-      <td>
-        Complete
-      </td>
+      <th scope="row">Plan for infrastructure modernization</th>
+      <td>Complete</td>
     </tr>
     <tr>
-      <td>Publish roadmap on Digital.gov</th>
-      <td>
-        Complete
-      </td>
+      <th scope="row">Publish roadmap on Digital.gov</th>
+      <td>Complete</td>
     </tr>
     <tr>
-      <td>Migrate the accessibility.digital.gov microsite to Digital.gov as a guide</th>
-      <td>
-        In progress
-      </td>
+      <th scope="row">Migrate the accessibility.digital.gov microsite to Digital.gov as a guide</th>
+      <td>In progress</td>
     </tr>
     <tr>
-      <td>Plan and host the Spring 2024 Digital.gov Community Summit</th>
-      <td>
-        In progress
-      </td>
+      <th scope="row">Plan and host the Spring 2024 Digital.gov Community Summit</th>
+      <td>In progress</td>
     </tr>
     <tr>
-      <td>Share more agency case studies and success stories with community members</th>
-      <td>
-        In progress
-      </td>
+      <th scope="row">Share more agency case studies and success stories with community members</th>
+      <td>In progress</td>
     </tr>
     <tr>
-      <td>Publish more evergreen content, including topic and policy pages</th>
-      <td>
-        In progress
-      </td>
+      <th scope="row">Publish more evergreen content, including topic and policy pages</th>
+      <td>In progress</td>
     </tr>
     <tr>
-      <td>Publish short, actionable, accessible video content</th>
-      <td>
-        In progress
-      </td>
+      <th scope="row">Publish short, actionable, accessible video content</th>
+      <td>In progress</td>
     </tr>
     <tr>
-      <td>Increase engagement and create space for more community members to participate</th>
-      <td>
-        In progress
-      </td>
+      <th scope="row">Increase engagement and create space for more community members to participate</th>
+      <td>In progress</td>
     </tr>
     <tr>
-      <td>Grow collaboration with web and digital executives across government</th>
-      <td>
-        In progress
-      </td>
+      <th scope="row">Grow collaboration with web and digital executives across government</th>
+      <td>In progress</td>
     </tr>
     <tr>
-      <td>Update federal plain language guidelines</th>
-      <td>
-        Upcoming
-      </td>
+      <th scope="row">Update federal plain language guidelines</th>
+      <td>Upcoming</td>
     </tr>
     <tr>
-      <td>Conduct pilot workshops with community members to identify problems and overcome challenges</th>
-      <td>
-        Upcoming
-      </td>
+      <th scope="row">Conduct pilot workshops with community members to identify problems and overcome challenges</th>
+      <td>Upcoming</td>
     </tr>
     <tr>
-      <td>Host the Fall 2024 Digital.gov Community Summit</th>
-      <td>
-        Upcoming
-      </td>
+      <th scope="row">Host the Fall 2024 Digital.gov Community Summit</th>
+      <td>Upcoming</td>
     </tr>
     <tr>
-      <td>Roll out a modern content management system</th>
-      <td>
-        Upcoming
-      </td>
+      <th scope="row">Roll out a modern content management system</th>
+      <td>Upcoming</td>
     </tr>
     <tr>
-      <td>Roll out a modern platform for member engagement and communication</th>
-      <td>
-        Upcoming
-      </td>
+      <th scope="row">Roll out a modern platform for member engagement and communication</th>
+      <td>Upcoming</td>
     </tr>
   </tbody>
 </table>

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -86,7 +86,7 @@ Our roadmap is an up-to-date report on the work we’re doing to improve Digital
       </td>
     </tr>
     <tr>
-      <td">Migrate the accessibility.digital.gov microsite to Digital.gov as a guide</th>
+      <td>Migrate the accessibility.digital.gov microsite to Digital.gov as a guide</th>
       <td>
         In progress
       </td>

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -70,7 +70,7 @@ Our roadmap is an up-to-date report on the work we’re doing to improve Digital
     <tr>
       <td>Create user types based on research to identify a broad grouping of different types of customers and users</th>
       <td>
-        Complete.
+        Complete
       </td>
     </tr>
     <tr>

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -32,7 +32,7 @@ Our roadmap is an up-to-date report on the work we’re doing to improve Digital
   </thead>
   <tbody>
     <tr>
-      <th scope="row">Prepare and equip members for change related to M-23-22 policy guidance through regular, ongoing communications</th>
+      <td>Prepare and equip members for change related to M-23-22 policy guidance through regular, ongoing communications</th>
       <td>
         Complete
       </td>

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -104,7 +104,7 @@ Our roadmap is an up-to-date report on the work we’re doing to improve Digital
       </td>
     </tr>
     <tr>
-      <td">Publish more evergreen content, including topic and policy pages</th>
+      <td>Publish more evergreen content, including topic and policy pages</th>
       <td>
         In progress
       </td>


### PR DESCRIPTION
## Summary

Adds the FY 2024 roadmap to the Digital.gov [About us](https://digital.gov/about/) page. 
### Preview

See preview here: https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/bc-add-roadmap-about-us/about/

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

1. Make sure that alignment and style are correct. (Use [Introduction to Analytics](https://digital.gov/resources/an-introduction-to-analytics/) to compare the style)
2. Review text entry for errors

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
