### PR TITLE
Updating speakers on USWDS Aug 2024 event page

### DIFF
--- a/content/events/2024/08/2024-08-15-uswds-monthly-call-august-2024.md
+++ b/content/events/2024/08/2024-08-15-uswds-monthly-call-august-2024.md
@@ -39,7 +39,8 @@ In this online session with the USWDS team, you will:
 
 * **Dan Williams** - Product Lead, USWDS
 * **Matt Henry** - Engineering Lead, USWDS
-* **James Mejia** - Developer, USWDS contractor
+* **Anne Petersen** - Experience Design Lead, USWDS
+* **Amy Leadem** - Developer, USWDS contractor
 
 ## Join our Communities of Practice
 


### PR DESCRIPTION
## Summary

Updating speaker list per updated event brief.

## Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/brunerae-USWDS-aug-mc-speaker-update/event/2024/08/15/uswds-monthly-call-august-2024/)

-->


## How To Test

1. Navigate to event page
2. Verify it lists same speakers as [event brief](https://docs.google.com/document/d/186KgWqvof7utMdzGaPySO3cRMrP5C8gT18kdV5iLMq0/edit)

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [X] Branch is up-to-date and includes latest from `main`
- [x] PR has correct labels
- [x] A11y testing (voice over testing, meets WCAG, run axe tools)
-->
