### PR TITLE
Fix two small issues on COP landing pages

### DIFF
--- a/content/communities/communicators.md
+++ b/content/communities/communicators.md
@@ -53,4 +53,4 @@ Become a member to network with subject matter experts with extensive experience
 
 Digital.gov fosters this essential community by providing spaces designed to share best practices, resources, and networking opportunities. Remember, when participating in this community, you must follow [Digital.gov community guidelines](https://digital.gov/communities/community-guidelines/).
 
-{{< featured-resource link="topics/communication/" kicker="Featured resource" >}}
+{{< featured-resource link="topics/communication/" kicker="Featured topic" >}}

--- a/content/communities/contact-center.md
+++ b/content/communities/contact-center.md
@@ -48,4 +48,4 @@ Become a member to explore methods of service delivery that improve customer exp
 
 Digital.gov fosters this passionate community by providing spaces designed to host educational forums and discussions. Remember, when participating in this community, you must follow [Digital.gov community guidelines](https://digital.gov/communities/community-guidelines/).
 
-{{< featured-resource link="topics/contact-centers" >}}
+{{< featured-resource link="topics/contact-centers" kicker="Featured topic" >}}

--- a/content/communities/multilingual.md
+++ b/content/communities/multilingual.md
@@ -57,4 +57,4 @@ Become a member to meet the growing demand for government information and servic
 
 Digital.gov fosters this unique community by providing spaces designed to collaborate to solve common issues, offer translation best practices, define terminology, and be a resource to each other. Remember, when participating in this community, you must follow [Digital.gov community guidelines](https://digital.gov/communities/community-guidelines/).
 
-{{< featured-resource link="topics/multilingual" >}}
+{{< featured-resource link="topics/multilingual" kicker="Featured topic" >}}

--- a/content/communities/plain-language-community-of-practice.md
+++ b/content/communities/plain-language-community-of-practice.md
@@ -60,4 +60,4 @@ Become a member to collaborate with colleagues who are dedicated to the idea tha
 
 Digital.gov fosters this engaging community by providing spaces designed to empower members on their communication and plain language journeys. Remember, when participating in this community, you must follow [Digital.gov community guidelines](https://digital.gov/communities/community-guidelines/).
 
-{{< featured-resource link="topics/plain-language" >}}
+{{< featured-resource link="topics/plain-language" kicker="Featured topic" >}}

--- a/content/communities/social-media.md
+++ b/content/communities/social-media.md
@@ -51,4 +51,4 @@ Become a member to spark new ideas, connect, and collaborate.
 
 Digital.gov fosters this vibrant community by providing spaces designed to empower members on their digital and social media journeys. Remember, when participating in this community, you must follow [Digital.gov community guidelines](https://digital.gov/communities/community-guidelines/).
 
-{{< featured-resource link="topics/social-media" >}}
+{{< featured-resource link="topics/social-media" kicker="Featured topic" >}}

--- a/content/communities/user-experience.md
+++ b/content/communities/user-experience.md
@@ -54,4 +54,4 @@ Become a member to share and learn how to produce efficient, effective, and usef
 
 Digital.gov fosters this lively community by providing spaces to help members connect, learn, and grow on their user experience journeys. Remember, when participating in this community, you must follow [Digital.gov community guidelines](https://digital.gov/communities/community-guidelines/).
 
-{{< featured-resource link="topics/user-experience" >}}
+{{< featured-resource link="topics/user-experience" kicker="Featured topic" >}}

--- a/content/communities/web-analytics-and-optimization.md
+++ b/content/communities/web-analytics-and-optimization.md
@@ -58,4 +58,4 @@ Become a member to uncover best practices, tips, and tools for web analytics, se
 
 Digital.gov fosters this dynamic community by providing spaces to engage in collaborative discussion and share new technology and trends. Remember, when participating in this community, you must follow [Digital.gov community guidelines](https://digital.gov/communities/community-guidelines/).
 
-{{< featured-resource link="topics/analytics" >}}
+{{< featured-resource link="topics/analytics" kicker="Featured topic" >}}

--- a/content/communities/web-managers-forum.md
+++ b/content/communities/web-managers-forum.md
@@ -79,4 +79,4 @@ Become a member to learn more about creating, managing, and contributing to gove
 
 Digital.gov fosters this fundamental community by providing spaces for sharing ideas, challenges, lessons learned, and best practices for managing government websites and digital services. Remember, when participating in this community, you must follow [Digital.gov community guidelines](https://digital.gov/communities/community-guidelines/).
 
-{{< featured-resource link="topics/digital-service-delivery" >}}
+{{< featured-resource link="topics/digital-service-delivery" kicker="Featured topic" >}}

--- a/themes/digital.gov/layouts/communities/single.html
+++ b/themes/digital.gov/layouts/communities/single.html
@@ -59,12 +59,6 @@
 
               {{/* Community Events */}}
               {{- partial "core/get-upcomingevents.html" . -}}
-
-
-              <div class="community_conduct">
-                <h2 id="community-conduct">Community Conduct</h2>
-                {{- partial "core/community_pagefooter.html" . -}}
-              </div>
             </div>
           {{- end -}}
         </div>


### PR DESCRIPTION
## Summary

Removes the `Community Conduct` section and updates the `featured-resource` kicker to be read `Featured topics`.

![Join the Communicators _ Digital_gov](https://github.com/user-attachments/assets/b717f6f2-b4c8-4812-afb7-a4b2a12a3013)


## Preview

[Link to Preview]()


## Solution

