### PR TITLE
Changed lastmod tag to contain last update on Git

### DIFF
--- a/config/gulp/upload.js
+++ b/config/gulp/upload.js
@@ -47,7 +47,7 @@ const fileDir = "content/uploads/_working-files/to-process/";
 async function uploadImage(filePath, fileName) {
     try {
         const fileContent = await fs.promises.readFile(filePath);
-        let contentType = mimeTypes.lookup(filePath) || "application/octet-stream";
+        const contentType = mimeTypes.lookup(filePath) || "application/octet-stream";
         await client.send(new AWS.PutObjectCommand({
             Bucket: bucketName,
             Key: fileName,
@@ -126,10 +126,10 @@ async function cleanup() {
  * Initiates the upload process for both images and files
  */
 const upload = async () => {
-    let imageDirExists = fs.existsSync(imageDir);
-    let imageFiles = imageDirExists ? fs.readdirSync(imageDir) : [];
-    let fileDirExists = fs.existsSync(fileDir);
-    let fileFiles = fileDirExists ? fs.readdirSync(fileDir) : [];
+    const imageDirExists = fs.existsSync(imageDir);
+    const imageFiles = imageDirExists ? fs.readdirSync(imageDir) : [];
+    const fileDirExists = fs.existsSync(fileDir);
+    const fileFiles = fileDirExists ? fs.readdirSync(fileDir) : [];
     try {
         // Upload image files
         for (const file of imageFiles) {

--- a/themes/digital.gov/layouts/sitemap.xml
+++ b/themes/digital.gov/layouts/sitemap.xml
@@ -1,8 +1,8 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {{ range .Data.Pages }}
   <url>
-    <loc>https://digital.gov{{ .Permalink | relURL }}</loc>
-    <lastmod>{{ safeHTML ( .Date | time.Format "2006-01-02" ) }}</lastmod>
+    <loc>https://digital.gov{{ .Permalink | relURL }}</loc>{{ with .GitInfo }}
+    <lastmod>{{ .AuthorDate.Format "2006-01-02" }}</lastmod>{{ end }}
     {{ with .Sitemap.ChangeFreq }}<changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
     <priority>{{ .Sitemap.Priority }}</priority>{{ end }}
   </url>


### PR DESCRIPTION
## Summary

Previously, `lastmod` tag contained page publish date, which does not account for any updates made to the page after its publish date. Changing the `lastmod` tag to contain last update on Git applies a more accurate date to each page, strengthening search results on Digital.gov

Continuation of work done on pr #7801 

## Preview

Comparison between updated Sitemap `lastmod` date with its associate Git update date
![Screenshot 2024-08-05 at 9 47 26 AM](https://github.com/user-attachments/assets/47286cb9-1efe-4303-ace2-baa119e8de7d)



Comparison between updated Sitemap `lastmod` date with its associate Git update date
![Screenshot 2024-08-05 at 9 54 17 AM](https://github.com/user-attachments/assets/ee708806-5d6d-454c-8c41-f14c7902d1b3)


## How To Test

1. Find a page that has been recently updated (not published) on Github
2. Run localhost
3. Find associated page in sitemap, check if date is the same as the Github date


<!--
## Dependency updates

| Dependency name              | Previous version | New version |
| ---------------------------- | :--------------: | :---------: |
| [Updated dependency example] |     [1.0.0]      |   [1.0.1]   |
| [New dependency example]     |        --        |   [3.0.1]   |
| [Removed dependency example] |     [2.10.2]     |     --      |
-->

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Branch is up-to-date and includes latest from `main`
- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
-->
