### PR TITLE
Display communities in alphabetical order

### DIFF
--- a/themes/digital.gov/layouts/partials/core/featured-communities.html
+++ b/themes/digital.gov/layouts/partials/core/featured-communities.html
@@ -9,14 +9,11 @@
 {{ $context := .context }}
 {{ $layout := .layout }}
 
+{{/* list featured communities in alphabetical order */}}
 {{ $page_header := $context.Site.GetPage "/communities" }}
 {{ $communities := (where $context.Site.Pages "Section" "communities").ByTitle }}
 {{ $communities = (where $communities ".Params.weight" "ge" 1) }}
 {{ $dg_communities := (where $communities ".Params.dg_highlight" "eq" true) }}
-{{/* featured community is listed first, followed by the other dg 7 listed alphabetically by title */}}
-{{ $featured_community := (where $communities ".Params.weight" "eq" 2) }}
-{{ $dg_communities = union $featured_community $dg_communities }}
-
 
 <div class="page-head">
   {{ with $page_header }}

--- a/themes/digital.gov/layouts/partials/core/featured-communities.html
+++ b/themes/digital.gov/layouts/partials/core/featured-communities.html
@@ -15,6 +15,7 @@
 {{ $communities = (where $communities ".Params.weight" "ge" 1) }}
 {{ $dg_communities := (where $communities ".Params.dg_highlight" "eq" true) }}
 
+
 <div class="page-head">
   {{ with $page_header }}
     <h1>{{- .Title | markdownify -}}</h1>


### PR DESCRIPTION
## Summary
Display communities in alphabetical order, see [preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-display-cop-alphabetically/communities/)

---

### Dev Checklist

- [x] PR has correct labels
- [x] A11y testing (voice over testing, meets WCAG, run axe tools)
- [x] Code is formatted properly
