### PR TITLE
Default to full sized images

### DIFF
--- a/themes/digital.gov/layouts/shortcodes/img.html
+++ b/themes/digital.gov/layouts/shortcodes/img.html
@@ -23,7 +23,7 @@
 {{- $thisuid := replaceRE "\\.[jpegpn]{3,4}$" "" $thisuid -}}
 {{- $thisimg := index $.Site.Data.images $thisuid -}}
 {{- $imgBase := $thisimg.uid -}}
-{{- $imgExt := $thisimg.format -}}
+{{- $imgExt := $thisimg.format  -}}
 {{- $imgBaseCDN := printf "%s/%s" $cdnurl $imgBase -}}
 {{- $imgWidth := $thisimg.width -}}
 {{- $imgHeight := $thisimg.height -}}
@@ -41,14 +41,13 @@
   {{ $imageClasses = $imageClasses | append "image-inline" }}
 {{ end }}
 
-
 <div class="{{ delimit $imageClasses " " }}">
   {{- if or (eq $imgExt "jpg") (eq $imgExt "jpeg") (eq $imgExt "png") -}}
     <img
       src="{{- if ne $prefix $thisuid -}}
         {{- $thisuid -}}
       {{- else -}}
-        {{- $imgBaseCDN -}}_w800.{{- $imgExt -}}
+        {{- $imgBaseCDN -}}_w1200.{{- $imgExt -}}
       {{- end -}}"
       {{- if or (.Get "alt") $thisimg.alt -}}
         alt="{{- with .Get "alt" -}}
@@ -76,7 +75,7 @@
         {{- end -}}
         "
       {{- end -}}
-      sizes="(max-width: 800px) 100vw, 400px"
+      sizes="(max-width: 800px) 100vw, 1200px"
     />
   {{- else -}}
     <img


### PR DESCRIPTION
## Summary
Updated the image shortcode to change the default size in the src attribute from 800px to 1200px, ensuring images are displayed at their correct sizes. 


Basic description of work done. Closes [#issue_no].

### Preview

[Link to Preview]()



### Solution
Changed the default size in the src attribute from 800px to 1200px. This ensures that the larger image size is used by default, addressing the issue of images appearing smaller than intended.

### How To Test
1. Open the preview link to verify that images are displayed at their intended sizes.
2. Compare with the original design using the Wayback Machine to ensure consistency.
3. Resize the browser window to test the responsive behavior of the images.

<img width="1440" alt="Screen Shot 2024-07-02 at 12 21 02 PM" src="https://github.com/GSA/digitalgov.gov/assets/172419749/15720400-b16f-4b02-9868-6749e28612ea">
<img width="1440" alt="Screen Shot 2024-07-02 at 12 21 47 PM" src="https://github.com/GSA/digitalgov.gov/assets/172419749/182fa439-64c2-49b8-844a-7201c190d8f6">
<img width="1440" alt="Screen Shot 2024-07-02 at 12 22 08 PM" src="https://github.com/GSA/digitalgov.gov/assets/172419749/d34ebf63-41b3-4043-9400-368c6b8e0b1d">


---

### Dev Checklist

- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
- [ ] Code is formatted properly
