### PR TITLE
Refactor img shortcode 

### DIFF
--- a/themes/digital.gov/layouts/shortcodes/img.html
+++ b/themes/digital.gov/layouts/shortcodes/img.html
@@ -13,25 +13,22 @@
 {{- $prefix := replaceRE "^(http[s]://).+$" "$1" $thisuid -}}
 {{- $align := .Get "align" | default "" -}}
 
-
-<div
-  class="image{{- if $align }} image-{{ $align }}{{- end }}"
->
+<div class="image{{- if $align }} image-{{ $align }}{{- end }}">
   {{- if (or (eq $imgExt "jpg") (or (eq $imgExt "jpeg") (eq $imgExt "png"))) -}}
-    < img
+    <img
       src="{{- if ne $prefix $thisuid -}}
         {{- $thisuid -}}
       {{- else -}}
         {{- $imgBaseCDN -}}_w800.{{- $imgExt -}}
       {{- end -}}"
-      {{- if or (.Get "alt") $thisimg.alt }}
+      {{- if or (.Get "alt") $thisimg.alt -}}
         alt="{{- with .Get "alt" -}}
           {{- . -}}
         {{- else -}}
           {{- $thisimg.alt -}}
-        {{ end }}"
+        {{- end -}}
       {{- end -}}
-      {{- if eq $prefix $thisuid }}
+      {{- if eq $prefix $thisuid -}}
         srcset="
         {{- if ge $imgWidth 200 -}}
           {{- $imgBaseCDN -}}_bu.jpg 48w,
@@ -49,18 +46,18 @@
           {{- $imgBaseCDN -}}.{{- $imgExt }} {{ $imgWidth -}}w
         {{- end -}}
         "
-      {{- end }}
+      {{- end -}}
       sizes="(max-width: 800px) 100vw, 800px"
     />
   {{- else -}}
     <img
       src="{{- $imgBaseCDN -}}.{{- $imgExt -}}"
-      {{- if or (.Get "alt") $thisimg.alt }}
+      {{- if or (.Get "alt") $thisimg.alt -}}
         alt="{{- with .Get "alt" -}}
           {{- . -}}
         {{- else -}}
           {{- $thisimg.alt -}}
-        {{ end }}"
+        {{- end -}}
       {{- end -}}
     />
   {{- end -}}

--- a/themes/digital.gov/layouts/shortcodes/img.html
+++ b/themes/digital.gov/layouts/shortcodes/img.html
@@ -11,14 +11,15 @@
 {{- $imgCaption := $thisimg.caption -}}
 {{- $imgCredit := $thisimg.credit -}}
 {{- $prefix := replaceRE "^(http[s]://).+$" "$1" $thisuid -}}
+{{- $align := .Get "align" | default "" -}}
 
 
 <div
-  class="image{{- if (.Get "align") -}}
-    image-{{- .Get "align" -}}
-  {{- else }}
-    {{- if lt $imgWidth 600 -}}image-right{{- end -}}
-  {{- end -}}"
+  class="image{{- if $align }}
+    image-{{ $align }}
+  {{- else if lt $imgWidth 600 }}
+    image-right
+  {{- end }}"
 >
   {{- if (or (eq $imgExt "jpg") (or (eq $imgExt "jpeg") (eq $imgExt "png"))) -}}
     <img
@@ -27,7 +28,7 @@
       {{- else -}}
         {{- $imgBaseCDN -}}_w800.{{- $imgExt -}}
       {{- end -}}"
-      {{ if or (.Get "alt" ) $thisimg.alt }}
+      {{- if or (.Get "alt") $thisimg.alt }}
         alt="{{- with .Get "alt" -}}
           {{- . -}}
         {{- else -}}
@@ -53,13 +54,12 @@
         {{- end -}}
         "
       {{- end }}
-
       sizes="(max-width: 800px) 100vw, 800px"
     />
   {{- else -}}
     <img
       src="{{- $imgBaseCDN -}}.{{- $imgExt -}}"
-      {{ if or (.Get "alt" ) $thisimg.alt }}
+      {{- if or (.Get "alt") $thisimg.alt }}
         alt="{{- with .Get "alt" -}}
           {{- . -}}
         {{- else -}}
@@ -75,6 +75,5 @@
       {{- end -}}
     </p>
   {{- end -}}
-
 </div>
 <!-- image -->

--- a/themes/digital.gov/layouts/shortcodes/img.html
+++ b/themes/digital.gov/layouts/shortcodes/img.html
@@ -15,14 +15,10 @@
 
 
 <div
-  class="image{{- if $align }}
-    image-{{ $align }}
-  {{- else if lt $imgWidth 600 }}
-    image-right
-  {{- end }}"
+  class="image{{- if $align }} image-{{ $align }}{{- end }}"
 >
   {{- if (or (eq $imgExt "jpg") (or (eq $imgExt "jpeg") (eq $imgExt "png"))) -}}
-    <img
+    < img
       src="{{- if ne $prefix $thisuid -}}
         {{- $thisuid -}}
       {{- else -}}

--- a/themes/digital.gov/layouts/shortcodes/img.html
+++ b/themes/digital.gov/layouts/shortcodes/img.html
@@ -13,7 +13,8 @@
 {{- $prefix := replaceRE "^(http[s]://).+$" "$1" $thisuid -}}
 {{- $align := .Get "align" | default "" -}}
 
-<div class="image{{- if $align }} image-{{ $align }}{{- end }}">
+
+<div class="image{{- if $align }}image-{{ $align }}{{- end }}">
   {{- if or (eq $imgExt "jpg") (eq $imgExt "jpeg") (eq $imgExt "png") -}}
     <img
       src="{{- if ne $prefix $thisuid -}}

--- a/themes/digital.gov/layouts/shortcodes/img.html
+++ b/themes/digital.gov/layouts/shortcodes/img.html
@@ -14,7 +14,7 @@
 {{- $align := .Get "align" | default "" -}}
 
 <div class="image{{- if $align }} image-{{ $align }}{{- end }}">
-  {{- if (or (eq $imgExt "jpg") (or (eq $imgExt "jpeg") (eq $imgExt "png"))) -}}
+  {{- if or (eq $imgExt "jpg") (eq $imgExt "jpeg") (eq $imgExt "png") -}}
     <img
       src="{{- if ne $prefix $thisuid -}}
         {{- $thisuid -}}
@@ -26,7 +26,7 @@
           {{- . -}}
         {{- else -}}
           {{- $thisimg.alt -}}
-        {{- end -}}
+        {{- end -}}"
       {{- end -}}
       {{- if eq $prefix $thisuid -}}
         srcset="
@@ -57,13 +57,13 @@
           {{- . -}}
         {{- else -}}
           {{- $thisimg.alt -}}
-        {{- end -}}
+        {{- end -}}"
       {{- end -}}
     />
   {{- end -}}
   {{- if or $imgCaption $imgCredit -}}
     <p>
-      {{- $imgCaption | markdownify -}}{{- if $imgCredit }}
+      {{- $imgCaption | markdownify -}}{{- if $imgCredit -}}
         <span>—&nbsp;{{ $imgCredit | markdownify -}}</span>
       {{- end -}}
     </p>

--- a/themes/digital.gov/src/scss/new/_images.scss
+++ b/themes/digital.gov/src/scss/new/_images.scss
@@ -52,13 +52,9 @@
   @include u-display("block");
   @include u-margin-left("auto");
   @include u-margin-right("auto");
-  @include u-maxw("100%");
+  @include u-maxw("full");
   text-align: center;
 }
-
-
-
-
 
 img[alt] {
   font-style: italic;

--- a/themes/digital.gov/src/scss/new/_images.scss
+++ b/themes/digital.gov/src/scss/new/_images.scss
@@ -48,6 +48,18 @@
   @include u-width("card-lg");
 }
 
+.image-center {
+  @include u-display("block");
+  @include u-margin-left("auto");
+  @include u-margin-right("auto");
+  @include u-maxw("100%");
+  text-align: center;
+}
+
+
+
+
+
 img[alt] {
   font-style: italic;
 }


### PR DESCRIPTION
## Summary

Updated the Hugo img shortcode to handle the align parameter and removed the automatic assignment of the image-right class for images less than 600 pixels wide. Add new scss class for center

### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/fix-img-shortcode/)




### How To Test

1. Test image-center class
2. Test template


---

