### PR TITLE
Rs hotfix/fix corrupt image uploads

### DIFF
--- a/config/gulp/file-upload.js
+++ b/config/gulp/file-upload.js
@@ -24,7 +24,9 @@ const headers = {
 
 function uploadImage() {
   return gulp
-    .src("content/uploads/_working-images/processed/*")
+    .src("content/uploads/_working-images/processed/*", { 
+      encoding: false,
+    })
     .pipe(publisher.publish(headers))
     .pipe(
       awspublish.reporter({
@@ -44,7 +46,9 @@ function uploadFile() {
   });
 
   return gulp
-    .src("content/uploads/_working-files/to-process/*")
+    .src("content/uploads/_working-files/to-process/*", { 
+      removeBOM: true, 
+    })
     .pipe(staticRename)
     .pipe(publisher.publish(headers))
     .pipe(
@@ -114,33 +118,19 @@ function determineWhichToUpload() {
 
     if (imageFiles.length > 0) {
       uploadsToComplete += 1;
-      const imageUploadStream = uploadImage();
-      imageUploadStream.on('finish', () => {
-        uploadsCompleted += 1;
-        checkCompletion();
-      });
-      imageUploadStream.on('error', (err) => {
-        console.error("Error uploading images:", err);
-        reject(err);
-      });
+      uploadImage(); 
+      uploadsCompleted += 1;
+      checkCompletion();
     }
 
     if (fileFiles.length > 0) {
       uploadsToComplete += 1;
-      const fileUploadStream = uploadFile();
-      fileUploadStream.on('finish', () => {
-        uploadsCompleted += 1;
-        checkCompletion();
-      });
-      fileUploadStream.on('error', (err) => {
-        console.error("Error uploading files:", err);
-        reject(err);
-      });
+      uploadFile();
+      uploadsCompleted += 1;
+      checkCompletion();
     }
 
-    if (uploadsToComplete === 0) {
-      resolve(); // If no uploads are initiated, resolve immediately.
-    }
+  return resolve();
   });
 }
 

--- a/config/gulp/file-upload.js
+++ b/config/gulp/file-upload.js
@@ -65,20 +65,18 @@ function uploadFile() {
 function cleanup() {
   return new Promise((resolve, reject) => {
     let imageDir = "content/uploads/_working-images/processed";
-    let fileDir = "content/uploads/_working-files/to-process";
+    let fileDir = "content/uploads/_working-files";
 
     if (fs.existsSync(imageDir)) {
-      if (fs.readdirSync(imageDir).length > 0) {
-        console.log(`Images have number of files ${fs.readdirSync(imageDir).length}`);
-        // delete tht folder
-        del([imageDir]);
-        resolve();
-      } else {
-        resolve();
-      }
-    } else {
-      resolve();
+      // remove the folder
+      del([imageDir]);
+    } 
+
+    if (fs.existsSync(fileDir)) {
+      // remove the folder
+      del([fileDir]);
     }
+    resolve();
   });
 }
 


### PR DESCRIPTION
## Summary

Implements the fix mentioned [here](https://github.com/gulpjs/gulp/issues/2803#issuecomment-2114188780)
Closes #7780.

### Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/rs-hotfix/fix-corrupt-image-uploads/)

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

### Solution

### How To Test

1. Add an image to `content\uploads\_inbox\__add image or static files to this folder__`
2. Run npx gulp upload
3. Click the link that appears in the generated YAML
4. Notice the image now renders. 
---

### Dev Checklist

- [x] PR has correct labels
- [x] A11y testing (voice over testing, meets WCAG, run axe tools)
- [x] Code is formatted properly
