### PR TITLE
Update "Preview in Federalist" path

### DIFF
--- a/.github/workflows/pr-preview-link.yml
+++ b/.github/workflows/pr-preview-link.yml
@@ -19,5 +19,5 @@ jobs:
       - name: Comment Pull Request
         uses: thollander/actions-comment-pull-request@main
         with:
-          message: ":mag: [__Preview in Federalist__](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.app.cloud.gov/preview/gsa/digitalgov.gov/${{ github.head_ref }}/)"
+          message: ":mag: [__Preview in Federalist__](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/${{ github.head_ref }}/)"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Updates the federalist preview path to work for the "Preview in Federalist" link.

<img width="948" alt="Screen Shot 2024-02-27 at 11 40 36 AM" src="https://github.com/GSA/digitalgov.gov/assets/104778659/5be768be-53f8-40fc-bc02-115a8307cc01">

**Preview in Federalist**

The link in the preview path needs to be updated to the new path. Currently displays an error in some builds.
#7362 uses the wrong working preview link.

**Github Actions**

The **pages/build** link points to the correct preview path.
<img width="914" alt="Screen Shot 2024-02-27 at 11 58 04 AM" src="https://github.com/GSA/digitalgov.gov/assets/104778659/cf02b922-5c5e-420f-ad75-040b5b800fab">



