### PR TITLE
fix two featured resources in topics

### DIFF
--- a/content/topics/accessibility/_index.md
+++ b/content/topics/accessibility/_index.md
@@ -26,7 +26,7 @@ legislation:
 # Featured resource to display at the top of the page
 featured_resources:
   resources:
-    - link: "/an-introduction-to-accessibility"
+    - link: "/resources/an-introduction-to-accessibility/"
 
 # Featured community to display at the top of the page
 featured_communities:

--- a/content/topics/information-collection/_index.md
+++ b/content/topics/information-collection/_index.md
@@ -24,7 +24,7 @@ legislation:
 # Featured resource to display at the top of the page
 featured_resources:
   resources:
-    - link: "/guide-paperwork-reduction-act"
+    - link: "https://pra.digital.gov/"
 
 # Featured community to display at the top of the page
 featured_communities:

--- a/content/topics/information-collection/_index.md
+++ b/content/topics/information-collection/_index.md
@@ -24,7 +24,7 @@ legislation:
 # Featured resource to display at the top of the page
 featured_resources:
   resources:
-    - link: "/services/service_pra"
+    - link: "/sources/source_pra-guide"
 
 # Featured community to display at the top of the page
 featured_communities:

--- a/content/topics/information-collection/_index.md
+++ b/content/topics/information-collection/_index.md
@@ -24,7 +24,7 @@ legislation:
 # Featured resource to display at the top of the page
 featured_resources:
   resources:
-    - link: "https://pra.digital.gov/"
+    - link: "/services/service_pra"
 
 # Featured community to display at the top of the page
 featured_communities:


### PR DESCRIPTION
Featured Resources are not displaying on Accessibility and Information Collection; fix links in front matter

## Summary

Basic description of work done.

## Preview

https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/fix-two-featured-resources-in-topics/topics/accessibility/ 

https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/fix-two-featured-resources-in-topics/topics/information-collection/ 


<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

## Solution

Provide a summary of the solution this PR offers.

<!--
It can be helpful if we understand:
1. What the solution is,
2. Why this approach was chosen,
3. How you implemented the change, and
4. Possible limitations of this approach and alternate solution paths.
-->


## How To Test

1. First Step
2. Second Step
3. Third Step

<!--
For PRs that include dependency updates, uncomment this section and
include a list of the changed dependencies and version numbers.
-->

<!--
## Dependency updates

| Dependency name              | Previous version | New version |
| ---------------------------- | :--------------: | :---------: |
| [Updated dependency example] |     [1.0.0]      |   [1.0.1]   |
| [New dependency example]     |        --        |   [3.0.1]   |
| [Removed dependency example] |     [2.10.2]     |     --      |
-->

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Branch is up-to-date and includes latest from `main`
- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
-->
