### PR TITLE
add headers to override default AWS settings

### DIFF
--- a/config/gulp/file-upload.js
+++ b/config/gulp/file-upload.js
@@ -45,7 +45,7 @@ function uploadFile() {
   return gulp
     .src("content/uploads/_working-files/to-process/*")
     .pipe(staticRename)
-    .pipe(publisher.publish())
+    .pipe(publisher.publish(headers))
     .pipe(
       awspublish.reporter({
         states: ["create", "update", "delete"],

--- a/config/gulp/file-upload.js
+++ b/config/gulp/file-upload.js
@@ -16,10 +16,15 @@ const publisher = awspublish.create({
   secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
 });
 
+const headers = {
+  "Cache-Control": "max-age=315360000, no-transform, public",
+  'x-amz-acl': 'public-read'
+}
+
 function uploadImage() {
   return gulp
     .src("content/uploads/_working-images/processed/*")
-    .pipe(publisher.publish())
+    .pipe(publisher.publish(headers))
     .pipe(
       awspublish.reporter({
         states: ["create", "update", "delete"],

--- a/data/images/flag-test-1.yml
+++ b/data/images/flag-test-1.yml
@@ -1,0 +1,12 @@
+
+  # https://s3.amazonaws.com/digitalgov/flag-test-1.jpg
+  # Image shortcode: {{< img src=flag-test-1 >}}'
+  date     :  2024-06-04 12:40:48 -0400
+  uid      :  flag-test-1
+  width    :  219
+  height   :  180
+  format   :  jpg
+  credit   :  
+  caption  :  
+  alt      :  
+  


### PR DESCRIPTION
## Summary

An issue with the file upload function not letting viewers see the file. 

It is stated here in the documentation: [Bucket Permissions](https://www.npmjs.com/package/gulp-awspublish#bucket-permissions)

### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/rs-hotfix/fix-image-privacy-in-s3-upload/images)

 
### Solution

I added headers that cache the file. 

Here's what each property does:

1. `"Cache-Control": "max-age=315360000, no-transform, public"`: This is an HTTP header that defines caching behavior. The `max-age=315360000` directive tells the browser to cache the file for 315360000 seconds (approximately 10 years). The `no-transform` directive tells any intermediaries (like CDNs or proxies) not to modify the file. The `public` directive indicates that the file can be cached by any cache, not just the user's browser.

2. `'x-amz-acl': 'public-read'`: This is a custom HTTP header used by Amazon S3 when uploading a file. The `x-amz-acl` header sets the Access Control List (ACL) for the file. The value `public-read` means the file can be read by anyone, but only the owner of the S3 bucket can write or modify the file.

### How To Test

1. Add an image to *`content/uploads/_inbox/__add image or static files to this folder__`*
2. Run Command `npx gulp upload`
3. Click on the link in the newly generated .yaml file
4. Your image should be displayed in your browser. 

---

### Dev Checklist

- [x] PR has correct labels
- [x] A11y testing (voice over testing, meets WCAG, run axe tools)
- [x] Code is formatted properly
