### PR TITLE
Fix container element

### DIFF
--- a/themes/digital.gov/src/js/guide-sidenav.js
+++ b/themes/digital.gov/src/js/guide-sidenav.js
@@ -120,15 +120,18 @@ function createSublist() {
   const subList = document.createElement("ul");
   subList.classList.add("usa-sidenav__sublist");
   const links = createLinks();
-  links.forEach((link) => {
-    const subItem = document.createElement("li");
-    subItem.classList.add("usa-sidenav__item");
-    subItem.appendChild(link);
-    subList.appendChild(subItem);
-  });
-  const currentItem = document.querySelector(".usa-sidenav__item.current");
-  if (currentItem) {
-    currentItem.appendChild(subList);
+  // check if links has items to avoid displaying an empty ul
+  if (links.length !== 0) {
+    links.forEach((link) => {
+      const subItem = document.createElement("li");
+      subItem.classList.add("usa-sidenav__item");
+      subItem.appendChild(link);
+      subList.appendChild(subItem);
+    });
+    const currentItem = document.querySelector(".usa-sidenav__item.current");
+    if (currentItem) {
+      currentItem.appendChild(subList);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes logic to only display a guide side nav `usa-sidenav__sublist` when there are items to display.

## Preview
[Link to Preview]()


## Solution
Adds a conditional check for displaying a sublist only if there are sublist items to display. This fixes a bug flagged by SiteImprove that was displaying an empty `<ul>` on some guide pages.

<details><summary>Fixes</summary>
<p>

<b>Empty List Error</b>
<img width="1203" alt="image (4)" src="https://github.com/user-attachments/assets/149ef945-7f6d-4e94-a937-0535df067067">

<b>Fix: Removed When No Items</b>
<img width="1205" alt="image (3)" src="https://github.com/user-attachments/assets/98519bb0-38a1-47cb-bb0f-dfeae098fa6e">

<b>Expected: Render Items</b>
<img width="1219" alt="image" src="https://github.com/user-attachments/assets/34aeb411-3f0a-4842-a35d-34b63fbb30d5">

</p>
</details> 

## How To Test

1. Visit each guide page below
2. Should not see empty `<ul class="usa-sidenav__sublist>"` element
3. Should see `<ul class="usa-sidenav__sublist>"` with list items on pages when `guidenav/*.yml` page has a `subnav` child

> [!NOTE]
> Site Improve Report will not change until this is merged and re-run


## What To Test


| production pages                                                                                                                                     | test pages                                                                                                                                                                                                                                       |
| ---------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| [https://digital.gov/guides/hcd/design-concepts/communicating-ideas/](https://digital.gov/guides/hcd/design-concepts/communicating-ideas/ )          | [guides/hcd/design-concepts/communicating-ideas](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-update-a11y-guide-sidenav/guides/hcd/design-concepts/communicating-ideas)           |
| [https://digital.gov/guides/hcd/design-concepts/designed-things/](https://digital.gov/guides/hcd/design-concepts/designed-things/)                   | [guides/hcd/design-concepts/designed-things](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-update-a11y-guide-sidenav/guides/hcd/design-concepts/designed-things)                   |
| [https://digital.gov/guides/hcd/design-operations/making/](https://digital.gov/guides/hcd/design-operations/making/)                                 | [guides/hcd/design-operations/making](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-update-a11y-guide-sidenav/guides/hcd/design-operations/making)                                 |
| [https://digital.gov/guides/hcd/design-operations/propose-a-model/](https://digital.gov/guides/hcd/design-operations/propose-a-model/)               | [guides/hcd/design-operations/propose-a-model](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-update-a11y-guide-sidenav/guides/hcd/design-operations/propose-a-model)               |
| [https://digital.gov/guides/hcd/discovery-concepts/up-next/](https://digital.gov/guides/hcd/discovery-concepts/up-next/)                             | [guides/hcd/discovery-concepts/up-next](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-update-a11y-guide-sidenav/guides/hcd/discovery-concepts/up-next)                             |
| [https://digital.gov/guides/hcd/discovery-operations/interview-checklist/](https://digital.gov/guides/hcd/discovery-operations/interview-checklist/) | [guides/hcd/discovery-operations/interview-checklist](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-update-a11y-guide-sidenav/guides/hcd/discovery-operations/interview-checklist) |
| [https://digital.gov/guides/hcd/discovery-operations/interviews/](https://digital.gov/guides/hcd/discovery-operations/interviews/)                   | [guides/hcd/discovery-operations/interviews](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-update-a11y-guide-sidenav/guides/hcd/discovery-operations/interviews/)                  |
| [https://digital.gov/guides/hcd/discovery-operations/research-checklist/](https://digital.gov/guides/hcd/discovery-operations/research-checklist/)   | <br>[guides/hcd/discovery-operations/interviews](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-update-a11y-guide-sidenav/guides/hcd/discovery-operations/interviews/)              |
| [https://digital.gov/guides/hcd/discovery-operations/timeline/](https://digital.gov/guides/hcd/discovery-operations/timeline/)                       | [guides/hcd/discovery-operations/timeline](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-update-a11y-guide-sidenav/guides/hcd/discovery-operations/timeline)                       |


**Should have a sublist with links:**

- [guides/hcd/discovery-concepts/plan-research](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-update-a11y-guide-sidenav/guides/hcd/discovery-concepts/plan-research/#content-start)
