### PR TITLE
updated social media links to open in new browser tab

### DIFF
--- a/themes/digital.gov/layouts/partials/core/get_sharetools.html
+++ b/themes/digital.gov/layouts/partials/core/get_sharetools.html
@@ -8,6 +8,8 @@
       <a
         class="twitter"
         aria-label="Share on Twitter"
+        target="_blank"
+        rel="noreferrer"
         href="http://twitter.com/share?url=https://digital.gov{{ (urls.Parse .Permalink) }}&amp;text={{ .Title }}"
       >
         <svg
@@ -23,6 +25,8 @@
       <a
         class="facebook"
         aria-label="Share on Facebook"
+        target="_blank"
+        rel="noreferrer"
         href="http://www.facebook.com/sharer.php?u=https://digital.gov{{ (urls.Parse .Permalink) }}&t={{ .Title | urlize }}"
       >
         <svg
@@ -40,6 +44,8 @@
       <a
         class="linkedin"
         aria-label="Share on LinkedIn"
+        target="_blank"
+        rel="noreferrer"
         href="https://www.linkedin.com/shareArticle?mini=true&url=https://digital.gov{{ (urls.Parse .Permalink) }}&title={{ .Title | urlize }}&summary={{ .Params.summary | urlize }}&source={{ "Digital.gov" | urlize }}"
       >
         <svg


### PR DESCRIPTION
## Problem Statement

Selecting social media icons to share content on website opens social media link on the current tab, going to an non-government external website.

## Summary

Updated share social media links in ```get_sharetools.html``` to open in new browser tab and improve security. Affects all layouts that include Share Tools.

### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/kl-social-media-links-new-tab/event/2024/06/20/uswds-monthly-call-june-2024/)
Select X, Facebook, or LinkedIn buttons to view change.
<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution
added ```target="_blank"``` to social media links
added ```rel="noreferrer"``` to social media links

Example:
```      
<a
        class="twitter"
        aria-label="Share on Twitter"
        target="_blank"
        rel="noreferrer"
        href="http://twitter.com/share?url=https://digital.gov{{ (urls.Parse .Permalink) }}&amp;text={{ .Title }}"
> 
```

### Screenshots
Before:
<img width="579" alt="Screenshot 2024-06-12 at 2 34 07 PM" src="https://github.com/GSA/digitalgov.gov/assets/90117979/3b0ff71c-2bae-4804-b035-970644afe909">

After:
<img width="532" alt="Screenshot 2024-06-12 at 2 35 51 PM" src="https://github.com/GSA/digitalgov.gov/assets/90117979/f5449ad7-2d9f-4732-9ec3-a18564192be9">

---

### Dev Checklist

- [x] PR has correct labels
- [x] A11y testing (voice over testing, meets WCAG, run axe tools)
- [x] Code is formatted properly
