### PR TITLE
Hide glossary header when summary box component is displayed

### DIFF
--- a/themes/digital.gov/layouts/guides/single.html
+++ b/themes/digital.gov/layouts/guides/single.html
@@ -19,7 +19,9 @@
       {{- else -}}
         {{- partial "core/guides/guide-content.html" . -}}
       {{- end -}}
-      {{- partial "core/glossary.html" . -}}
+      {{- if .Parent.Params.glossary -}}
+        {{- partial "core/glossary.html" . -}}
+      {{- end -}}
     </article>
   </main>
 {{ end }}

--- a/themes/digital.gov/layouts/landings/list.html
+++ b/themes/digital.gov/layouts/landings/list.html
@@ -9,7 +9,6 @@
         </a>
       </div>
     </header>
-
     <article class="dg-landing__body grid-container grid-container-desktop">
       <div>
         {{- .Content -}}
@@ -46,6 +45,8 @@
       {{- end -}}
       {{- partial "core/attribution.html" . -}}
     </article>
-    {{- partial "core/glossary.html" . -}}
+    {{- if .Parent.Params.glossary -}}
+      {{- partial "core/glossary.html" . -}}
+    {{- end -}}
   </main>
 {{ end }}

--- a/themes/digital.gov/layouts/partials/core/glossary.html
+++ b/themes/digital.gov/layouts/partials/core/glossary.html
@@ -1,31 +1,27 @@
-{{ if ne .Params.glossary nil }}
-  <aside
-    class="dg-glossary__container"
-    aria-describedby="dg-glossary__result"
-    aria-hidden="true"
-  >
-    <button title="Close glossary" class="dg-glossary__close" disabled>
-      <svg
-        class="usa-icon dg-icon dg-icon--large"
-        aria-hidden="true"
-        focusable="true"
-      >
-        <use xlink:href="{{ "/uswds/img/sprite.svg#close" | relURL }}"></use>
-      </svg>
-    </button>
-
-    <h2>Glossary</h2>
-    <label for="dg-glossary__search" class="usa-label"
-      >Search for a term:</label
+<aside
+  class="dg-glossary__container"
+  aria-describedby="dg-glossary__result"
+  aria-hidden="true"
+>
+  <button title="Close glossary" class="dg-glossary__close" disabled>
+    <svg
+      class="usa-icon dg-icon dg-icon--large"
+      aria-hidden="true"
+      focusable="true"
     >
-    <input
-      id="dg-glossary__search"
-      class="dg-glossary__search usa-input"
-      type="text"
-      disabled
-    />
-    <div class="dg-glossary__content" id="dg-glossary__result">
-      <ul class="dg-glossary__list add-list-reset"></ul>
-    </div>
-  </aside>
-{{ end }}
+      <use xlink:href="{{ "/uswds/img/sprite.svg#close" | relURL }}"></use>
+    </svg>
+  </button>
+
+  <h2 class="dg-glossary__header">Glossary</h2>
+  <label for="dg-glossary__search" class="usa-label">Search for a term:</label>
+  <input
+    id="dg-glossary__search"
+    class="dg-glossary__search usa-input"
+    type="text"
+    disabled
+  />
+  <div class="dg-glossary__content" id="dg-glossary__result">
+    <ul class="dg-glossary__list add-list-reset"></ul>
+  </div>
+</aside>

--- a/themes/digital.gov/layouts/partials/core/glossary.html
+++ b/themes/digital.gov/layouts/partials/core/glossary.html
@@ -1,27 +1,31 @@
-<aside
-  class="dg-glossary__container"
-  aria-describedby="dg-glossary__result"
-  aria-hidden="true"
->
-  <button title="Close glossary" class="dg-glossary__close" disabled>
-    <svg
-      class="usa-icon dg-icon dg-icon--large"
-      aria-hidden="true"
-      focusable="true"
-    >
-      <use xlink:href="{{ "/uswds/img/sprite.svg#close" | relURL }}"></use>
-    </svg>
-  </button>
+{{ if isset .Params "glossary" }}
+  <aside
+    class="dg-glossary__container"
+    aria-describedby="dg-glossary__result"
+    aria-hidden="true"
+  >
+    <button title="Close glossary" class="dg-glossary__close" disabled>
+      <svg
+        class="usa-icon dg-icon dg-icon--large"
+        aria-hidden="true"
+        focusable="true"
+      >
+        <use xlink:href="{{ "/uswds/img/sprite.svg#close" | relURL }}"></use>
+      </svg>
+    </button>
 
-  <h2>Glossary</h2>
-  <label for="dg-glossary__search" class="usa-label">Search for a term:</label>
-  <input
-    id="dg-glossary__search"
-    class="dg-glossary__search usa-input"
-    type="text"
-    disabled
-  />
-  <div class="dg-glossary__content" id="dg-glossary__result">
-    <ul class="dg-glossary__list add-list-reset"></ul>
-  </div>
-</aside>
+    <h2>Glossary</h2>
+    <label for="dg-glossary__search" class="usa-label"
+      >Search for a term:</label
+    >
+    <input
+      id="dg-glossary__search"
+      class="dg-glossary__search usa-input"
+      type="text"
+      disabled
+    />
+    <div class="dg-glossary__content" id="dg-glossary__result">
+      <ul class="dg-glossary__list add-list-reset"></ul>
+    </div>
+  </aside>
+{{ end }}

--- a/themes/digital.gov/layouts/partials/core/glossary.html
+++ b/themes/digital.gov/layouts/partials/core/glossary.html
@@ -1,4 +1,4 @@
-{{ if isset .Params "glossary" }}
+{{ if ne .Params.glossary nil }}
   <aside
     class="dg-glossary__container"
     aria-describedby="dg-glossary__result"

--- a/themes/digital.gov/src/js/summary-box.js
+++ b/themes/digital.gov/src/js/summary-box.js
@@ -10,7 +10,7 @@
 
   const guideSummaryList = guideSummary.querySelector(".usa-list");
   const pageHeaders = document.querySelectorAll(
-    "h2:not(.usa-summary-box__heading, .dg-guide__content-header-title)"
+    "h2:not(.usa-summary-box__heading, .dg-guide__content-header-title, .dg-glossary__header)"
   );
 
   function createSummaryBox() {


### PR DESCRIPTION
## Summary
Guide pages that display a `summary box` displays the **Glossary** `h2` when it should not be visible.


### Preview

[Link to Preview]()

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution
Wrapping the `glossary.html` with a conditional to check for the `glossary` front matter field will only display the `glossary` component when it is called.

If the `summary box` is used on a page that uses the `glossary`, then don't display the **Glossary** `h2`.

### How To Test

1. First Step
2. Second Step
3. Third Step

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
