### PR TITLE
Removed duplicate markup

### DIFF
--- a/themes/digital.gov/layouts/authors/list.html
+++ b/themes/digital.gov/layouts/authors/list.html
@@ -97,40 +97,6 @@
             {{- end -}}
 
             {{- partial "core/pagination.html" . -}}
-
-            {{/* Gets the blog posts they have written */}}
-            {{- $posts := where $posts ".Params.author" "intersect" (slice .Params.slug) -}}
-
-            {{/* Gets the guides they have written */}}
-            {{- $guides := where $guides ".Params.author" "intersect" (slice .Params.slug) -}}
-
-            {{/* Merges the blog posts and the guides */}}
-            {{- $posts := union $posts $guides -}}
-
-            {{/* Merges the past events and the recent blog posts */}}
-            {{ $stream := union $posts $past_events }}
-
-            {{/* Sorting all the items by date and reverse chron */}}
-            {{ $stream := $stream.ByDate.Reverse }}
-
-            {{/* If there are any blog posts at all... */}}
-            {{- if $stream -}}
-              <h2>Latest Content by {{ .Params.display_name }}</h2>
-
-              {{/* Loop through all the pages */}}
-              {{- range $stream -}}
-                {{- if eq .Type "events" -}}
-                  {{- .Render "card-event" -}}
-                {{- end -}}
-
-                {{- if eq .Type "news" -}}
-                  {{ .Render "card-news" }}
-                {{- end -}}
-
-              {{- end -}}
-            {{- end -}}
-
-            {{- partial "core/pagination.html" . -}}
           </section>
         </div>
         {{- partial "partials/core/see-all-footer.html" -}}


### PR DESCRIPTION
## Summary

Removes duplicate author markup below pagination

<img width="1091" alt="Screenshot 2024-10-04 at 3 37 49 PM" src="https://github.com/user-attachments/assets/c92f98f2-6c66-4c0c-8c3f-3f886d04e862">

## Preview

https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-remove-dupe-author-markup/authors/ammie-farraj-feijoo/ 
