### PR TITLE
deleted hurricane milton alert.yml

### DIFF
--- a/data/sitewide_alert.yml
+++ b/data/sitewide_alert.yml
@@ -20,4 +20,4 @@ data:
   header: "Hurricane guidance for U.S. government websites and social media"
   alerts:
     - "[digital.gov/hurricane-helene](/hurricane-helene)"
-    - "[digital.gov/hurricane-milton](/hurricane-milton)"
+  


### PR DESCRIPTION
## Summary

removed the hurricane milton bullet from the sitewide alert

## Preview

[Link to Preview](https://federalist-466b7d92-5da1-4208-974f-d61fd4348571.sites.pages.cloud.gov/preview/gsa/digitalgov.gov/cltm-change_sitewide_alert-milton/)

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

## Solution

Provide a summary of the solution this PR offers.

<!--
It can be helpful if we understand:
1. What the solution is,
2. Why this approach was chosen,
3. How you implemented the change, and
4. Possible limitations of this approach and alternate solution paths.
-->


## How To Test

1. The sitewide alert banner at the top of the site should only include a bullet on Hurricane Helene, not Milton.

<!--
For PRs that include dependency updates, uncomment this section and
include a list of the changed dependencies and version numbers.
-->

<!--
## Dependency updates

| Dependency name              | Previous version | New version |
| ---------------------------- | :--------------: | :---------: |
| [Updated dependency example] |     [1.0.0]      |   [1.0.1]   |
| [New dependency example]     |        --        |   [3.0.1]   |
| [Removed dependency example] |     [2.10.2]     |     --      |
-->

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Branch is up-to-date and includes latest from `main`
- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
-->
