### PR TITLE
Bug: Update inpage nav setting to target H2s

### DIFF
--- a/themes/digital.gov/layouts/resources/single.html
+++ b/themes/digital.gov/layouts/resources/single.html
@@ -21,6 +21,7 @@
           data-title-heading-level="h4"
           data-root-margin="-350px 0px -350px 0px"
           aria-label="Related content"
+          data-heading-elements="h2"
         >
           <div class="dg-related-items" data-related-items>
             {{- partial "core/get_related.html" . -}}


### PR DESCRIPTION
## Summary
Added setting in `in-pav nav` to only target `H2` elements

## Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/cm-inpage-nav-fix/resources/how-to-build-an-analytics-strategy/)

## Solution

Added `data-heading-elements="h2"` which can be found [here in the USWDS docs](https://designsystem.digital.gov/components/in-page-navigation/#using-the-in-page-navigation-component-2) 

**Before and After**
<img width="1507" alt="Screenshot 2024-09-12 at 4 24 04 PM" src="https://github.com/user-attachments/assets/65c4a044-a0d9-4d0e-8788-46cfdcde3da1">


<!--
It can be helpful if we understand:
1. What the solution is,
2. Why this approach was chosen,
3. How you implemented the change, and
4. Possible limitations of this approach and alternate solution paths.
-->


## How To Test

Visit [Preview 1](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/cm-inpage-nav-fix//resources/checklist-of-requirements-for-federal-digital-services/) and [Preview 2](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/cm-inpage-nav-fix//resources/an-introduction-to-pronouns/) and verify that the inpage nav is only showing the H2s 

<!--
For PRs that include dependency updates, uncomment this section and
include a list of the changed dependencies and version numbers.
-->

<!--
## Dependency updates

| Dependency name              | Previous version | New version |
| ---------------------------- | :--------------: | :---------: |
| [Updated dependency example] |     [1.0.0]      |   [1.0.1]   |
| [New dependency example]     |        --        |   [3.0.1]   |
| [Removed dependency example] |     [2.10.2]     |     --      |
-->

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Branch is up-to-date and includes latest from `main`
- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
-->
