### PR TITLE
Fix news-card images

### DIFF
--- a/themes/digital.gov/layouts/partials/core/img-featured.html
+++ b/themes/digital.gov/layouts/partials/core/img-featured.html
@@ -32,9 +32,11 @@
   {{- $imgHeight := $thisimg.height -}}
 
   {{- $.Scratch.Set "imgSuffix" "" -}}
-  {{- if ge $imgWidth -}}
+  {{- if ge $imgWidth 800 -}}
+    {{- $.Scratch.Set "imgSuffix" "_w800" -}}
+  {{- else -}}
     {{- $.Scratch.Set "imgSuffix" "" -}}
-  {{- end -}}
+  {{ end }}
 
 
   <div class="media-featured">

--- a/themes/digital.gov/layouts/partials/core/img-featured.html
+++ b/themes/digital.gov/layouts/partials/core/img-featured.html
@@ -32,8 +32,8 @@
   {{- $imgHeight := $thisimg.height -}}
 
   {{- $.Scratch.Set "imgSuffix" "" -}}
-  {{- if ge $imgWidth 400 -}}
-    {{- $.Scratch.Set "imgSuffix" "_w400" -}}
+  {{- if ge $imgWidth 800 -}}
+    {{- $.Scratch.Set "imgSuffix" "_w800" -}}
   {{- end -}}
 
 

--- a/themes/digital.gov/layouts/partials/core/img-featured.html
+++ b/themes/digital.gov/layouts/partials/core/img-featured.html
@@ -32,8 +32,8 @@
   {{- $imgHeight := $thisimg.height -}}
 
   {{- $.Scratch.Set "imgSuffix" "" -}}
-  {{- if ge $imgWidth 800 -}}
-    {{- $.Scratch.Set "imgSuffix" "_w800" -}}
+  {{- if ge $imgWidth -}}
+    {{- $.Scratch.Set "imgSuffix" "" -}}
   {{- end -}}
 
 


### PR DESCRIPTION
## Summary
Updated template logic to display `800px` size images with a fallback for the original for `card-news` component. Current code was looking for the `400px`.

## Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/nl-fix-news-images/)
