### PR TITLE
Update web-managers-forum.md

### DIFF
--- a/content/communities/web-managers-forum.md
+++ b/content/communities/web-managers-forum.md
@@ -15,9 +15,30 @@ aliases:
 # see all topics at https://digital.gov/topics
 topics:
   - analytics
-  - product-and-project-management
-  - user-experience
+  - accessibility
+  - communication
+  - customer-experience
   - content-strategy
+  - design
+  - plain-language
+  - product-and-project-management
+  - usability
+  - user-experience
+  - governance
+  - digital-service-delivery
+  - user-centered-design
+  - human-centered-design
+  - search-engine-optimization
+  - multimedia
+  - multilingual
+  - mobile
+  - policy
+  - information-architecture
+  - social-media
+  - privacy
+  - security
+
+
 # see all authors at https://digital.gov/authors
 authors:
   - toni-bonitto


### PR DESCRIPTION
## Summary

Web Content Managers covers the breadth of our work-- but had only 4 topics, which kept it from appearing as a related community to join on events, resources, etc.

Expanded topics list from 4 to 23

### Preview
Live event page https://digital.gov/event/2024/05/16/uswds-monthly-call-may-2024/ does not have WM in the Join a Community list

https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/expand-topics/event/2024/05/16/uswds-monthly-call-may-2024/ 
now it does

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

1. First Step
2. Second Step
3. Third Step

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
