### PR TITLE
Add intro to federal website standards to homepage

### DIFF
--- a/content/resources/an-introduction-to-search.md
+++ b/content/resources/an-introduction-to-search.md
@@ -13,7 +13,7 @@ topics:
 # 0 -- hidden
 # 1 -- visible
 # 2 -- highlighted
-weight: 7
+weight: 1
 
 slug: an-introduction-to-search
 

--- a/content/resources/introduction-to-federal-web-standards.md
+++ b/content/resources/introduction-to-federal-web-standards.md
@@ -23,7 +23,7 @@ primary_image: "hands-puzzle-pieces-girafchik123-istock-getty-images-2091035051"
 # 0 -- hidden
 # 1 -- visible
 # 2 -- highlighted
-weight: 1
+weight: 7
 
 ---
 


### PR DESCRIPTION
## Summary

Add [An introduction to federal website standards](https://digital.gov/resources/introduction-to-federal-web-standards/) to homepage in lieu of [An introduction to search](https://digital.gov/resources/an-introduction-to-search/).

## Preview

[Link to Preview]()

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

## Solution

Provide a summary of the solution this PR offers.

<!--
It can be helpful if we understand:
1. What the solution is,
2. Why this approach was chosen,
3. How you implemented the change, and
4. Possible limitations of this approach and alternate solution paths.
-->


## How To Test

1. First Step
2. Second Step
3. Third Step

<!--
For PRs that include dependency updates, uncomment this section and
include a list of the changed dependencies and version numbers.
-->

<!--
## Dependency updates

| Dependency name              | Previous version | New version |
| ---------------------------- | :--------------: | :---------: |
| [Updated dependency example] |     [1.0.0]      |   [1.0.1]   |
| [New dependency example]     |        --        |   [3.0.1]   |
| [Removed dependency example] |     [2.10.2]     |     --      |
-->

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Branch is up-to-date and includes latest from `main`
- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
-->
