### PR TITLE
Update the CTA on policy cards

### DIFF
--- a/themes/digital.gov/layouts/partials/core/card-legislation.html
+++ b/themes/digital.gov/layouts/partials/core/card-legislation.html
@@ -26,7 +26,7 @@
       {{ end }}
       {{ if .link }}
         <div class="usa-card__footer">
-          <a href="{{- .link | relURL -}}" class="usa-button"> View policy </a>
+          <a href="{{- .link | relURL -}}" class="usa-button"> Explore policy </a>
         </div>
       {{ end }}
     </div>

--- a/themes/digital.gov/layouts/partials/core/card-legislation.html
+++ b/themes/digital.gov/layouts/partials/core/card-legislation.html
@@ -26,7 +26,7 @@
       {{ end }}
       {{ if .link }}
         <div class="usa-card__footer">
-          <a href="{{- .link | relURL -}}" class="usa-button"> Explore policy </a>
+          <a href="{{- .link | relURL -}}" class="usa-button">Explore policy</a>
         </div>
       {{ end }}
     </div>


### PR DESCRIPTION
## Summary

This updates the text from "View policy" to "explore policy" on topic cards. 

Was:
<img width="1010" alt="image" src="https://github.com/GSA/digitalgov.gov/assets/96838068/1bd5cb2e-f59c-4129-b3b3-af1cc31d5d42">

Now:

<img width="1008" alt="Screenshot 2024-06-25 at 2 07 37 PM" src="https://github.com/GSA/digitalgov.gov/assets/104778659/f9b0112a-804f-41f8-9da8-9af8dd1624e1">


### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/bc-update-policycard-cta/topics/artificial-intelligence/)

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

1. First Step
2. Second Step
3. Third Step

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
