### PR TITLE
DG - Guide menu: Remove custom class in favor native hidden

### DIFF
--- a/themes/digital.gov/src/js/guide-mobile-menu.js
+++ b/themes/digital.gov/src/js/guide-mobile-menu.js
@@ -20,11 +20,10 @@
    */
   function handleResize(breakpoint) {
     if (breakpoint.matches) {
-      dgAccordionMobileMenu.classList.add("dg-hide");
-      dgGuideMenuBar.classList.remove("dg-hide");
+      dgAccordionMobileMenu.setAttribute("hidden", "true");
     } else {
-      dgAccordionMobileMenu.classList.remove("dg-hide");
-      dgGuideMenuBar.classList.add("dg-hide");
+      dgAccordionMobileMenu.removeAttribute("hidden");
+      dgGuideMenuBar.setAttribute("hidden", "true");
     }
   }
 

--- a/themes/digital.gov/src/scss/new/_uswds-overrides.scss
+++ b/themes/digital.gov/src/scss/new/_uswds-overrides.scss
@@ -67,7 +67,3 @@
   }
 }
 /* stylelint-enable */
-
-.dg-hide {
-  visibility: hidden;
-}

--- a/themes/digital.gov/src/scss/new/guides/_guide-menu-bar.scss
+++ b/themes/digital.gov/src/scss/new/guides/_guide-menu-bar.scss
@@ -6,12 +6,15 @@
   @include u-z(200);
   align-items: center;
   background-color: color("gray-10");
-  display: flex;
   height: units(10);
   justify-content: center;
   position: sticky;
   top: -1px;
   white-space: nowrap;
+
+  @include at-media("mobile-lg") {
+    display: flex;
+  }
 
   &-image-container {
     flex-shrink: 0;
@@ -83,7 +86,6 @@
 
 // Styles the mobile vertical menu bar
 .guide-mobile-menu {
-  display: block;
   position: sticky;
   top: -1px;
   z-index: z-index(100);


### PR DESCRIPTION
## Summary

Removes custom class in favor of `hidden` attribute. This is built-in, so no additional maintenance required that a custom class would need.

Components will also display in case JavaScript fails.

### Preview

[HCD Guide →](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/jm-guide-mobile-menu/guides/hcd/introduction/)

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

Zero regressions in guide navigations.

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
