### PR TITLE
Remove author landing page and metadata (authors D-E)

### DIFF
--- a/content/authors/_index.md
+++ b/content/authors/_index.md
@@ -3,4 +3,11 @@ title: "Authors"
 deck: "The people who have contributed their stories and guidance over the years."
 summary: "The people who have contributed their stories and guidance over the years."
 redirectto: /news
+aliases: 
+  - /authors/deborah-bennett
+  - /authors/dominic-mcdevitt-parks
+  - /authors/donavan-albert
+  - /authors/donna-canestraro
+  - /authors/donna-dodson
+  - /authors/dorothy-amatucci
 ---

--- a/content/authors/dahianna-salazar-foreman/_index.md
+++ b/content/authors/dahianna-salazar-foreman/_index.md
@@ -3,22 +3,11 @@ display_name: Dahianna Salazar Foreman
 first_name: Dahianna
 last_name: Salazar Foreman
 # If you include an email address, it will be displayed on your profile page
-email: 
 # Keep it under 50 words and only one paragraph
-bio: Dahianna Salazar Foreman serves as the U.S. Digital Corps Communications Lead and oversees Digital Marketing for the Technology Transformation Services (TTS) Outreach team. Prior to working at TTS, she led outreach efforts for afterschool programming at elementary schools within the District of Columbia Public Schools.
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: 
-# [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
 # Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
 # Learn more about getting a Github account at [URL]
 github: Dahianna
 slug: dahianna-salazar-foreman
-# See [URL] for a full list of profile photo options
-profile_photo: github
-linkedin: dahiannasalazar
-
 ---

--- a/content/authors/dalia-elshimy/_index.md
+++ b/content/authors/dalia-elshimy/_index.md
@@ -8,26 +8,14 @@ display_name: "Dalia El-Shimy"
 first_name: "Dalia"
 last_name: "El-Shimy"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "delshimy"
@@ -37,11 +25,6 @@ github: "delshimy"
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/dan-hammer/_index.md
+++ b/content/authors/dan-hammer/_index.md
@@ -7,32 +7,17 @@ display_name: "Dan Hammer"
 first_name: "Dan"
 last_name: "Hammer"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: dan-hammer
 
-# if you include an email address, it will be displayed on your profile page
-email: "daniel.s.hammer@nasa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-youtube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/dan-kenny/_index.md
+++ b/content/authors/dan-kenny/_index.md
@@ -7,32 +7,17 @@ display_name: "Dan Kenny"
 first_name: "Dan"
 last_name: "Kenny"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: dan-kenny
 
-# if you include an email address, it will be displayed on your profile page
-email: "Daniel.Kenny@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-youtube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/dan-pomeroy/_index.md
+++ b/content/authors/dan-pomeroy/_index.md
@@ -7,32 +7,17 @@ display_name: "Dan Pomeroy"
 first_name: "Dan"
 last_name: "Pomeroy"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: dan-pomeroy
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Dan Pomeroy is the Director, DCOI Managing Partner PMO"
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-youtube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/dan-wendling/_index.md
+++ b/content/authors/dan-wendling/_index.md
@@ -2,31 +2,10 @@
 display_name: Dan Wendling
 first_name: Dan
 last_name: Wendling
-# List your pronoun(s) if you want them displayed alongside your name.
-# If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: He/him
-# If you include an email address, it will be displayed on your profile page
-email: ""
-# Keep it under 50 words and only one paragraph
-bio: Dan Wendling is an information systems librarian helping National Library
-  of Medicine staff collaborate around important issues in analytics.
-# Where can people learn more about your work?
-# Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
-# e.g. U.S. General Services Administration
 agency_full_name: National Library of Medicine
-# Agency Acronym [e.g., GSA]
-agency: NLM
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
-# [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
 # Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
 # Learn more about getting a Github account at [URL]
 github: ""
-facebook: ""
-linkedin: ""
-youtube: ""
 slug: dan-wendling
 profile_source: ""
-twitter: ""
 ---

--- a/content/authors/dan-williams/_index.md
+++ b/content/authors/dan-williams/_index.md
@@ -7,47 +7,22 @@ display_name: "Dan Williams"
 first_name: "Dan"
 last_name: "Williams"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: dan-williams
 
-# if you include an email address, it will be displayed on your profile page
-email: "daniel.williams@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: "Dan Williams is the program lead for the U.S. Web Design System (USWDS)."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: "https://designsystem.digital.gov/"
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Portland, OR"
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
 github: "thisisdano"
 
-# Profile Photo
-# See [URL] for a full list of profile photo options
-# github-photo — requires a github ID
-profile_source: ""
-
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-youtube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/dana-allen-greil/_index.md
+++ b/content/authors/dana-allen-greil/_index.md
@@ -7,32 +7,17 @@ display_name: "Dana Allen-Greil"
 first_name: "Dana"
 last_name: "Allen-Greil"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: dana-allen-greil
 
-# if you include an email address, it will be displayed on your profile page
-email: "dana.allen-greil@nara.gov"
 
-# Bio — keep it under 50 words
-bio: "Dana Allen-Greil is the Web and Social Media Branch Chief at the National Archives and Records Administration."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-youtube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/dana-chisnell/_index.md
+++ b/content/authors/dana-chisnell/_index.md
@@ -2,21 +2,7 @@
 display_name: Dana Chisnell
 first_name: Dana
 last_name: Chisnell
-# List your pronoun(s) if you want them displayed alongside your name.
-# If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: She | her
-# Keep it under 50 words and only one paragraph
-bio: Dana Chisnell is a generalist problem solver and digital services expert in
-  policy design research at the United States Digital Service (USDS). She is
-  currently Deputy Director for CX at the Department of Homeland Security. As an
-  author, pioneer, and thought leader in civic design and customer experience,
-  Dana brings much experience to the government space. This is Dana’s second
-  tour of duty at the Digital Service.
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. Department of Homeland Security
-# Agency Acronym [e.g., GSA]
-agency: DHS
 slug: dana-chisnell
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: Andover, Massachusetts
 ---

--- a/content/authors/dana-e-wagner/_index.md
+++ b/content/authors/dana-e-wagner/_index.md
@@ -2,9 +2,6 @@
 display_name: Dana E. Wagner
 first_name: Dana
 last_name: Wagner
-# e.g. U.S. General Services Administration
-agency_full_name:
-# Agency Acronym [e.g., GSA]
-agency: 
+agency_full_name: "U.S. General Services Administration"
 slug: dana-e-wagner
 ---

--- a/content/authors/daniel-j-pino/_index.md
+++ b/content/authors/daniel-j-pino/_index.md
@@ -6,40 +6,17 @@ display_name: "Daniel J Pino"
 first_name: "Daniel J."
 last_name: "Pino"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: "He/Him/His"
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: daniel.pino@gsa.gov
 
-# Bio — keep it under 50 words
-bio: "Senior Consultant focused on USWDS and 21 C IDEA events and communications initiatives."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url:
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Washington, D.C."
 
 # A GitHub account will allow you to edit pages on DigitalGov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "DanielJPino"
-
-# Profile Photo
-# See [URL] for a full list of profile photo options
-profile_photo: "digit-pride"
-
-# [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/daniel-yi/_index.md
+++ b/content/authors/daniel-yi/_index.md
@@ -2,16 +2,8 @@
 display_name: Daniel Yi
 first_name: Daniel
 last_name: Yi
-# List your pronoun(s) if you want them displayed alongside your name.
-# If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: He/him
 # Keep it under 50 words and only one paragraph
-bio: Daniel Yi is the Senior Counsel for Innovation for the United States Department of Justice’s Civil Rights Division. Dan leads the Division’s effort to use the design process and entrepreneurial principles to test new solutions for sticky problems in legal practice and civil rights. He graduated from the College of William and Mary and Yale Law School.
 # e.g. U.S. General Services Administration
 agency_full_name: United States Department of Justice
-# Agency Acronym [e.g., GSA]
-agency: DOJ
 slug: daniel-yi
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: Washington, DC
 ---

--- a/content/authors/danielle-brigida/_index.md
+++ b/content/authors/danielle-brigida/_index.md
@@ -7,32 +7,17 @@ display_name: "Danielle Brigida"
 first_name: "Danielle"
 last_name: "Brigida"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: danielle-brigida
 
-# if you include an email address, it will be displayed on your profile page
-email: "danielle_brigida@fws.gov"
 
-# Bio — keep it under 50 words
-bio: "Danielle Brigida is the National Social Media Manager for U.S. Fish and Wildlife Service. She&#39;s a wildlife geek who loves being outside and playing online with purpose. She can be reached at danielle_brigida@fws.gov."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-youtube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/danielle-lee/_index.md
+++ b/content/authors/danielle-lee/_index.md
@@ -2,21 +2,10 @@
 display_name: Danielle Lee
 first_name: Danielle
 last_name: Lee
-# Keep it under 50 words and only one paragraph
-bio: "Danielle Lee is a content strategist for Login.gov. Prior to joining
-  Login.gov, she worked in marketing communications and customer research.
-  Danielle leverages her expertise and knowledge in UX writing, research and
-  strategy to help create a secure, accessible, usable and equitable single sign
-  on experience for the public. "
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
-# [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
 # Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
 # Learn more about getting a Github account at [URL]
 github: Danielle-Lee
 slug: danielle-lee
-# See [URL] for a full list of profile photo options
-profile_photo: github
 ---

--- a/content/authors/danita-stenberg/_index.md
+++ b/content/authors/danita-stenberg/_index.md
@@ -7,32 +7,17 @@ display_name: "Danita Stenberg"
 first_name: "Danita"
 last_name: "Stenberg"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: danita-stenberg
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Danita Stenberg is a Multimedia Communications Specialist at the United States Nuclear Regulatory Commission (NRC)."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/dannielle-blumenthal/_index.md
+++ b/content/authors/dannielle-blumenthal/_index.md
@@ -7,32 +7,17 @@ display_name: "Dannielle Blumenthal"
 first_name: "Dannielle"
 last_name: "Blumenthal"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: dannielle-blumenthal
 
-# if you include an email address, it will be displayed on your profile page
-email: "dannielle.blumenthal@nist.gov"
 
-# Bio — keep it under 50 words
-bio: "Dannielle Blumenthal is the Director of Digital Engagement for the Office of Innovation at The National Archives."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/darlene-gamble/_index.md
+++ b/content/authors/darlene-gamble/_index.md
@@ -7,32 +7,17 @@ display_name: "Darlene Gamble"
 first_name: "Darlene"
 last_name: "Gamble"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: darlene-gamble
 
-# if you include an email address, it will be displayed on your profile page
-email: "Darlene_Gamble@ao.uscourts.gov"
 
-# Bio — keep it under 50 words
-bio: "Darlene Gamble is a Web Analytics Specialist at the Administrative Office of the U. S. Courts."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/darlene-meskell/_index.md
+++ b/content/authors/darlene-meskell/_index.md
@@ -7,32 +7,17 @@ display_name: "Darlene Meskell"
 first_name: "Darlene"
 last_name: "Meskell"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: darlene-meskell
 
-# if you include an email address, it will be displayed on your profile page
-email: "darlene.meskell@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/darren-b-lurie/_index.md
+++ b/content/authors/darren-b-lurie/_index.md
@@ -7,32 +7,17 @@ display_name: "Darren B. Lurie"
 first_name: "Darren"
 last_name: "Lurie"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: darren-b-lurie
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/darren-cole/_index.md
+++ b/content/authors/darren-cole/_index.md
@@ -7,32 +7,17 @@ display_name: "Darren Cole"
 first_name: "Darren"
 last_name: "Cole"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: darren-cole
 
-# if you include an email address, it will be displayed on your profile page
-email: "darren.cole@nara.gov"
 
-# Bio — keep it under 50 words
-bio: "Web and Social Media Branch, Office of Innovation, National Archives and Records Administration."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/data-gov-team/_index.md
+++ b/content/authors/data-gov-team/_index.md
@@ -7,32 +7,17 @@ display_name: "Data.gov Team"
 first_name: "Data.gov Team"
 last_name: "Data.gov Team"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: data-gov-team
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/davar-ardalan/_index.md
+++ b/content/authors/davar-ardalan/_index.md
@@ -7,32 +7,17 @@ display_name: "Davar Ardalan"
 first_name: "Davar"
 last_name: "Ardalan"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: davar-ardalan
 
-# if you include an email address, it will be displayed on your profile page
-email: "Davar.Ardalan@pif.gov"
 
-# Bio — keep it under 50 words
-bio: "Davar is the deputy director of the [Presidential Innovation Fellowship Program](https://www.presidentialinnovationfellows.gov/)."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: "https://www.presidentialinnovationfellows.gov/"
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: "innovfellows"
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/davey-gibian/_index.md
+++ b/content/authors/davey-gibian/_index.md
@@ -7,32 +7,17 @@ display_name: "Davey Gibian"
 first_name: "Davey"
 last_name: "Gibian"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: davey-gibian
 
-# if you include an email address, it will be displayed on your profile page
-email: "david.gibian@pif.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/david-a-bray/_index.md
+++ b/content/authors/david-a-bray/_index.md
@@ -7,32 +7,17 @@ display_name: "David A. Bray"
 first_name: "David"
 last_name: "Bray"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: david-a-bray
 
-# if you include an email address, it will be displayed on your profile page
-email: "david.bray@fcc.gov"
 
-# Bio — keep it under 50 words
-bio: "David A. Bray is the Chief Information Officer for the Federal Communications Commission."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/david-a-kennedy/_index.md
+++ b/content/authors/david-a-kennedy/_index.md
@@ -7,32 +7,17 @@ display_name: "David A. Kennedy"
 first_name: "David A."
 last_name: "Kennedy"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: david-a-kennedy
 
-# if you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/david-a-kosub-phd/_index.md
+++ b/content/authors/david-a-kosub-phd/_index.md
@@ -8,26 +8,14 @@ display_name: "David A Kosub, Ph.D"
 first_name: "David A"
 last_name: "Kosub, PhD"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "National Institutes of Health"
 
-# Agency Acronym [e.g., GSA]
-agency: "NIH"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/david-chiles/_index.md
+++ b/content/authors/david-chiles/_index.md
@@ -7,32 +7,17 @@ display_name: "David Chiles"
 first_name: "David"
 last_name: "Chiles"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: david-chiles
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "David Chiles is Chief Technology Officer at USPTO."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/david-cooper/_index.md
+++ b/content/authors/david-cooper/_index.md
@@ -7,32 +7,17 @@ display_name: "David Cooper"
 first_name: "David"
 last_name: "Cooper"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: david-cooper
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/david-corwin/_index.md
+++ b/content/authors/david-corwin/_index.md
@@ -8,40 +8,19 @@ display_name: "David Corwin"
 first_name: "David"
 last_name: "Corwin"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "David Corwin is a polyglot software engineer with 15 years of experience in various roles including web application consulting, front and backend engineering, and scientific computing. He is currently the lead engineer of Federalist and was formerly a consulting engineer with 18F."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "davemcorwin"
 
-# Profile Photo
-# See [URL] for a full list of profile photo options
-profile_photo: ""
-
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/david-fern/_index.md
+++ b/content/authors/david-fern/_index.md
@@ -7,32 +7,17 @@ display_name: "David Fern"
 first_name: "David"
 last_name: "Fern"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: david-fern
 
-# if you include an email address, it will be displayed on your profile page
-email: "david.fern@ssa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: "defern"
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/david-hale/_index.md
+++ b/content/authors/david-hale/_index.md
@@ -7,32 +7,17 @@ display_name: "David Hale"
 first_name: "David"
 last_name: "Hale"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: david-hale
 
-# if you include an email address, it will be displayed on your profile page
-email: "davehale@mail.nih.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/david-hebert/_index.md
+++ b/content/authors/david-hebert/_index.md
@@ -7,32 +7,17 @@ display_name: "David Hebert"
 first_name: "David"
 last_name: "Hebert"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: david-hebert
 
-# if you include an email address, it will be displayed on your profile page
-email: "dhebert@usgs.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/david-herring/_index.md
+++ b/content/authors/david-herring/_index.md
@@ -7,32 +7,17 @@ display_name: "David Herring"
 first_name: "David"
 last_name: "Herring"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: david-herring
 
-# if you include an email address, it will be displayed on your profile page
-email: "David.Herring@uspto.gov"
 
-# Bio — keep it under 50 words
-bio: "David Herring is a Usability and Interaction Design consultant at the United States Patent and Trademark Office."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/david-j-taube/_index.md
+++ b/content/authors/david-j-taube/_index.md
@@ -3,13 +3,9 @@ display_name: David J. Taube
 first_name: David
 last_name: Taube
 # If you include an email address, it will be displayed on your profile page
-email: dtaube@oge.gov
 # Keep it under 50 words and only one paragraph
-bio: David J. Taube joined the Office of Government Ethics in 2019 and serves as an Associate Counsel in the Ethics Law and Policy Branch.  He previously practiced ethics and general government law in the IRS Office of Chief Counsel and the National Geospatial-Intelligence Agency Office of General Counsel.  Before joining these agencies, David worked for three United States courts of appeals as a law clerk and staff attorney. David graduated from Amherst College and the Georgetown University Law Center.
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. Office of Government Ethics
-# Agency Acronym [e.g., GSA]
-agency: OGE
 slug: david-j-taube
 
 ---

--- a/content/authors/david-kaufmann/_index.md
+++ b/content/authors/david-kaufmann/_index.md
@@ -7,32 +7,17 @@ display_name: "David Kaufmann"
 first_name: "David"
 last_name: "Kaufmann"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: david-kaufmann
 
-# if you include an email address, it will be displayed on your profile page
-email: "david.kaufmann@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: "David Kaufmann is a Federal Information Specialist with USA.gov."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/david-lipscomb/_index.md
+++ b/content/authors/david-lipscomb/_index.md
@@ -2,32 +2,14 @@
 display_name: David Lipscomb
 first_name: David
 last_name: Lipscomb
-# List your pronoun(s) if you want them displayed alongside your name.
-# If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: He | Him
 # If you include an email address, it will be displayed on your profile page
-email: dcl@georgetown.edu
 # Keep it under 50 words and only one paragraph
-bio: David Lipscomb is the Director of the Writing Center and Associate Teaching Professor at Georgetown University. As Vice Chair of the Center for Plain Language, David leads the Center’s Federal Report Card program. At Georgetown, David incorporates plain writing principles into his courses and has designed assignments in which students complete plain writing challenges for a number of government agencies. Currently, he is exploring the ways new research in cognitive psychology lends support to traditional writing advice.
-# Where can people learn more about your work?
-# Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: null
 # e.g. U.S. General Services Administration
-agency_full_name: ""
-# Agency Acronym [e.g., GSA]
-agency: ""
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
-# [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
+agency_full_name: "U.S. General Services Administration"
 # Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
 # Learn more about getting a Github account at [URL]
 github: ""
 # See [URL] for a full list of profile photo options
 profile_photo: ""
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 slug: david-lipscomb
 ---

--- a/content/authors/david-mader/_index.md
+++ b/content/authors/david-mader/_index.md
@@ -7,32 +7,17 @@ display_name: "David Mader"
 first_name: "David"
 last_name: "Mader"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: david-mader
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "David Mader is the Controller at the Office of Management and Budget."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/david-s-ferriero/_index.md
+++ b/content/authors/david-s-ferriero/_index.md
@@ -7,32 +7,17 @@ display_name: "David S. Ferriero"
 first_name: "David S."
 last_name: "Ferriero"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: david-s-ferriero
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "David S. Ferriero was confirmed as 10th Archivist of the United States on November 6, 2009. Previously, Mr. Ferriero served as the Andrew W. Mellon Director of the New York Public Libraries (NYPL). He was part of the leadership team responsible for integrating the four research libraries and 87 branch libraries into one seamless service for users, creating the largest public library system in the United States and one of the largest research libraries in the world. Mr. Ferriero was in charge of collection strategy; conservation; digital experience; reference and research services; and education, programming, and exhibitions."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/david-shive/_index.md
+++ b/content/authors/david-shive/_index.md
@@ -7,32 +7,17 @@ display_name: "David Shive"
 first_name: "David"
 last_name: "Shive"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: david-shive
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "David A. Shive is the Chief Information Officer for the U.S. General Services Administration."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/david-siegrist/_index.md
+++ b/content/authors/david-siegrist/_index.md
@@ -2,20 +2,8 @@
 display_name: David Siegrist
 first_name: David
 last_name: Siegrist
-# List your pronoun(s) if you want them displayed alongside your name.
-# If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: He | Him
-# If you include an email address, it will be displayed on your profile page
-email: david.siegrist@gsa.gov
-# Keep it under 50 words and only one paragraph
-bio: "David has over 20 years of information technology (IT) experience leading agency wide modernization efforts. As a Cloud Infrastructure Lead at the [Centers of Excellence (CoE)](https://coe.gsa.gov/), he is responsible for cloud infrastructure, contact center, data center modernization, and cyber-security support. He works with customers at a technical and strategic level, engaging people, process, and technology to foster a culture of modernization and a roadmap to success on their journey."
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
 slug: david-siegrist
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: Ashburn, VA
-linkedin: david-siegrist-591945b8
 
 ---

--- a/content/authors/david-warren/_index.md
+++ b/content/authors/david-warren/_index.md
@@ -8,26 +8,14 @@ display_name: "David Warren"
 first_name: "David"
 last_name: "Warren"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/deanna-mccray-james/_index.md
+++ b/content/authors/deanna-mccray-james/_index.md
@@ -3,11 +3,8 @@ display_name: Deanna McCray-James
 first_name: Deanna
 last_name: McCray-James
 # Keep it under 50 words and only one paragraph
-bio: Public Access Officer Deanna McCray-James serves in the Office of Communications at the Library of Congress. She leads internal and emergency communications, manages outreach efforts for various programs, exhibitions, and events, and directs the office’s various internship opportunities and students.
 # e.g. U.S. General Services Administration
 agency_full_name: Library of Congress
-# Agency Acronym [e.g., GSA]
-agency: LOC
 slug: deanna-mccray-james
 
 ---

--- a/content/authors/deb-lebel/_index.md
+++ b/content/authors/deb-lebel/_index.md
@@ -7,32 +7,17 @@ display_name: "Deb LeBel"
 first_name: "Deb"
 last_name: "LeBel"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: deb-lebel
 
-# if you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Deb LeBel is a partnership specialist at AIDS.gov."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/debbie-bucci/_index.md
+++ b/content/authors/debbie-bucci/_index.md
@@ -8,26 +8,14 @@ display_name: "Debbie Bucci"
 first_name: "Debbie"
 last_name: "Bucci"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Department of Health and Human Services"
 
-# Agency Acronym [e.g., GSA]
-agency: "HHS"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/deborah-bennett/_index.md
+++ b/content/authors/deborah-bennett/_index.md
@@ -7,6 +7,7 @@ display_name: "Deborah Bennett"
 first_name: "Deborah"
 last_name: "Bennett"
 
+expirydate: 2025-02-18
 
 # slug — the specific user-id for an author.
 slug: deborah-bennett

--- a/content/authors/deborah-bennett/_index.md
+++ b/content/authors/deborah-bennett/_index.md
@@ -7,32 +7,17 @@ display_name: "Deborah Bennett"
 first_name: "Deborah"
 last_name: "Bennett"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: deborah-bennett
 
-# if you include an email address, it will be displayed on your profile page
-email: "dbennett@mail.nih.gov"
 
-# Bio — keep it under 50 words
-bio: "Deborah Bennett is an Information Technology Specialist at the National Library of Medicine."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/debra-harris/_index.md
+++ b/content/authors/debra-harris/_index.md
@@ -7,32 +7,17 @@ display_name: "Debra Harris"
 first_name: "Debra"
 last_name: "Harris"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: debra-harris
 
-# if you include an email address, it will be displayed on your profile page
-email: "DEBRA.HARRIS@dfas.mil"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/denise-turner-roth/_index.md
+++ b/content/authors/denise-turner-roth/_index.md
@@ -7,32 +7,17 @@ display_name: "Denise Turner Roth"
 first_name: "Denise"
 last_name: "Turner Roth"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: denise-turner-roth
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/department-of-homeland-security/_index.md
+++ b/content/authors/department-of-homeland-security/_index.md
@@ -7,32 +7,17 @@ display_name: "U.S. Department of Homeland Security"
 first_name: "U.S. Department of"
 last_name: "Homeland Security"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: department-of-homeland-security
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/derek-masaki/_index.md
+++ b/content/authors/derek-masaki/_index.md
@@ -8,26 +8,14 @@ display_name: "Derek Masaki"
 first_name: "Derek"
 last_name: "Masaki"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: dmasaki@usgs.gov
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Geological Survey"
 
-# Agency Acronym [e.g., GSA]
-agency: "USGS"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/digitalgov-team/_index.md
+++ b/content/authors/digitalgov-team/_index.md
@@ -7,32 +7,17 @@ display_name: "Digital.gov Team"
 first_name: "Digital.gov"
 last_name: "Team"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: digitalgov-team
 
-# if you include an email address, it will be displayed on your profile page
-email: "digitalgov@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/dmccleskey/_index.md
+++ b/content/authors/dmccleskey/_index.md
@@ -7,32 +7,17 @@ display_name: "Dawn Pointer McCleskey"
 first_name: "Dawn"
 last_name: "Pointer McCleskey"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: dmccleskey
 
-# if you include an email address, it will be displayed on your profile page
-email: "dawn.mccleskey@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: "Dawn Pointer McCleskey is the program manager of Search.gov (formerly DigitalGov Search) at the U.S. General Services Administration (GSA). She is a librarian on a mission to help people find what they are looking for."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: "@dapmcc"
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/dominic-mcdevitt-parks/_index.md
+++ b/content/authors/dominic-mcdevitt-parks/_index.md
@@ -6,7 +6,8 @@
 display_name: "Dominic McDevitt-Parks"
 first_name: "Dominic"
 last_name: "McDevitt-Parks"
-
+e
+xpirydate: 2025-02-18
 
 # slug — the specific user-id for an author.
 slug: dominic-mcdevitt-parks

--- a/content/authors/dominic-mcdevitt-parks/_index.md
+++ b/content/authors/dominic-mcdevitt-parks/_index.md
@@ -6,19 +6,13 @@
 display_name: "Dominic McDevitt-Parks"
 first_name: "Dominic"
 last_name: "McDevitt-Parks"
-e
-xpirydate: 2025-02-18
+expirydate: 2025-02-18
 
 # slug — the specific user-id for an author.
 slug: dominic-mcdevitt-parks
 
-
-
-
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
-
-
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -28,7 +22,6 @@ github: ""
 # See [URL] for a full list of profile photo options
 # github-photo — requires a github ID
 profile_source: ""
-
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/dominic-mcdevitt-parks/_index.md
+++ b/content/authors/dominic-mcdevitt-parks/_index.md
@@ -7,32 +7,17 @@ display_name: "Dominic McDevitt-Parks"
 first_name: "Dominic"
 last_name: "McDevitt-Parks"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: dominic-mcdevitt-parks
 
-# if you include an email address, it will be displayed on your profile page
-email: "dominic.mcdevitt-parks@nara.gov"
 
-# Bio — keep it under 50 words
-bio: "Dominic McDevitt-Parks is a Digital Content Specialist, Wikipedian in Residence at the National Archives and Records Administration."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/dominique-gebru/_index.md
+++ b/content/authors/dominique-gebru/_index.md
@@ -2,14 +2,8 @@
 display_name: Dominique Gebru
 first_name: Dominique
 last_name: Gebru
-# If you include an email address, it will be displayed on your profile page
-email: Dominique.P.Gebru@faa.gov
-# Keep it under 50 words and only one paragraph
-bio: 
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. Federal Aviation Administration
-# Agency Acronym [e.g., GSA]
-agency: FAA
 slug: dominique-gebru
 
 ---

--- a/content/authors/dominique-ramirez/_index.md
+++ b/content/authors/dominique-ramirez/_index.md
@@ -8,26 +8,14 @@ display_name: "Dominique Ramirez"
 first_name: "Dominique"
 last_name: "Ramirez"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Dominique Ramirez is a Public Affairs Specialist at the Department of Veterans Affairs. Dominique serves as a web developer, social media manager, and manages 300 interns through the Virtual Student Federal Service."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Department of Veterans Affairs"
 
-# Agency Acronym [e.g., GSA]
-agency: "VA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/donavan-albert/_index.md
+++ b/content/authors/donavan-albert/_index.md
@@ -7,32 +7,17 @@ display_name: "Donavan Albert"
 first_name: "Donavan"
 last_name: "Albert"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: donavan-albert
 
-# if you include an email address, it will be displayed on your profile page
-email: "dalbert@fs.fed.us"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/donavan-albert/_index.md
+++ b/content/authors/donavan-albert/_index.md
@@ -7,6 +7,7 @@ display_name: "Donavan Albert"
 first_name: "Donavan"
 last_name: "Albert"
 
+expirydate: 2025-02-18
 
 # slug — the specific user-id for an author.
 slug: donavan-albert

--- a/content/authors/donna-canestraro/_index.md
+++ b/content/authors/donna-canestraro/_index.md
@@ -7,6 +7,7 @@ display_name: "Donna Canestraro"
 first_name: "Donna"
 last_name: "Canestraro"
 
+expirydate: 2025-02-18
 
 # slug — the specific user-id for an author.
 slug: donna-canestraro

--- a/content/authors/donna-canestraro/_index.md
+++ b/content/authors/donna-canestraro/_index.md
@@ -7,32 +7,17 @@ display_name: "Donna Canestraro"
 first_name: "Donna"
 last_name: "Canestraro"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: donna-canestraro
 
-# if you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/donna-dodson/_index.md
+++ b/content/authors/donna-dodson/_index.md
@@ -7,6 +7,7 @@ display_name: "Donna Dodson"
 first_name: "Donna"
 last_name: "Dodson"
 
+expirydate: 2025-02-18
 
 # slug — the specific user-id for an author.
 slug: donna-dodson

--- a/content/authors/donna-dodson/_index.md
+++ b/content/authors/donna-dodson/_index.md
@@ -7,32 +7,17 @@ display_name: "Donna Dodson"
 first_name: "Donna"
 last_name: "Dodson"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: donna-dodson
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Donna Dodson is the Chief Cybersecurity Advisor for the NIST Information Technology Laboratory and Director of the National Cybersecurity Center of Excellence (NCCoE). Since joining NIST in 1987, Donna has been selected as a Fed 100 winner for innovations in cybersecurity, as one of the top 10 influential people in government IT in 2011, and as one of Fed Scoop’s Top 50 D.C. Women in Tech."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/donna-garland/_index.md
+++ b/content/authors/donna-garland/_index.md
@@ -8,26 +8,14 @@ display_name: "Donna Garland"
 first_name: "Donna"
 last_name: "Garland"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/donna-ledbetter/_index.md
+++ b/content/authors/donna-ledbetter/_index.md
@@ -2,14 +2,8 @@
 display_name: Donna Ledbetter
 first_name: Donna
 last_name: Ledbetter
-# List your pronoun(s) if you want them displayed alongside your name.
-# If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: She/Her
 # Keep it under 50 words and only one paragraph
-bio: Donna Ledbetter is the Editor and Technical Writer for the National Institute of Corrections (NIC) at the Bureau of Prisons (BOP) of the U.S. Department of Justice (DOJ). She is also the program manager for her agency’s Section 508 and plain language programs. She has previously delivered federal presentations on writing annual reports and plain language for Section 508. Her professional interests currently include narrative nonfiction, UX writing, and the ever-evolving world of digital publishing.
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. Department of Justice
-# Agency Acronym [e.g., GSA]
-agency: NIC
 slug: donna-ledbetter
 ---

--- a/content/authors/donna-roy/_index.md
+++ b/content/authors/donna-roy/_index.md
@@ -2,11 +2,5 @@
 display_name: Donna Roy
 first_name: Donna
 last_name: Roy
-# Keep it under 50 words and only one paragraph
-bio: Donna is the Assistant Director, Chief Information Officer, directing all
-  technology areas including Application Development, Cybersecurity, Data,
-  Design, End User Systems and Strategy, Enterprise Architecture, Network
-  Engineering and Systems Engineering at the Consumer Financial Protection
-  Bureau.
 slug: donna-roy
 ---

--- a/content/authors/dorothy-amatucci/_index.md
+++ b/content/authors/dorothy-amatucci/_index.md
@@ -7,6 +7,7 @@ display_name: "Dorothy Amatucci"
 first_name: "Dorothy"
 last_name: "Amatucci"
 
+expirydate: 2025-02-18
 
 # slug — the specific user-id for an author.
 slug: dorothy-amatucci

--- a/content/authors/dorothy-amatucci/_index.md
+++ b/content/authors/dorothy-amatucci/_index.md
@@ -7,32 +7,17 @@ display_name: "Dorothy Amatucci"
 first_name: "Dorothy"
 last_name: "Amatucci"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: dorothy-amatucci
 
-# if you include an email address, it will be displayed on your profile page
-email: "Dorothy.Amatucci@ed.gov"
 
-# Bio — keep it under 50 words
-bio: "U.S. Department of Education"
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/dotgov-team/_index.md
+++ b/content/authors/dotgov-team/_index.md
@@ -7,32 +7,17 @@ display_name: "DotGov Team"
 first_name: "DotGov"
 last_name: "Team"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: dotgov-team
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/doug-walker/_index.md
+++ b/content/authors/doug-walker/_index.md
@@ -7,32 +7,17 @@ display_name: "Doug Walker"
 first_name: "Doug"
 last_name: "Walker"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: doug-walker
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Doug Walker is Deputy Commissioner, Communications at the Social Security Administration."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/dr-alondra-nelson/_index.md
+++ b/content/authors/dr-alondra-nelson/_index.md
@@ -6,32 +6,17 @@ display_name: "Dr. Alondra Nelson"
 first_name: "Alondra"
 last_name: "Nelson"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: 
 
 # slug — the specific user-id for an author.
 slug: dr-alondra-nelson
 
-# if you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Dr. Alondra Nelson is Head of the White House Office of Science and Technology Policy."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: "https://www.whitehouse.gov/ostp/directors-office/"
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "White House Office of Science & Technology Policy"
 
-# Agency Acronym [e.g., GSA]
-agency: "OSTP"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -42,11 +27,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: "digit-dark"
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: "AlondraNelson46"
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/dr-caren-cooper/_index.md
+++ b/content/authors/dr-caren-cooper/_index.md
@@ -8,26 +8,14 @@ display_name: "Dr. Caren Cooper"
 first_name: "Dr. Caren"
 last_name: "Cooper"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Associate Professor of Forestry and Environmental Resources at North Carolina State University."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: https://faculty.cnr.ncsu.edu/carencooper/
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/dr-dj-patil/_index.md
+++ b/content/authors/dr-dj-patil/_index.md
@@ -7,32 +7,17 @@ display_name: "Dr. DJ Patil"
 first_name: "DJ"
 last_name: "Patil"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: dr-dj-patil
 
-# if you include an email address, it will be displayed on your profile page
-email: "Dhanurjay_A_Patil@ostp.eop.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/dr-emily-shen/_index.md
+++ b/content/authors/dr-emily-shen/_index.md
@@ -8,26 +8,14 @@ display_name: "Dr. Emily Shen"
 first_name: "Emily "
 last_name: "Shen"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "A technical staff member in the Secure Resilient Systems and Technology Group at MIT Lincoln Laboratory. Her primary research interests lie in cryptography. She currently leads projects designing and developing secure multi-party computation technology for privacy-preserving collaboration. She has also worked on cryptographically secure database search and access control."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/dr-jedidah-isler/_index.md
+++ b/content/authors/dr-jedidah-isler/_index.md
@@ -6,32 +6,17 @@ display_name: "Dr. Jedidah Isler"
 first_name: "Jedidah"
 last_name: "Isler"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: 
 
 # slug — the specific user-id for an author.
 slug: dr-jedidah-isler
 
-# if you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Dr. Jedidah Isler leads the Science and Society division at the White House Office of Science & Technology Policy (OSTP), as the Principal Assistant Director. The Science and Society Team advances the President’s commitment to ensuring that all of America can participate in, contribute to, and benefit from science and technology. An inaugural White House team, the Science and Society Team directs priority efforts to protect the integrity of science in the federal government, broaden participation in STEM fields, strengthen the U.S. research infrastructure and its security, and ensure that all Americans have equitable access to the benefits of new and emerging technologies and scientific innovation.<br /><br />Dr. Isler brings her expertise as an astrophysicist and expert in supermassive black holes, science communicator, founder, and vocal advocate for the rightful presence of women of color, non-binary people of color, and marginalized groups more broadly, in science & technology. She has served on the Astronomy & Astrophysics (Astro2020) Decadal Survey’s inaugural State of the Profession and Society Impacts panel, was a member of the American Institute of Physics TEAM-UP Task Force to advance African Americans in Physics and Astronomy, for which she was awarded the 2022 American Physical Society Excellence in Physics Education Award. She has delivered 2 TED talks, and was on the astrophysics faculty at Dartmouth College immediately before beginning public service. She brings these complimentary experiences to the work of advancing equity in Federal science & technology strategy and policy."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: "https://jedidahislerphd.com/about/"
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "White House Office of Science & Technology Policy"
 
-# Agency Acronym [e.g., GSA]
-agency: "OSTP"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -42,11 +27,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: "digit-light"
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: "JedidahIsler46"
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/dr-julie-kinn/_index.md
+++ b/content/authors/dr-julie-kinn/_index.md
@@ -8,26 +8,14 @@ display_name: "Dr. Julie Kinn"
 first_name: "Julie"
 last_name: "Kinn"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Research Psychologist, DHA Connected Health"
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/dr-kaeli-yuen/_index.md
+++ b/content/authors/dr-kaeli-yuen/_index.md
@@ -2,36 +2,12 @@
 display_name: Dr. Kaeli Yuen
 first_name: Kaeli
 last_name: Yuen
-# List your pronoun(s) if you want them displayed alongside your name.
-# If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: she/her/hers
-# If you include an email address, it will be displayed on your profile page
-email: kaeli.yuen@gsa.gov
-# Keep it under 50 words and only one paragraph
-bio: Dr. Kaeli Yuen is a Presidential Innovation Fellow (PIF) detailed to the
-  U.S. Department of Veterans Affairs’ Office of the Chief Technology Officer,
-  where she works to improve the digital experience of Veterans and their
-  healthcare providers. She is a physician and clinical informaticist
-  experienced in research, product management, and health information
-  technologies. Originally from Los Angeles, California, Kaeli received an MD
-  from the Keck School of Medicine of the University of California, and a BS in
-  Biology from Stanford University.
-# Where can people learn more about your work?
-# Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: https://presidentialinnovationfellows.gov/fellows/kaeli-yuen/
 # e.g. U.S. General Services Administration
 agency_full_name: Presidential Innovation Fellows
-# Agency Acronym [e.g., GSA]
-agency: PIF
-# [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
 # Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
 # Learn more about getting a Github account at [URL]
 github: kaeliwyuen
 slug: dr-kaeli-yuen
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: Washington, DC
 # See [URL] for a full list of profile photo options
 profile_photo: github
-twitter: PIFgov
-linkedin: kaeli-yuen-90b7a665
 ---

--- a/content/authors/dr-kelvin-droegemeier/_index.md
+++ b/content/authors/dr-kelvin-droegemeier/_index.md
@@ -8,26 +8,14 @@ display_name: "Dr. Kelvin Droegemeier"
 first_name: "Dr. Kelvin"
 last_name: "Droegemeier"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Director of the White House Office of Science and Technology Policy"
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: https://www.whitehouse.gov/people/kelvin-k-droegemeier/
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "White House"
 
-# Agency Acronym [e.g., GSA]
-agency: "OSTP"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/dr-ku-mcmahan/_index.md
+++ b/content/authors/dr-ku-mcmahan/_index.md
@@ -8,26 +8,14 @@ display_name: "Dr. Ku McMahan"
 first_name: "Dr. Ku"
 last_name: "McMahan"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "At USAID, Dr. Ku McMahan serves as team lead for Securing Water for Food: A Grand Challenge for Development in the U.S. Global Development Lab at USAID."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "United States Agency for International Development"
 
-# Agency Acronym [e.g., GSA]
-agency: "USAID"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/dr-matt-biggerstaff/_index.md
+++ b/content/authors/dr-matt-biggerstaff/_index.md
@@ -2,16 +2,7 @@
 display_name: Dr. Matt Biggerstaff
 first_name: Matt
 last_name: Biggerstaff
-# List your pronoun(s) if you want them displayed alongside your name.
-# If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: He/Him
-# If you include an email address, it will be displayed on your profile page
-email: ""
-# Keep it under 50 words and only one paragraph
-bio: Dr. Matt Biggerstaff has been with CDC since 2006, and an epidemiologist with its Influenza Division since 2009. In this role, he leads CDC influenza forecasting and modeling activities and works to understand and evaluate how forecasting and mathematical modeling can complement influenza surveillance and inform seasonal and pandemic influenza public health actions. He also serves as a Senior Advisor for Infectious Disease Modeling and Analytics to the CDC’s Deputy Director for Infectious Diseases, and has led and supported the CDC’s and the U.S. government’s interagency modeling and forecasting response to the COVID-19 pandemic since January 2020.
 # e.g. U.S. General Services Administration
 agency_full_name: Center for Disease Control
-# Agency Acronym [e.g., GSA]
-agency: CDC
 slug: dr-matt-biggerstaff
 ---

--- a/content/authors/dr-rachael-bradley-montgomery/_index.md
+++ b/content/authors/dr-rachael-bradley-montgomery/_index.md
@@ -2,14 +2,7 @@
 display_name: "Dr. Rachael Bradley Montgomery"
 first_name: Rachael
 last_name: Bradley Montgomery
-# List your pronoun(s) if you want them displayed alongside your name.
-# If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: She/Her
-# Keep it under 50 words and only one paragraph
-bio: "Dr. Rachael Bradley Montgomery has been working in accessibility and usability for more than 20 years. She currently serves in the following five roles: Digital accessibility specialist at the Library of Congress, Co-chair of the W3C Accessibility Guidelines Working Group; Executive director of Accessible Community, Adjunct lecturer at University of Maryland’s College of Information Studies (iSchool), and Affiliate faculty with the Trace Center."
 # e.g. U.S. General Services Administration
 agency_full_name: Library of Congress
-# Agency Acronym [e.g., GSA]
-agency: LoC
 slug: dr-rachael-bradley-montgomery
 ---

--- a/content/authors/dr-robert-read/_index.md
+++ b/content/authors/dr-robert-read/_index.md
@@ -7,32 +7,17 @@ display_name: "Robert L. Read, PhD"
 first_name: "Robert"
 last_name: "Read"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: dr-robert-read
 
-# if you include an email address, it will be displayed on your profile page
-email: "robert.read@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/dr-taha-kass-hout/_index.md
+++ b/content/authors/dr-taha-kass-hout/_index.md
@@ -7,32 +7,17 @@ display_name: "Dr. Taha Kass-Hout"
 first_name: "Taha"
 last_name: "Kass-Hout"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: dr-taha-kass-hout
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Dr. Taha Kass-Hout is the Chief Health Informatics Officer of the U.S. Food and Drug Administration (FDA)."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/drew-zachary/_index.md
+++ b/content/authors/drew-zachary/_index.md
@@ -8,26 +8,14 @@ display_name: "Drew Zachary"
 first_name: "Drew"
 last_name: "Zachary"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Census Bureau"
 
-# Agency Acronym [e.g., GSA]
-agency: "USCB"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/duane-rollins/_index.md
+++ b/content/authors/duane-rollins/_index.md
@@ -7,32 +7,17 @@ display_name: "Duane Rollins"
 first_name: "Duane"
 last_name: "Rollins"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: duane-rollins
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/dustin-renwick/_index.md
+++ b/content/authors/dustin-renwick/_index.md
@@ -7,32 +7,17 @@ display_name: "Dustin Renwick"
 first_name: "Dustin"
 last_name: "Renwick"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: dustin-renwick
 
-# if you include an email address, it will be displayed on your profile page
-email: "renwick.dustin@epa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/dywane-boyd/_index.md
+++ b/content/authors/dywane-boyd/_index.md
@@ -7,32 +7,17 @@ display_name: "Dywane Boyd"
 first_name: "Dywane"
 last_name: "Boyd"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: dywane-boyd
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Dywane Boyd is the Testing Coordinator in the OPM Office of the Chief Information Officer."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/ed-burrows/_index.md
+++ b/content/authors/ed-burrows/_index.md
@@ -6,29 +6,17 @@ display_name: "Ed Burrows"
 first_name: "Ed"
 last_name: "Burrows"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
 # user id — not easily changed
 slug: "ed-burrows"
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: edward.burrows@gsa.gov
 
-# Bio — keep it under 50 words
-bio: "GSA RPA Program Manager, Office of the Chief Financial Officer"
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on DigitalGov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -38,10 +26,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-youtube: ""
 
 # ♥♥♥ Make it better ♥♥♥
 ---

--- a/content/authors/ed-simcox/_index.md
+++ b/content/authors/ed-simcox/_index.md
@@ -7,32 +7,17 @@ display_name: "Ed Simcox"
 first_name: "Ed"
 last_name: "Simcox"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: ed-simcox
 
-# if you include an email address, it will be displayed on your profile page
-email: "Edwin.Simcox@hhs.gov"
 
-# Bio — keep it under 50 words
-bio: "Ed Simcox is Chief Technology Officer and Acting Chief Information Officer at the U.S. Department of Health and Human Services (HHS)."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: "https://www.hhs.gov/cto/"
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/eddie-tejeda/_index.md
+++ b/content/authors/eddie-tejeda/_index.md
@@ -8,26 +8,14 @@ display_name: "Eddie Tejeda"
 first_name: "Eddie"
 last_name: "Tejeda"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: eddie.tejeda@gsa.gov
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "New York City"
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "eddietejeda"
@@ -37,11 +25,6 @@ github: "eddietejeda"
 profile_photo: "github"
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/eden-savino/_index.md
+++ b/content/authors/eden-savino/_index.md
@@ -7,32 +7,17 @@ display_name: "Eden Savino"
 first_name: "Eden"
 last_name: "Savino"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: eden-savino
 
-# if you include an email address, it will be displayed on your profile page
-email: "savinoe@gao.gov"
 
-# Bio — keep it under 50 words
-bio: "Eden Savino is a Senior Analyst in the Health Care team at the U.S. Government Accountability Office (GAO)."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/edgardo-morales/_index.md
+++ b/content/authors/edgardo-morales/_index.md
@@ -7,32 +7,17 @@ display_name: "Edgardo Morales"
 first_name: "Edgardo"
 last_name: "Morales Santiago"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: edgardo-morales
 
-# if you include an email address, it will be displayed on your profile page
-email: "edgardo.morales@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: "Edgardo Morales Santiago is a member of the USA.gov Outreach Team at the U.S. General Services Administration."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/elaine-johanson/_index.md
+++ b/content/authors/elaine-johanson/_index.md
@@ -8,26 +8,14 @@ display_name: "Elaine Johanson"
 first_name: "Elaine"
 last_name: "Johanson"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "As the acting director of health informatics within the Office of the Chief Scientist at FDA, Elaine brings more than 35 years of information technology and health informatics experience. In this position, she utilizes non-traditional mechanisms to share FDA data and to engage external experts in evolving areas of regulatory science. In addition, she facilitates agency-wide participation in international health data and terminology standards, leads the identification and curation of substance information, and the exchange of product labeling information for FDA."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Food and Drug Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "FDA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/electra-holmes/_index.md
+++ b/content/authors/electra-holmes/_index.md
@@ -8,26 +8,14 @@ display_name: "Electra Holmes"
 first_name: "Electra"
 last_name: "Holmes"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/eleni-geschkaramanlidis/_index.md
+++ b/content/authors/eleni-geschkaramanlidis/_index.md
@@ -8,26 +8,14 @@ display_name: "Eleni Gesch-Karamanlidis"
 first_name: "Eleni"
 last_name: "Gesch-Karamanlidis"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/elham-tabassi/_index.md
+++ b/content/authors/elham-tabassi/_index.md
@@ -1,7 +1,7 @@
 ---
 display_name: Elham Tabassi
 first_name: Elham
-last_name: Elham
+last_name: Tabassi
 # Keep it under 50 words and only one paragraph
 # e.g. U.S. General Services Administration
 agency_full_name: National Institute of Standards and Technology

--- a/content/authors/elham-tabassi/_index.md
+++ b/content/authors/elham-tabassi/_index.md
@@ -3,10 +3,7 @@ display_name: Elham Tabassi
 first_name: Elham
 last_name: Elham
 # Keep it under 50 words and only one paragraph
-bio: "Elham Tabassi is the Chief of Staff in the Information Technology Laboratory (ITL) at the National Institute of Standards and Technology (NIST). ITL, one of six research laboratories within NIST, supports NIST’s mission to promote U.S. innovation and industrial competitiveness. "
 # e.g. U.S. General Services Administration
 agency_full_name: National Institute of Standards and Technology
-# Agency Acronym [e.g., GSA]
-agency: NIST
 slug: elham-tabassi
 ---

--- a/content/authors/elisa-chen/_index.md
+++ b/content/authors/elisa-chen/_index.md
@@ -3,14 +3,8 @@ display_name: Elisa Chen
 first_name: Elisa
 last_name: Chen
 # Keep it under 50 words and only one paragraph
-bio: "Elisa Chen is an 18F design strategist on detail with the U.S. Web Design System. Prior to her detail, Elisa partnered with federal agencies to improve the user experience of government services using human centered approaches. In her &#34;spare&#34; time, Elisa enjoys throwing pottery and building community."
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: Minnetonka, Minnesota
-# [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
 # Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
 # Learn more about getting a Github account at [URL]
 github: elisaachen

--- a/content/authors/elizabeth-ayer/_index.md
+++ b/content/authors/elizabeth-ayer/_index.md
@@ -6,29 +6,17 @@ display_name: "Elizabeth Ayer"
 first_name: "Elizabeth"
 last_name: "Ayer"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: "she/her"
 
 # user id — not easily changed
 slug: "elizabeth-ayer"
 
-# Email — If you include an email address, it will be displayed on your profile page
-email:
 
-# Bio — keep it under 50 words
-bio: "Elizabeth is a product manager with 18F working to support Lean Agile principles in government."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url:
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "18F"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on DigitalGov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "ecayer"
@@ -38,10 +26,6 @@ github: "ecayer"
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: "ElizAyer"
-facebook: ""
-instagram: ""
-youtube: ""
 
 
 # Make it better ♥

--- a/content/authors/elizabeth-cain/_index.md
+++ b/content/authors/elizabeth-cain/_index.md
@@ -8,26 +8,14 @@ display_name: "Elizabeth Cain"
 first_name: "Elizabeth"
 last_name: "Cain"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/elizabeth-hochberg/_index.md
+++ b/content/authors/elizabeth-hochberg/_index.md
@@ -7,32 +7,17 @@ display_name: "Elizabeth Hochberg"
 first_name: "Beth"
 last_name: "Hochberg"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: elizabeth-hochberg
 
-# if you include an email address, it will be displayed on your profile page
-email: "elizabeth.hochberg@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/elizabeth-l-petrun-sayers/_index.md
+++ b/content/authors/elizabeth-l-petrun-sayers/_index.md
@@ -4,7 +4,5 @@ first_name: Elizabeth
 last_name: Petrun Sayers
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. Food and Drug Administration
-# Agency Acronym [e.g., GSA]
-agency: FDA
 slug: elizabeth-l-petrun-sayers
 ---

--- a/content/authors/elizabeth-molina/_index.md
+++ b/content/authors/elizabeth-molina/_index.md
@@ -2,12 +2,7 @@
 display_name: Elizabeth Molina
 first_name: Elizabeth
 last_name: Molina
-# Keep it under 50 words and only one paragraph
-bio: Elizabeth is a Program Analyst for the Enterprise Emerging Leaders Program
-  (EELP) in the Office of Human Resources Management (OHRM) at GSA.
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
 slug: elizabeth-molina
 ---

--- a/content/authors/elizabeth-zeitler/_index.md
+++ b/content/authors/elizabeth-zeitler/_index.md
@@ -7,32 +7,17 @@ display_name: "Elizabeth Zeitler"
 first_name: "Elizabeth"
 last_name: "Zeitler"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: elizabeth-zeitler
 
-# if you include an email address, it will be displayed on your profile page
-email: "zeitlere@mcc.gov"
 
-# Bio — keep it under 50 words
-bio: "Elizabeth Zeitler is a Transportation Advisor and Open Data advocate at the Millennium Challenge Corporation’s Division of Monitoring and Evaluation. She works to increase information access, use and learning for partner countries and for MCC as a AAAS Science and Technology Policy Fellow."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/ellen-arnold-losey/_index.md
+++ b/content/authors/ellen-arnold-losey/_index.md
@@ -7,32 +7,17 @@ display_name: "Ellen Arnold Losey"
 first_name: "Ellen Arnold"
 last_name: "Losey"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: ellen-arnold-losey
 
-# if you include an email address, it will be displayed on your profile page
-email: "earnold-losey@imls.gov"
 
-# Bio — keep it under 50 words
-bio: "Ellen Arnold Losey is the Senior Graphic Designer and Webmaster at the Institute of Museum and Library Services."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/ellen-langhans/_index.md
+++ b/content/authors/ellen-langhans/_index.md
@@ -7,32 +7,17 @@ display_name: "Ellen Langhans"
 first_name: "Ellen"
 last_name: "Langhans"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: ellen-langhans
 
-# if you include an email address, it will be displayed on your profile page
-email: "Ellen.Langhans@hhs.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/ellen-ryan/_index.md
+++ b/content/authors/ellen-ryan/_index.md
@@ -8,26 +8,14 @@ display_name: "Ellen Ryan"
 first_name: "Ellen"
 last_name: "Ryan"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Department of Commerce "
 
-# Agency Acronym [e.g., GSA]
-agency: "DOC "
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/emileigh-barnes/_index.md
+++ b/content/authors/emileigh-barnes/_index.md
@@ -7,32 +7,17 @@ display_name: "Emileigh Barnes"
 first_name: "Emileigh"
 last_name: "Barnes"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: emileigh-barnes
 
-# if you include an email address, it will be displayed on your profile page
-email: "emileigh.barnes@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/emily-boja-phd/_index.md
+++ b/content/authors/emily-boja-phd/_index.md
@@ -8,26 +8,14 @@ display_name: "Emily Boja, Ph.D."
 first_name: "Emily"
 last_name: "Boja"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: "Her/She"
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: Emily.Boja@fda.hhs.gov
 
-# Bio — keep it under 50 words
-bio: "Dr. Boja is a health scientist who will support OHI’s precisionFDA initiative and other informatics endeavors. Prior to joining OHI, she was a Program Director at the Office of Cancer Clinical Proteomic Research, NCI, NIH, providing scientific expertise and leadership in managing the Clinical Proteomic Tumor Analysis Consortium program."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Food and Drug Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "FDA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/emily-canis/_index.md
+++ b/content/authors/emily-canis/_index.md
@@ -7,32 +7,17 @@ display_name: "Emily Canis"
 first_name: "Emily"
 last_name: "Canis"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: emily-canis
 
-# if you include an email address, it will be displayed on your profile page
-email: "emily.canis@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/emily-herrick/_index.md
+++ b/content/authors/emily-herrick/_index.md
@@ -8,26 +8,14 @@ display_name: "Emily Herrick"
 first_name: "Emily"
 last_name: "Herrick"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Designer, Civic Service Design Studio"
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "em-herrick"
@@ -37,11 +25,6 @@ github: "em-herrick"
 profile_photo: "github"
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/emily-mcdonald/_index.md
+++ b/content/authors/emily-mcdonald/_index.md
@@ -4,7 +4,5 @@ first_name: Emily
 last_name: McDonald
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. Food and Drug Administration
-# Agency Acronym [e.g., GSA]
-agency: FDA
 slug: emily-mcdonald
 ---

--- a/content/authors/emily-parkhurst/_index.md
+++ b/content/authors/emily-parkhurst/_index.md
@@ -2,22 +2,7 @@
 display_name: Emily Parkhurst
 first_name: Emily
 last_name: Parkhurst
-# List your pronoun(s) if you want them displayed alongside your name.
-# If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
-# If you include an email address, it will be displayed on your profile page
-email: emily.parkhurst@nist.gov
-# Keep it under 50 words and only one paragraph
-bio: Ms. Parkhurst is a general attorney in the Office of the Chief Counsel
-  (OCC) for the National Institute of Standards and Technology (NIST). She has
-  been an employee of OCC/NIST since 2014. Ms. Parkhurst is the OCC/NIST
-  attorney located at the NIST campus in Boulder, Colorado. She provides legal
-  advice to NIST staff on NIST’s programmatic legal authority and works closely
-  with NIST management and NIST scientists, engineers, and administrative staff
-  to provide guidance and responses to their legal questions.
 # e.g. U.S. General Services Administration
 agency_full_name: National Institute of Standards and Technology
-# Agency Acronym [e.g., GSA]
-agency: NIST
 slug: emily-parkhurst
 ---

--- a/content/authors/emma-perron/_index.md
+++ b/content/authors/emma-perron/_index.md
@@ -8,26 +8,14 @@ display_name: "Emma Perron"
 first_name: "Emma"
 last_name: "Perron"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email:
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url:
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Washington D.C."
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/eric-beidel/_index.md
+++ b/content/authors/eric-beidel/_index.md
@@ -7,32 +7,17 @@ display_name: "Eric Beidel"
 first_name: "Eric"
 last_name: "Beidel"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: eric-beidel
 
-# if you include an email address, it will be displayed on your profile page
-email: "eric.beidel@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: "Eric Beidel is a communications specialist for the Challenge.gov program at the U.S. General Services Administration."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/eric-ewing/_index.md
+++ b/content/authors/eric-ewing/_index.md
@@ -8,26 +8,14 @@ display_name: "Eric Ewing"
 first_name: "Eric"
 last_name: "Ewing"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Eric Ewing has over 8 years of experience in data, analytics and artificial intelligence initiatives. Eric has served as a senior advisor to multiple federal Chief Data Officers, providing leadership, guidance, and expertise into enterprise modernization initiatives. With the Centers of Excellence (CoE), Eric consolidates and organizes long and short term strategy for data and Artificial Intelligence (AI) while leading initiatives for the management of data as a strategic asset. Prior to joining the CoE, Eric was a data scientist and senior consultant leading key analytics programs, AI research and development, and IT supply chain security initiatives with both private and public sector partners."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/eric-kanter/_index.md
+++ b/content/authors/eric-kanter/_index.md
@@ -8,26 +8,14 @@ display_name: "Eric Kanter"
 first_name: "Eric"
 last_name: "Kanter"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "Office of Congressman Seth Moulton (MA-06)"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/eric-mill/_index.md
+++ b/content/authors/eric-mill/_index.md
@@ -15,7 +15,7 @@ slug: eric-mill
 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: "General Services Administration"
+agency_full_name: "U.S. General Services Administration"
 
 
 

--- a/content/authors/eric-mill/_index.md
+++ b/content/authors/eric-mill/_index.md
@@ -7,32 +7,17 @@ display_name: "Eric Mill"
 first_name: "Eric"
 last_name: "Mill"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: eric-mill
 
-# if you include an email address, it will be displayed on your profile page
-email: "eric.mill@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Washington D.C."
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: "konklone"
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: "konklone"
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/erica-groshen/_index.md
+++ b/content/authors/erica-groshen/_index.md
@@ -7,32 +7,17 @@ display_name: "Erica L. Groshen"
 first_name: "Erica"
 last_name: "Groshen"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: erica-groshen
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Erica L. Groshen became the 14th Commissioner of Labor Statistics in January 2013. Prior to joining BLS, Dr. Groshen was a Vice President in the Research and Statistics Group at the Federal Reserve Bank of New York. Her research has focused on labor markets over the business cycle, regional economics, wage rigidity and dispersion, the male-female wage differential, and the role of employers in labor market outcomes. She also served on advisory boards for BLS and the U.S. Census Bureau. Before joining the Federal Reserve Bank of New York in 1994, Dr. Groshen was a visiting assistant professor of economics at Barnard College at Columbia University and an economist at the Federal Reserve Bank of Cleveland. She was a visiting economist at the Bank for International Settlements in Basel, Switzerland, in 1999–2000. Dr. Groshen earned a Ph.D. in economics from Harvard University and a bachelor’s degree in economics and mathematics from the University of Wisconsin-Madison. Dr. Groshen’s office can be contacted at (202) 691-7800."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/erica-kritt/_index.md
+++ b/content/authors/erica-kritt/_index.md
@@ -2,16 +2,7 @@
 display_name: Erica Kritt
 first_name: Erica
 last_name: Kritt
-# Keep it under 50 words and only one paragraph
-bio: "Erica Kritt is an outreach and engagement specialist at CFPB. She works to
-  coordinate the Bureau’s email program and create engaging content that helps
-  people take the next step on their financial journey. "
-# Where can people learn more about your work?
-# Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 # e.g. U.S. General Services Administration
 agency_full_name: Consumer Financial Protection Bureau
-# Agency Acronym [e.g., GSA]
-agency: CFPB
 slug: erica-kritt
 ---

--- a/content/authors/erik-martin/_index.md
+++ b/content/authors/erik-martin/_index.md
@@ -7,32 +7,17 @@ display_name: "Erik Martin"
 first_name: "Erik"
 last_name: "Martin"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: erik-martin
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Erik Martin is a Policy Advisor for the White House Office of Science and Technology Policy."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/erika-brown/_index.md
+++ b/content/authors/erika-brown/_index.md
@@ -7,32 +7,17 @@ display_name: "Erika Brown"
 first_name: "Erika"
 last_name: "Brown"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: erika-brown
 
-# if you include an email address, it will be displayed on your profile page
-email: "ebrown2@peacecorps.gov"
 
-# Bio — keep it under 50 words
-bio: "Erika is a Marketing and Communication Coordinator for Peace Corps Response, a short-term, high-impact Peace Corps program."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/erin-scheithe/_index.md
+++ b/content/authors/erin-scheithe/_index.md
@@ -7,32 +7,17 @@ display_name: "Erin Scheithe"
 first_name: "Erin"
 last_name: "Scheithe"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: erin-scheithe
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Erin Scheithe is a Content Specialist in the Consumer Financial Protection Bureau’s Office for Older Americans, which focuses on educating and engaging with consumers 62 and older on financial matters. In this role she writes, edits, and presents material on fraud and scam prevention, financial caregiving, and retirement planning. The majority of Erin’s career has been spent developing financial education materials for consumer audiences. She worked for both the American Bankers Association and North Carolina Bankers Association to develop financial education programs for children and parents. In addition, she developed resources on financial security issues for the 50&#43; population while working for AARP’s consumer education division. Erin also has experience composing and coordinating large-scale grassroots advocacy campaigns. A native of Virginia, Erin obtained both a bachelor’s degree in English literature and a master’s degree in Educational Psychology from the University of Virginia."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/erin-twamley/_index.md
+++ b/content/authors/erin-twamley/_index.md
@@ -7,32 +7,17 @@ display_name: "Erin Twamley"
 first_name: "Erin"
 last_name: "Twamley"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: erin-twamley
 
-# if you include an email address, it will be displayed on your profile page
-email: "erin.twamley@ee.doe.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/evan-matthew-papp/_index.md
+++ b/content/authors/evan-matthew-papp/_index.md
@@ -8,26 +8,14 @@ display_name: "Evan Matthew Papp"
 first_name: "Evan Matthew"
 last_name: "Papp"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "United States Agency for International Development"
 
-# Agency Acronym [e.g., GSA]
-agency: "USAID"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: "EvanMatthewPapp"
-facebook: ""
-instagram: "evanmatthewpapp"
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/evan-ray/_index.md
+++ b/content/authors/evan-ray/_index.md
@@ -3,7 +3,6 @@ display_name: Evan Ray
 first_name: Evan
 last_name: Ray
 # Keep it under 50 words and only one paragraph
-bio: Evan Ray is a Research Assistant Professor of Biostatistics at University of Massachusetts Amherst, where he received his PhD in statistics, developing methods to infer physical activity type and intensity from accelerometer data. A former postdoctoral in the Reich Lab at University of Massachusetts Amherst, he also works on developing methods for predicting infectious disease outbreaks.
 # e.g. U.S. General Services Administration
 agency_full_name: Reich Lab at University of Massachusetts Amherst
 slug: evan-ray

--- a/content/news/2015/05/2015-05-21-digitalgov-citizen-services-summit-2015-open-innovation-and-collaboration.md
+++ b/content/news/2015/05/2015-05-21-digitalgov-citizen-services-summit-2015-open-innovation-and-collaboration.md
@@ -20,8 +20,6 @@ The theme of this year&#8217;s Summit was "open." The agenda was packed with pre
 
 Megan Smith, U.S. Chief Technology Officer, opened the Summit, challenging all techies in government to help solve problems and be part of decision-making at the highest levels of government.
 
-{{< tweet user="JanetBS" id="601376122086039552" >}}
-
 She also said that young people have found ways to serve their country through the Peace Corps and Teach for America and invited the group to think how they could serve digitally.
 
 <blockquote class="twitter-tweet" data-width="500">

--- a/content/news/2015/06/2015-06-12-digitalgov-citizen-services-summit-reflections-from-our-livestream-host-and-full-recording-now-available.md
+++ b/content/news/2015/06/2015-06-12-digitalgov-citizen-services-summit-reflections-from-our-livestream-host-and-full-recording-now-available.md
@@ -54,15 +54,11 @@ Federal agencies were also invited to showcase their programs, tools and innovat
 
 {{< tweet user="jakegab" id="601206392905674752" >}}
 
-{{< tweet user="lauraandotis" id="601432623186051072" >}}
-
 {{< tweet user="FedRAMP" id="601370769533308928" >}}
 
 The Summit's hashtag, [&#35;DigitalGov15](https://twitter.com/hashtag/DigitalGov15?src=hash), became a top trend across the United States on Twitter. Thank you to everyone who came in person to attend, tuned in online via livestream, tweeted throughout the event, put us in the top US trends, and helped to make &#35;DigitalGov15 such a success!
 
 {{< tweet user="BernettaReese" id="601102824252936193" >}}
-
-{{< tweet user="BernettaReese" id="601385199994327040" >}}
 
 {{< tweet user="WhoTrendedIT" id="601382714542022657" >}}
 

--- a/content/news/2015/06/2015-06-12-digitalgov-citizen-services-summit-reflections-from-our-livestream-host-and-full-recording-now-available.md
+++ b/content/news/2015/06/2015-06-12-digitalgov-citizen-services-summit-reflections-from-our-livestream-host-and-full-recording-now-available.md
@@ -34,7 +34,6 @@ Megan Smith, U.S. Chief Technology Officer in the Office of Science and Technolo
 
 Dr. David Bray, Chief Information Officer for the Federal Communications Commission and 2015 Eisenhower Fellow, talked about going exponential and the Internet of Everything, and encouraged federal employees to become #ChangeAgents.
 
-{{< tweet user="BernettaReese" id="601102824252936193" >}}
 
 {{< tweet user="alyciap1" id="601392825348050944" >}}
 
@@ -58,7 +57,6 @@ Federal agencies were also invited to showcase their programs, tools and innovat
 
 The Summit's hashtag, [&#35;DigitalGov15](https://twitter.com/hashtag/DigitalGov15?src=hash), became a top trend across the United States on Twitter. Thank you to everyone who came in person to attend, tuned in online via livestream, tweeted throughout the event, put us in the top US trends, and helped to make &#35;DigitalGov15 such a success!
 
-{{< tweet user="BernettaReese" id="601102824252936193" >}}
 
 {{< tweet user="WhoTrendedIT" id="601382714542022657" >}}
 

--- a/content/news/2016/09/2016-09-26-gsa-hosts-first-ever-technology-industry-day-in-washington-d-c.md
+++ b/content/news/2016/09/2016-09-26-gsa-hosts-first-ever-technology-industry-day-in-washington-d-c.md
@@ -24,8 +24,6 @@ On September 8, 2016 Administrator Denise Turner Roth of the [U.S. General Servi
 
 "The General Services Administration has a long history of being a strong leader in adopting technology in government," said Administrator Roth when giving her opening remarks at GSA's Technology Industry Day.
 
-{{< tweet user="18F" id="773873292746723328" >}}
-
 In a moderated panel, the leadership team shared their insights about the future of GSA’s role in making it easier for agencies to create and buy technology. The panel included GSA Administrator Denise Turner Roth, Acting [Technology Transformation Service](http://www.gsa.gov/portal/category/25729) (TTS) Commissioner David Shive, Chief Technology Officer Navin Vembar, Assistant Commissioner of [Integrated Technology Services](http://www.gsa.gov/portal/content/105150) Mary Davie and Executive Director of [18F](http://www.gsa.gov/portal/content/124182) Aaron Snow.
 
 {{< tweet user="USGSA" id="773881444896739328" >}}

--- a/content/news/2020/06/2020-06-30-bringing-our-humanity-work-5-ingredients.md
+++ b/content/news/2020/06/2020-06-30-bringing-our-humanity-work-5-ingredients.md
@@ -98,7 +98,7 @@ This month, we’re focusing on large group meetings: divisional Town Halls or o
 
 <p>We also encourage gratitude and reflection. Kudos are another staple of our meetings: we set aside a timeblock for teammates to thank each other, in their own words. The moderator can gather names ahead of time and call on each person to unmute. They can also read off kudos for anyone who can’t attend or would prefer not to unmute.</p>
 
-{{< tweet user="18F" id="1180123465963188224" >}}</li>
+</li>
 </ol>
 
 We hope you’ll stir together our five ingredients and create the dish that best serves your audience. Stay tuned for the next piece, focused on small team meetings.

--- a/content/news/2021/03/2021-03-23-tts-reflects-black-histories-to-celebrate-year-round.md
+++ b/content/news/2021/03/2021-03-23-tts-reflects-black-histories-to-celebrate-year-round.md
@@ -30,7 +30,7 @@ The TTS Diversity guild and the TTS’ Working While Black (WWB) affinity group 
 
 The TTS Outreach team also created social media campaigns focused on highlighting what Black History Month meant for our Black colleagues. We reached out to them and gathered content and feedback to create a social media campaign that not only provided our Black employees an opportunity to share their voice, but also showcase their outstanding work and expertise.
 
-<center>{{< tweet user="GSA_TTS" id="1359893539526746117" >}}
+<center>
 
 <hr width="75%">
 


### PR DESCRIPTION
## Summary

Metadata removal for author ranges D-E.

> [!NOTE]
> Will be merged into #8216 and also includes author removal for authors with no published content.


## Solution

Removes all other `author` fields.

**Fields to Keep**

- display_name
- first_name
- last_name
- agency_full_name
- github (github username)
- profile_source (digit-light, digit-dark, blank)


## How To Test

1. Only fields listed above are displayed
2. Remove non-published authors

