### PR TITLE
Update home.html

### DIFF
--- a/themes/digital.gov/layouts/home.html
+++ b/themes/digital.gov/layouts/home.html
@@ -68,7 +68,7 @@
                       <a
                         href="{{ "topics/digital-service-delivery/" | relURL }}"
                       >
-                        <span>See all 21st Century IDEA resources</span>
+                        <span>Deliver better digital services</span>
                         <svg
                           class="usa-icon dg-icon dg-icon--standard margin-bottom-05"
                           aria-hidden="true"


### PR DESCRIPTION
We are making this revision because the current CTA on the homepage doesn't match the outcome for users.

## Summary

Text on homepage CTA is changing from "See all 21st Century IDEA resources" to "Deliver better digital services"

### Preview

[Link to Preview]()

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### How To Test

1. Make sure homepage CTA text now reads "Deliver better digital services" instead of "See all 21st Century IDEA resources"

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
