### PR TITLE
Add redirect from topics to resources landing page

### DIFF
--- a/content/topics/_index.md
+++ b/content/topics/_index.md
@@ -2,5 +2,5 @@
 title: "Topics"
 summary: ""
 primary_image: "topics-og-primary-image"
-redirectto: https://digital.gov/resources/
+expirydate: 2024-07-03
 ---

--- a/content/topics/_index.md
+++ b/content/topics/_index.md
@@ -2,4 +2,5 @@
 title: "Topics"
 summary: ""
 primary_image: "topics-og-primary-image"
+redirectto: /resources
 ---

--- a/content/topics/_index.md
+++ b/content/topics/_index.md
@@ -2,5 +2,5 @@
 title: "Topics"
 summary: ""
 primary_image: "topics-og-primary-image"
-redirectto: /resources
+redirectto: https://digital.gov/resources/
 ---

--- a/content/topics/_index.md
+++ b/content/topics/_index.md
@@ -2,5 +2,8 @@
 title: "Topics"
 summary: ""
 primary_image: "topics-og-primary-image"
-expirydate: 2024-07-03
+redirectto: "https://digital.gov/resources/"
+# Using redirectto instead of alias as there are nearly 400 Hugo shortcodes
+# example {{< ref "/topics/mobile" >}}
+
 ---


### PR DESCRIPTION
## Summary
Add `redirectto` field to `/topics` to redirect to `/resources`.

### Preview
[Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-topics-redirect/topics)


### Solution

---

