### PR TITLE
a11y - fix heading order footer in contribute to digitalgov page

### DIFF
--- a/content/about/contribute.md
+++ b/content/about/contribute.md
@@ -60,7 +60,7 @@ Email [digitalgov@gsa.gov](mailto:digitalgov@gsa.gov) to volunteer to present or
 
 * **Huddles:** Huddles provide Digital.gov community members a place to discuss specific topics, share best practices, and spark ideas. Community huddles generally consist of a 5- to 10-minute presentation followed by a moderated, open mic discussion among panelists and community members.
 
-## Other ways to contribute
+### Other ways to contribute
 
 While we welcome event and content contributions from community members across all levels of experience, we know that can feel like a big leap, especially for folks who are new to the federal government or Digital.gov. So, we offer other ways to contribute.
 

--- a/content/resources/an-introduction-to-customer-experience.md
+++ b/content/resources/an-introduction-to-customer-experience.md
@@ -22,9 +22,9 @@ weight: 1
 ---
 ## What is customer experience?
 
-Customer experience (CX) is a person’s perception of an organization as a total sum of all of their experiences with that organization. For federal agencies, customer experience goes beyond individual transactions, or even a single agency, and encompasses the public's entire journey with government services. This includes everything from finding information to resolving issues. A deliberate [customer experience](https://digital.gov/topics/customer-experience/) strategy is to proactively design systems with the user in mind. 
+Customer experience (CX) is a person’s perception of an organization as a total sum of all of their experiences with that organization. For federal agencies, customer experience goes beyond individual transactions, or even a single agency, and encompasses the public's entire journey with government services. This includes everything from finding information to resolving issues. A deliberate [customer experience](https://digital.gov/topics/customer-experience/) strategy is to proactively design systems with the user in mind.
 
-When the public has positive interactions with a government service, it builds [trust](https://digital.gov/topics/trust/) in the government as a whole. Furthermore, a strong customer experience focus makes government more effective and efficient, saving both the public and the government time and resources. 
+When the public has positive interactions with a government service, it builds [trust](https://digital.gov/topics/trust/) in the government as a whole. Furthermore, a strong customer experience focus makes government more effective and efficient, saving both the public and the government time and resources.
 
 The ultimate goal of customer experience in the federal government is to ensure that our services successfully meet the public's needs, leading to better outcomes for individuals, and the nation.
 
@@ -36,7 +36,7 @@ Engage in comprehensive customer and user research, both qualitatively and quant
 
 ## How to start measuring customer experience
 
-Measuring a customer’s experience provides insight on how to improve a digital product or service. Tracking the customer journey involves collecting and analyzing data from various sources to effectively understand customer interactions. 
+Measuring a customer’s experience provides insight on how to improve a digital product or service. Tracking the customer journey involves collecting and analyzing data from various sources to effectively understand customer interactions.
 
 Here are some approaches you can use to leverage customer feedback and analytics:
 
@@ -46,9 +46,9 @@ Here are some approaches you can use to leverage customer feedback and analytics
 * **Analyze the data and information** to identify areas that should be improved.
 * **Iterate** to continuously improve and enhance customer experience.
 
-## What can I do next? 
+## What can I do next?
 
-If you manage a federal website, be sure you understand [the requirements for transforming federal customer experience and service delivery](https://www.whitehouse.gov/briefing-room/presidential-actions/2021/12/13/executive-order-on-transforming-federal-customer-experience-and-service-delivery-to-rebuild-trust-in-government/) to rebuild trust in government. Also, learn how to use and optimize the Digital Analytics Program and Touchpoints. 
+If you manage a federal website, be sure you understand [the requirements for transforming federal customer experience and service delivery](https://www.whitehouse.gov/briefing-room/presidential-actions/2021/12/13/executive-order-on-transforming-federal-customer-experience-and-service-delivery-to-rebuild-trust-in-government/) to rebuild trust in government. Also, learn how to use and optimize the Digital Analytics Program and Touchpoints.
 
 For example, at GSA, the agency’s Digital Presence Guidelines state, “All GSA public-facing websites must participate in the federal Digital Analytics Program by including the DAP tracking code on your website. All GSA public-facing websites should review site usage and search metrics at least monthly, and use the data to make informed decisions on how to continuously improve your site and exceed customer expectations. In addition to DAP, GSA sites have access to the free standard version of Google Analytics. GSA program offices should use this version of Google Analytics on your external and internal websites, if you need data capabilities above and beyond what DAP offers.”
 

--- a/content/resources/digitalgov-user-experience-program-speaking-opportunities.md
+++ b/content/resources/digitalgov-user-experience-program-speaking-opportunities.md
@@ -35,7 +35,7 @@ Potential audiences include:
 **User Centered Design** (November 2013)
   
 **Usability Testing and Debriefing Best Practices** (March 2012)
- 
+
 ## Our Presentations
 
 <iframe src="//www.slideshare.net/slideshow/embed_code/key/fRnpmnC0DUZCq" width="595" height="485" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe> <div style="margin-bottom:5px"> <strong> <a href="//www.slideshare.net/DigitalGov/why-the-best-gov-sites-use-user-centered-design" title="Why the best gov sites use User-Centered Design" target="_blank">Why the best gov sites use User-Centered Design</a> </strong> from <strong><a href="https://www.slideshare.net/DigitalGov" target="_blank">DigitalGov from General Services Administration</a></strong> </div>

--- a/content/resources/requirements-for-the-registration-and-use-of-gov-domains-in-the-federal-government.md
+++ b/content/resources/requirements-for-the-registration-and-use-of-gov-domains-in-the-federal-government.md
@@ -80,13 +80,13 @@ As a best practice, consider setting up a process to continuously monitor and ev
 
 ### How to register or renew a .gov domain
 
-To register or renew a .gov domain, follow the [domain name requirements](https://get.gov/domains/) outlined on [Get.gov](https://get.gov/). 
+To register or renew a .gov domain, follow the [domain name requirements](https://get.gov/domains/) outlined on [Get.gov](https://get.gov/).
 
-You should also review the [naming requirements for executive branch federal agencies](https://get.gov/domains/executive-branch-guidance/#naming-requirements-for-executive-branch-federal-agencies) that were issued along with M-23-10, The Registration and Use of .gov Domains in the Federal Government. All requests must be approved by your Chief Information Officer or head of agency, and include a description of how the domain will be used, its intended audience, why the domain is needed, and how the domain will conform to OMB policies and requirements. 
+You should also review the [naming requirements for executive branch federal agencies](https://get.gov/domains/executive-branch-guidance/#naming-requirements-for-executive-branch-federal-agencies) that were issued along with M-23-10, The Registration and Use of .gov Domains in the Federal Government. All requests must be approved by your Chief Information Officer or head of agency, and include a description of how the domain will be used, its intended audience, why the domain is needed, and how the domain will conform to OMB policies and requirements.
 
-OMB reviews executive branch agency domain requests and may contact the submitting agency with any questions during the process; they may deny a domain request or domain renewal. 
+OMB reviews executive branch agency domain requests and may contact the submitting agency with any questions during the process; they may deny a domain request or domain renewal.
 
-Federal agencies can establish .gov domain names for any legitimate purpose and can register domains as needed to most effectively meet their mission. However, .gov domain names are a shared resource across all U.S.-based government organizations, and agencies have a responsibility to carefully consider how potential domains might impact the public and how they interact with government information and services. 
+Federal agencies can establish .gov domain names for any legitimate purpose and can register domains as needed to most effectively meet their mission. However, .gov domain names are a shared resource across all U.S.-based government organizations, and agencies have a responsibility to carefully consider how potential domains might impact the public and how they interact with government information and services.
 
 {{< ring title="OMB Memo M-23-10">}}
 [Explore OMB Memo M-23-10, The Registration and Use of .gov Domains in the Federal Government (PDF, 98 KB, 3 pages)](https://www.whitehouse.gov/wp-content/uploads/2023/02/M-23-10-DOTGOV-Act-Guidance.pdf)

--- a/themes/digital.gov/layouts/partials/core/get_sharetools.html
+++ b/themes/digital.gov/layouts/partials/core/get_sharetools.html
@@ -46,7 +46,7 @@
         aria-label="Share on LinkedIn"
         target="_blank"
         rel="noreferrer"
-        href="https://www.linkedin.com/shareArticle?mini=true&url=https://digital.gov{{ (urls.Parse .Permalink) }}&title={{ .Title | urlize }}&summary={{ .Params.summary | urlize }}&source={{ "Digital.gov" | urlize }}"
+        href="https://www.linkedin.com/feed/?shareActive&mini=true&url=https://digital.gov{{ (urls.Parse .Permalink) }}&title={{ .Title | urlize }}&text={{ .Params.summary | urlize }}&source={{ "Digital.gov" | urlize }}"
       >
         <svg
           class="usa-icon dg-icon dg-icon--large margin-bottom-05"

--- a/themes/digital.gov/layouts/partials/core/get_sharetools.html
+++ b/themes/digital.gov/layouts/partials/core/get_sharetools.html
@@ -46,7 +46,7 @@
         aria-label="Share on LinkedIn"
         target="_blank"
         rel="noreferrer"
-        href="https://www.linkedin.com/feed/?shareActive&mini=true&url=https://digital.gov{{ (urls.Parse .Permalink) }}&title={{ .Title | urlize }}&text={{ .Params.summary | urlize }}&source={{ "Digital.gov" | urlize }}"
+        href="https://www.linkedin.com/sharing/share-offsite/?url={{ (urls.Parse .Permalink) }}&title={{ .Title | urlize }}&summary={{ .Params.summary | urlize }}&source={{ "Digital.gov" | urlize }}"
       >
         <svg
           class="usa-icon dg-icon dg-icon--large margin-bottom-05"

--- a/themes/digital.gov/layouts/partials/core/get_sharetools.html
+++ b/themes/digital.gov/layouts/partials/core/get_sharetools.html
@@ -46,7 +46,7 @@
         aria-label="Share on LinkedIn"
         target="_blank"
         rel="noreferrer"
-        href="https://www.linkedin.com/sharing/share-offsite/?url={{ (urls.Parse .Permalink) }}&title={{ .Title | urlize }}&summary={{ .Params.summary | urlize }}&source={{ "Digital.gov" | urlize }}"
+        href="https://www.linkedin.com/sharing/share-offsite/?url={{ (urls.Parse .Permalink) }}"
       >
         <svg
           class="usa-icon dg-icon dg-icon--large margin-bottom-05"

--- a/themes/digital.gov/layouts/partials/core/get_sharetools.html
+++ b/themes/digital.gov/layouts/partials/core/get_sharetools.html
@@ -27,7 +27,7 @@
         aria-label="Share on Facebook"
         target="_blank"
         rel="noreferrer"
-        href="http://www.facebook.com/sharer.php?u=https://digital.gov{{ (urls.Parse .Permalink) }}&t={{ .Title | urlize }}"
+        href="https://www.facebook.com/sharer/sharer.php?u=https://digital.gov{{ (urls.Parse .Permalink) }}"
       >
         <svg
           class="usa-icon dg-icon dg-icon--large margin-bottom-05"


### PR DESCRIPTION
## Summary
The header is breaking the semantic header structure on pages. The "Contribute to Digital.gov" page in the "About" section has a header, titled "Other ways to contribute" that has a mis-sized header. 

This change impacts only the "Contribute to Digital.gov" page in the "About" section, but a similar problem may persist on other changes.

Related to [#6075].

### Preview
[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/kl-a11y-fix-heading-order-footer/about/contribute/)

### Solution
Apply manual fix to .md page, correcting header from h2 to h3

###Screenshots
**Before:**
<img width="722" alt="Screenshot 2024-06-18 at 12 11 56 PM" src="https://github.com/GSA/digitalgov.gov/assets/90117979/eacec172-854b-4b81-8c37-0b68bc57fe81">

<img width="787" alt="Screenshot 2024-06-18 at 12 12 46 PM" src="https://github.com/GSA/digitalgov.gov/assets/90117979/931720bc-ab79-421f-9664-df1de28381f8">

**After:**
<img width="678" alt="Screenshot 2024-06-18 at 12 15 11 PM" src="https://github.com/GSA/digitalgov.gov/assets/90117979/eadb9ec0-fa2d-45b7-9bb7-3874112fce04">

<img width="812" alt="Screenshot 2024-06-18 at 12 28 45 PM" src="https://github.com/GSA/digitalgov.gov/assets/90117979/fe1d94e0-87d3-4fe7-be06-0e6908b06b89">



### Dev Checklist
- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
