### PR TITLE
Adding ppt file to USWDS August 2024 Event

### DIFF
--- a/content/events/2024/08/2024-08-15-uswds-monthly-call-august-2024.md
+++ b/content/events/2024/08/2024-08-15-uswds-monthly-call-august-2024.md
@@ -22,9 +22,10 @@ slug: uswds-monthly-call-august-2024
 event_platform: zoom
 
 primary_image: 2024-uswds-monthly-call-aug-title-card
-{{< asset-static file="uswds-monthly-call-august-2024.pptx" label="View the slides (Powerpoint presentation, 3.6 MB, 48 slides)">}}
 
 ---
+
+{{< asset-static file="uswds-monthly-call-august-2024.pptx" label="View the slides (Powerpoint presentation, 3.6 MB, 48 slides)">}}
 
 Join the U.S. Web Design System (USWDS) team to understand their progress toward developing beta web components. They’ll also answer questions and requests posted by the [community in the community choice discussion thread for the August monthly call on GitHub](https://github.com/uswds/uswds/discussions/5923). 
 

--- a/content/events/2024/08/2024-08-15-uswds-monthly-call-august-2024.md
+++ b/content/events/2024/08/2024-08-15-uswds-monthly-call-august-2024.md
@@ -22,6 +22,7 @@ slug: uswds-monthly-call-august-2024
 event_platform: zoom
 
 primary_image: 2024-uswds-monthly-call-aug-title-card
+{{< asset-static file="uswds-monthly-call-august-2024.pptx" label="View the slides (Powerpoint presentation, 3.6 MB, 48 slides)">}}
 
 ---
 


### PR DESCRIPTION
## Summary

Adding the PowerPoint file to the event page.

## Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/brunerae-uswds-aug-mc-ppt/event/2024/08/15/uswds-monthly-call-august-2024/)

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

## How To Test

1. Navigate to event page
2. Check that PowerPoint is there
3. Click to download


<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [x] Branch is up-to-date and includes latest from `main`
- [x] PR has correct labels
- [x] A11y testing (voice over testing, meets WCAG, run axe tools)
-->
