### PR TITLE
Create Nov 2024 USWDS Monthly Call event page

### DIFF
--- a/content/events/2024/11/2024-11-21-uswds-monthly-call-november-2024.md
+++ b/content/events/2024/11/2024-11-21-uswds-monthly-call-november-2024.md
@@ -1,0 +1,67 @@
+---
+title: USWDS Monthly Call - November 2024
+deck: The next generation of the design system
+kicker: USWDS
+summary: The U.S. Web Design System (USWDS) team will share their vision for the design system as a product, including USWDS Web Components and other new things the team expects to deliver in 2025. 
+event_organizer: Digital.gov
+cop_events: ""
+registration_url: https://gsa.zoomgov.com/meeting/register/vJItfumsrzwiGRcqviGv4fcTLhgHS8ClFEU
+date: 2024-11-21 14:00:00 -0500
+end_date: 2024-11-21 15:00:00 -0500
+
+# See all topics at https://digital.gov/topics
+topics:
+  - human-centered-design
+  - usability
+  - user-experience
+  - open-government
+
+slug: uswds-monthly-call-november-2024
+
+# zoom, youtube_live, adobe_connect, google
+event_platform: zoom
+
+primary_image: 2024-uswds-monthly-call-november-title-card
+---
+
+
+{{< asset-static file="">}}
+
+This month, join the U.S. Web Design System (USWDS) team as they lay out their vision for the direction of the design system.
+
+In this session, you’ll learn about:
+
+- What the USWDS team is currently developing and why it's important
+- What the team expects to deliver in 2025
+- The design system’s shift toward modularity, and the future relationship between the existing codebase, design tokens, utilities, design kits, and web components
+- What these changes mean for you as a design system user
+
+
+**This event is best suited for:** Design system users of all levels, especially product managers and software engineers.
+
+**Speakers**
+
+- **Dan Williams** - Product Lead, USWDS
+- **Matt Henry** - Engineering Lead, USWDS
+- **Anne Petersen** - Experience Design Lead, USWDS
+
+## Join our Communities of Practice
+
+- [USWDS](https://designsystem.digital.gov/about/community/)
+- [Section 508 IT Accessibility](https://www.section508.gov/manage/join-the-508-community/)
+
+_This event is part of a monthly series that takes place on the third Thursday of each month. Don’t forget to set a placeholder on your personal calendar for our future events this year._
+
+## About the USWDS
+
+[The U.S. Web Design System](https://designsystem.digital.gov/) is a toolkit of principles, guidance, and code to help government teams design and build accessible, mobile-friendly websites backed by user research and modern best practices.
+
+- [The U.S. Web Design System](https://designsystem.digital.gov/)
+- [Contribute on GitHub](https://github.com/uswds/uswds/issues)
+- [Email Us](mailto:uswds@gsa.gov)
+- [Join our community](https://digital.gov/communities/uswds/)
+- [Follow @uswds on Twitter](https://twitter.com/uswds)
+
+---
+
+_Disclaimer_: All references to specific brands, products, and/or companies are used only for illustrative purposes and do not imply endorsement by the U.S. federal government or any federal government agency.

--- a/content/events/2024/11/2024-11-21-uswds-monthly-call-november-2024.md
+++ b/content/events/2024/11/2024-11-21-uswds-monthly-call-november-2024.md
@@ -22,8 +22,8 @@ slug: uswds-monthly-call-november-2024
 event_platform: zoom
 
 primary_image: 2024-uswds-monthly-call-november-title-card
----
 
+---
 
 {{< asset-static file="">}}
 
@@ -35,7 +35,6 @@ In this session, you’ll learn about:
 - What the team expects to deliver in 2025
 - The design system’s shift toward modularity, and the future relationship between the existing codebase, design tokens, utilities, design kits, and web components
 - What these changes mean for you as a design system user
-
 
 **This event is best suited for:** Design system users of all levels, especially product managers and software engineers.
 


### PR DESCRIPTION
## Summary

Creating the event page for the November 2024 USWDS monthly call.

## Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/brunerae-USWDS-nov-mc/)

-->


## How To Test

1. Navigate to Events
2. Find the November 2024 event page
3. Verify page content matches event brief
4. Ensure Zoom registration link takes you to the correct page
