### PR TITLE
Formatting changes for services/directory

### DIFF
--- a/themes/digital.gov/layouts/services/directory.html
+++ b/themes/digital.gov/layouts/services/directory.html
@@ -25,7 +25,7 @@
     {{- $services := (where $services ".Params.weight" "ge" 1) -}}
 
 
-    <div class="grid-container grid-container-desktop-lg">
+    <div class="grid-container grid-container-desktop-lg directory">
       <div class="grid-row">
         <div class="grid-col-12">
           {{/* Gather all the service pages */}}

--- a/themes/digital.gov/src/scss/new/_service-contact.scss
+++ b/themes/digital.gov/src/scss/new/_service-contact.scss
@@ -7,7 +7,6 @@
   @include u-line-height("sans", 3);
   @include u-bg("white");
   @include u-border-bottom("1px", "gray-cool-10", "solid");
-  @include u-bg("white");
 
   @include at-media("tablet") {
     @include u-padding-y("105");
@@ -17,6 +16,7 @@
   .copy {
     @include u-display("flex");
     @include u-flex("align-start");
+    @include u-overflow("hidden");
 
     p {
       @include u-margin-top(0);

--- a/themes/digital.gov/src/scss/new/_services-directory.scss
+++ b/themes/digital.gov/src/scss/new/_services-directory.scss
@@ -2,10 +2,6 @@
 
 .services-contacts {
   @include u-bg("blue-warm-5");
-
-  header {
-    @include u-margin-bottom(5);
-  }
 }
 
 .service-contact-heading {
@@ -14,4 +10,8 @@
   @include at-media("tablet") {
     @include u-display("block");
   }
+}
+
+.directory {
+  @include u-padding-bottom(10);
 }


### PR DESCRIPTION
- Removed unnecessary header margin, added padding to directory table
- Hide overflow to prevent text clipping

### Changes
**services/directory.html**
<details>

<summary>Removed unnecessary margin for header and hide overflow</summary>
before:

<img width="397" src="https://github.com/GSA/digitalgov.gov/assets/113953467/cb223b03-a708-43b8-8408-8633f1b77af4">

---

after:

<img width="397" src="https://github.com/GSA/digitalgov.gov/assets/113953467/f1a68bb6-bb76-49c5-9e35-2188e97b21df">


</details>

See here for [preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/tc-services-formatting/services/directory/)

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

1. First Step
2. Second Step
3. Third Step

---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
