### PR TITLE
Create Sep 2024 USWDS Monthly Call

### DIFF
--- a/content/events/2024/9/2024-09-19-uswds-monthly-call-september-2024
+++ b/content/events/2024/9/2024-09-19-uswds-monthly-call-september-2024
@@ -1,0 +1,63 @@
+---
+title: USWDS Monthly Call - September 2024
+deck: The landscape of Web Components
+kicker: USWDS
+summary: The U.S. Web Design System team will share their exploration of Web Component-based design systems and best practices. 
+event_organizer: Digital.gov
+cop_events: ""
+registration_url: https://gsa.zoomgov.com/meeting/register/vJIsdemgrT8tHZvOdHYHRTKhveBs1rHPdBc
+end_date: 2024-09-19 15:00:00 -0500
+
+# See all topics at https://digital.gov/topics
+topics:
+  - design
+  - human-centered-design
+  - software-engineering
+  - open-source
+
+slug: uswds-monthly-call-september-2024
+
+# zoom, youtube_live, adobe_connect, google
+event_platform: zoom
+
+primary_image: 2024-uswds-monthly-call-sep-title-card
+
+---
+
+This month, join the U.S. Web Design System (USWDS) team in exploring the landscape of Web Components. The team will share their recent landscape analysis of Web Components-based design systems and discuss how these findings set a course for future USWDS development.  
+
+In this online session with the USWDS team, you will:
+
+* Learn what’s new in USWDS 3.9
+* Explore how other design systems are approaching Web ComponentsGain insight to the team’s thoughts about where USWDS might fit in the broader landscape of modern design systems
+
+
+**This event is best suited for:** Design system users of all levels. This will be a technical discussion geared toward developers, but anyone can attend; it requires no specialized knowledge.
+
+**Speakers**
+
+* **Dan Williams** - Product Lead, USWDS
+* **Matt Henry** - Engineering Lead, USWDS
+* **Anne Petersen** - Experience Design Lead, USWDS
+* **Jacline Contrino** - UX Researcher, USWDS contractor
+
+## Join our Communities of Practice
+
+* [USWDS](https://designsystem.digital.gov/about/community/)
+* [Section 508 IT Accessibility](https://www.section508.gov/manage/join-the-508-community/)
+
+*This event is part of a monthly series that takes place on the third Thursday of each month. Don’t forget to set a placeholder on your personal calendar for our future events this year.*
+
+## About the USWDS
+
+[The U.S. Web Design System](https://designsystem.digital.gov/) is a toolkit of principles, guidance, and code to help government teams design and build accessible, mobile-friendly websites backed by user research and modern best practices.
+
+* [The U.S. Web Design System](https://designsystem.digital.gov/)
+* [Contribute on GitHub](https://github.com/uswds/uswds/issues)
+* [Email Us](mailto:uswds@gsa.gov)
+* [Join our community](https://digital.gov/communities/uswds/)
+* [Follow @uswds on Twitter](https://twitter.com/uswds)
+
+---
+
+*Disclaimer*: All references to specific brands, products, and/or companies are used only for illustrative purposes and do not imply endorsement by the U.S. federal government or any federal government agency.


### PR DESCRIPTION
## Summary

Creating the event page for the Sep 2024 USWDS Monthly Call.

## Preview

[Link to Preview]()

## How To Test

1. Navigate to Events page
2. Click on August 2024 USWDS Monthly Call
3. Review page to ensure content matches the [event brief](https://docs.google.com/document/d/1N_Bfeak5yyaAn_JrwHNZx3KqNf80POfCK6I445QnL0M/edit)
4. Ensure image matches the title card linked in event brief
