### PR TITLE
Remove author landing page and metadata (authors J)

### DIFF
--- a/content/authors/_index.md
+++ b/content/authors/_index.md
@@ -3,4 +3,13 @@ title: "Authors"
 deck: "The people who have contributed their stories and guidance over the years."
 summary: "The people who have contributed their stories and guidance over the years."
 redirectto: /news
+aliases: 
+  - /authors/jerry-sheehan
+  - /authors/jesse-taggert
+  - /authors/jessica-milcetich
+  - /authors/jini-ryan
+  - /authors/joanna-karpinski-widzer
+  - /authors/joel-minton
+  - /authors/john-grill
+  - /authors/john-paul
 ---

--- a/content/authors/j-todd-breasseale/_index.md
+++ b/content/authors/j-todd-breasseale/_index.md
@@ -7,32 +7,17 @@ display_name: "J. Todd Breasseale"
 first_name: "J. Todd"
 last_name: "Breasseale"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: j-todd-breasseale
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "As Assistant Secretary for Public Affairs, J. Todd Breasseale oversees the Department of Homeland Security’s public outreach, media relations, and strategic and incident communication efforts and serves as the principal communication advisor to Secretary Jeh C. Johnson."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jack-avery/_index.md
+++ b/content/authors/jack-avery/_index.md
@@ -2,22 +2,10 @@
 display_name: Jack Avery
 first_name: Jack
 last_name: Avery
-# List your pronoun(s) if you want them displayed alongside your name.
-# If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: he/him
-# Keep it under 50 words and only one paragraph
-bio: Jack Avery is a federal contractor to Digital Analytics Program, providing
-  data analysis and help desk support, supporting more than 4,000 agency
-  customers.
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
-# [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
-# Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
 # Learn more about getting a Github account at [URL]
 github: masterccioli
 slug: jack-avery
 # See [URL] for a full list of profile photo options
-profile_photo: github
 ---

--- a/content/authors/jack-bienko/_index.md
+++ b/content/authors/jack-bienko/_index.md
@@ -7,32 +7,17 @@ display_name: "Jack Bienko"
 first_name: "Jack"
 last_name: "Bienko"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jack-bienko
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Jack Bienko is the Deputy for Entrepreneurship Education at the U.S. Small Business Administration."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jackie-kazil/_index.md
+++ b/content/authors/jackie-kazil/_index.md
@@ -7,32 +7,17 @@ display_name: "Jackie Kazil"
 first_name: "Jackie"
 last_name: "Kazil"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jackie-kazil
 
-# if you include an email address, it will be displayed on your profile page
-email: "jacqueline.kazil@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jackie-yarbro/_index.md
+++ b/content/authors/jackie-yarbro/_index.md
@@ -2,19 +2,7 @@
 display_name: Jackie Yarbro
 first_name: Jacqueline
 last_name: Yarbro
-# If you include an email address, it will be displayed on your profile page
-email: jyarbro@osc.gov
-# Keep it under 50 words and only one paragraph
-bio: Jacqueline (Jackie) Yarbro has been an attorney in the Hatch Act Unit at
-  the U.S. Office of Special Counsel since September 2018. During her time
-  working in the unit, she has investigated allegations of prohibited political
-  activity, advised on emerging areas of Hatch Act concern, and presented to
-  federal employee audiences about the law’s prohibitions. Jackie graduated from
-  Washington and Lee University and received her law degree from Georgetown
-  University Law Center.
 # e.g. U.S. General Services Administration
 agency_full_name: Office of Special Council
-# Agency Acronym [e.g., GSA]
-agency: OSC
 slug: jackie-yarbro
 ---

--- a/content/authors/jacqueline-snee/_index.md
+++ b/content/authors/jacqueline-snee/_index.md
@@ -7,32 +7,17 @@ display_name: "Jacqueline Snee"
 first_name: "Jacqueline"
 last_name: "Snee"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jacqueline-snee
 
-# if you include an email address, it will be displayed on your profile page
-email: "jacqueline.snee@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: "Jacqueline Snee is a Customer Experience Strategist for the Customer Experience Team within GSA&#39;s Federal Citizen Information Center. While she loves all aspects of customer experience, her passion is employee engagement."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Washington D.C."
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jacquelyn-dolezal-morales/_index.md
+++ b/content/authors/jacquelyn-dolezal-morales/_index.md
@@ -2,16 +2,9 @@
 display_name: Jacquelyn Dolezal Morales
 first_name: Jacquelyn
 last_name: Dolezal Morales
-# Keep it under 50 words and only one paragraph
-bio: Jacquelyn Dolezal Morales is a digital communications specialist with the
-  Inter-American Foundation based out of Washington, DC.
 # e.g. U.S. General Services Administration
 agency_full_name: " Inter-American Foundation"
-# Agency Acronym [e.g., GSA]
-agency: IAF
 slug: jacquelyn-dolezal-morales
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: Washington, D.C.
 # See [URL] for a full list of profile photo options
 profile_photo: digit-dark
 ---

--- a/content/authors/jada-jones/_index.md
+++ b/content/authors/jada-jones/_index.md
@@ -7,32 +7,17 @@ display_name: "Jada Jones"
 first_name: "Jada"
 last_name: "Jones"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jada-jones
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Jada is a graduate of the University of North Carolina at Greensboro with a Masters in Library and Information Science. She began her non-traditional librarian career at the FDA working on a STEAM outreach program for high school students. She currently works in public affairs and analytics. She has a background in archives, records management, and data management and has worked in education, outreach, and project management. She recently earned both a Graduate Certificate in Project Management and her PMP certification. Jada is also active in blogging and owns a small book-subscription box start-up. She has lived in rural China and loves to travel internationally. You can find her on [LinkedIn](https://www.linkedin.com/in/jada-jones-85b68353/)."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: "jada-jones-85b68353"
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jaime-kern/_index.md
+++ b/content/authors/jaime-kern/_index.md
@@ -2,12 +2,7 @@
 display_name: Jaime Kern
 first_name: Jaime
 last_name: Kern
-# List your pronoun(s) if you want them displayed alongside your name.
-# If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: she/her
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
 slug: jaime-kern
 ---

--- a/content/authors/jaime-mears/_index.md
+++ b/content/authors/jaime-mears/_index.md
@@ -7,32 +7,17 @@ display_name: "Jaime Mears"
 first_name: "Jaime"
 last_name: "Mears"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jaime-mears
 
-# if you include an email address, it will be displayed on your profile page
-email: "apuig@ftc.gov"
 
-# Bio — keep it under 50 words
-bio: "Jaime Mears works in the National Digital Initiatives division at the Library of Congress. She lead the planning and event coordination for the Collections as Data event and the Archives Unleashed datathon. Her professional interests include digital preservation and access, personal archiving, and teaching with primary sources. Jaime has a BA degree in English Literature from the University of Virginia and a MLS from the University of Maryland."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jamal-mazrui/_index.md
+++ b/content/authors/jamal-mazrui/_index.md
@@ -7,32 +7,17 @@ display_name: "Jamal Mazrui"
 first_name: "Jamal"
 last_name: "Mazrui"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jamal-mazrui
 
-# if you include an email address, it will be displayed on your profile page
-email: "Jamal.Mazrui@fcc.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/james-geoghegan/_index.md
+++ b/content/authors/james-geoghegan/_index.md
@@ -7,29 +7,14 @@ display_name: "Jim Geoghegan"
 first_name: "James"
 last_name: "Geoghegan"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
-# if you include an email address, it will be displayed on your profile page
-email: "james.geoghegan@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: "Jim Geoghegan is the RPA Community of Practice program manager, a consortium of 975 federal members from over 65 agencies. A proponent for action, he is passionate about building automation and efficiency into federal processes."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Washington D.C."
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -40,11 +25,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/james-gregory/_index.md
+++ b/content/authors/james-gregory/_index.md
@@ -7,29 +7,14 @@ display_name: "James Gregory"
 first_name: "James"
 last_name: "Gregory"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
-# if you include an email address, it will be displayed on your profile page
-email: "james2.gregory@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: "James Gregory is director of the Robotic Process Automation (RPA) Program at GSA."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Washington D.C."
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -40,11 +25,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/james-hill/_index.md
+++ b/content/authors/james-hill/_index.md
@@ -2,18 +2,10 @@
 display_name: James Hill
 first_name: James
 last_name: Hill
-# List your pronoun(s) if you want them displayed alongside your name.
-# If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
-# [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
 # Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
 # Learn more about getting a Github account at [URL]
 github: Jhhill32
 slug: james-hill
-# See [URL] for a full list of profile photo options
-profile_photo: github
 ---

--- a/content/authors/james-kim/_index.md
+++ b/content/authors/james-kim/_index.md
@@ -7,32 +7,17 @@ display_name: "James Kim"
 first_name: "James"
 last_name: "Kim"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: james-kim
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "James Kim is a toxicologist in the Office of Information and Regulatory Affairs at the Office of Management and Budget."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/james-mejia/_index.md
+++ b/content/authors/james-mejia/_index.md
@@ -8,26 +8,14 @@ display_name: "James Mejia"
 first_name: "James"
 last_name: "Mejia"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "mejiaj"
@@ -37,11 +25,6 @@ github: "mejiaj"
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/james-roberts/_index.md
+++ b/content/authors/james-roberts/_index.md
@@ -8,26 +8,14 @@ display_name: "James Roberts"
 first_name: "James"
 last_name: "Roberts"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Census Bureau"
 
-# Agency Acronym [e.g., GSA]
-agency: "USCB"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/jamie-albrecht/_index.md
+++ b/content/authors/jamie-albrecht/_index.md
@@ -7,32 +7,17 @@ display_name: "Jamie Albrecht"
 first_name: "Jamie"
 last_name: "Albrecht"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jamie-albrecht
 
-# if you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jamie-stark/_index.md
+++ b/content/authors/jamie-stark/_index.md
@@ -8,26 +8,14 @@ display_name: "Jamie Stark"
 first_name: "Jamie"
 last_name: "Stark"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "United States Citizenship and Immigration Services"
 
-# Agency Acronym [e.g., GSA]
-agency: "USCIS"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/jana-goldman/_index.md
+++ b/content/authors/jana-goldman/_index.md
@@ -8,26 +8,14 @@ display_name: "Jana Goldman"
 first_name: "Jana"
 last_name: "Goldman"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: https://plainlanguagenetwork.org/board/jana-goldman/
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/janet-linton/_index.md
+++ b/content/authors/janet-linton/_index.md
@@ -7,32 +7,17 @@ display_name: "Janet Linton"
 first_name: "Janet"
 last_name: "Linton"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: janet-linton
 
-# if you include an email address, it will be displayed on your profile page
-email: "lintonjl@nida.nih.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/janis-e-burl/_index.md
+++ b/content/authors/janis-e-burl/_index.md
@@ -4,7 +4,5 @@ first_name: Janis
 last_name: Burl
 # e.g. U.S. General Services Administration
 agency_full_name: Transportation Security Administration
-# Agency Acronym [e.g., GSA]
-agency: TSA
 slug: janis-e-burl
 ---

--- a/content/authors/jarah-meador/_index.md
+++ b/content/authors/jarah-meador/_index.md
@@ -6,43 +6,24 @@ display_name: "Dr. Jarah Meador"
 first_name: "Jarah"
 last_name: "Meador"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: "jarah-meador"
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: jarah.meador@gsa.gov
 
-# Bio — keep it under 50 words
-bio: "Jarah leads the crowdsourcing, citizen science and prize competition open innovation portfolio at GSA that includes the Challenge.Gov and CitizenScience.gov. Previously, she led the innovation sourcing program at the Department of Veterans Affairs Center for Innovation and this portfolio included prize competitions, broad agency announcements, and pay for success/social impact financing. The AAAS Science and Policy Technology Fellowship brought her to the federal government at the US Agency for International Development 10 years ago where she led a large-scale desalination technology development prize competition. Jarah earned her PhD in Cancer Biology at the University of Texas Graduate School of Biomedical Sciences and is an Air Force Veteran."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url:
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
-# A GitHub account will allow you to edit pages on DigitalGov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
 
 # Profile Photo
 # See [URL] for a full list of profile photo options
 profile_photo: ""
 
-# [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 
 # Make it better ♥

--- a/content/authors/jared-cunha/_index.md
+++ b/content/authors/jared-cunha/_index.md
@@ -8,26 +8,14 @@ display_name: "Jared Cunha"
 first_name: "Jared"
 last_name: "Cunha"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "jaredcunha"
@@ -37,11 +25,6 @@ github: "jaredcunha"
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/jared-shell/_index.md
+++ b/content/authors/jared-shell/_index.md
@@ -4,7 +4,5 @@ first_name: Jared
 last_name: Shell
 # e.g. U.S. General Services Administration
 agency_full_name:
-# Agency Acronym [e.g., GSA]
-agency: 
 slug: jared-shell
 ---

--- a/content/authors/jared-smith/_index.md
+++ b/content/authors/jared-smith/_index.md
@@ -8,26 +8,14 @@ display_name: "Jared Smith"
 first_name: "Jared"
 last_name: "Smith"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Jared Smith is the Associate Director of WebAIM. He is a highly demanded presenter and trainer and has provided web accessibility training to tens of thousands of web professionals throughout the world. With over 20 years of experience working in the web design, development, and accessibility field, he brings a wealth of knowledge and experience that is used to help others create and maintain highly accessible web content."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/jason-davis/_index.md
+++ b/content/authors/jason-davis/_index.md
@@ -8,26 +8,14 @@ display_name: "Jason Davis"
 first_name: "Jason"
 last_name: "Davis"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Jason Davis served five years with the Army’s 101st Airborne, including two combat tours to Iraq in support of Operation Iraqi Freedom. After leaving service, he earned a BA in Literary Journalism from the University of California at Irvine, and an MA in Writing (nonfiction) from Johns Hopkins University. Jason was an editor and photographer under the Motor Trend umbrella prior to running Veterans Benefits Administration’s social media from 2013 to 2019. Jason moved up the street to VA’s Digital Media Engagement team in June 2019."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Department of Veterans Affairs"
 
-# Agency Acronym [e.g., GSA]
-agency: "VA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/jason-duley/_index.md
+++ b/content/authors/jason-duley/_index.md
@@ -7,32 +7,17 @@ display_name: "Jason Duley"
 first_name: "Jason"
 last_name: "Duley"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jason-duley
 
-# if you include an email address, it will be displayed on your profile page
-email: "jason.duley@nasa.gov"
 
-# Bio — keep it under 50 words
-bio: "Open Data Program Manager, NASA Ames Research Center/HQ OCIO"
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jason-furman/_index.md
+++ b/content/authors/jason-furman/_index.md
@@ -7,32 +7,17 @@ display_name: "Jason Furman"
 first_name: "Jason"
 last_name: "Furman"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jason-furman
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Jason Furman was confirmed by the Senate on August 1, 2013 as the 28th Chairman of the Council of Economic Advisers. In this role, he serves as President Obama’s Chief Economist and a Member of the Cabinet."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: "https://www.whitehouse.gov/blog/author/jason-furman"
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jason-goldman/_index.md
+++ b/content/authors/jason-goldman/_index.md
@@ -7,32 +7,17 @@ display_name: "Jason Goldman"
 first_name: "Jason"
 last_name: "Goldman"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jason-goldman
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Jason Goldman grew up in St. Louis, Missouri and graduated with a degree in Astrophysics from Princeton University. He was part of the Blogger team acquired by Google in 2003. He worked as a product manager for Google from 2003 to 2006. In 2007, he helped start Twitter Inc where he was Head of Product and served on the board of directors until 2010. Along with Twitter co-founders Ev Williams and Biz Stone he started the Obvious Corporation in 2011 which has helped finance and found companies such as Branch and Medium. In April 2015, he became the first Chief Digital Officer of the White House."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jason-kelly/_index.md
+++ b/content/authors/jason-kelly/_index.md
@@ -7,32 +7,17 @@ display_name: "Jason Kelly"
 first_name: "Jason"
 last_name: "Kelly"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jason-kelly
 
-# if you include an email address, it will be displayed on your profile page
-email: "jason.s.kelly@navy.mil"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jason-kopp/_index.md
+++ b/content/authors/jason-kopp/_index.md
@@ -8,26 +8,14 @@ display_name: "Jason Kopp"
 first_name: "Jason"
 last_name: "Kopp"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Jason Kopp is the 2020 Census Advisor to American Samoa at the U.S. Census Bureau. He oversees the 2020 Census of American Samoa to ensure a complete and accurate count. Previously, Jason served as the inaugural Branch Chief of the Decennial Translation Branch from 2016 to 2019. In that position, he hired and recruited all branch staff, and created a standardized approach to translation workflow and quality assurance for translation requests across the agency. Jason has a master's degree in Translation and Localization Management (Spanish) from the Middlebury Institute of International Studies."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Census Bureau"
 
-# Agency Acronym [e.g., GSA]
-agency: "USCB"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/javier-chavez/_index.md
+++ b/content/authors/javier-chavez/_index.md
@@ -6,32 +6,17 @@ display_name: "Javier Chavez"
 first_name: "Javier"
 last_name: "Chavez"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: "he/him"
 
 # slug — the specific user-id for an author.
 slug: javier-chavez
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Javier is a technical information specialist and bilingual programs lead for the Health Information Products Unit, of the U.S. National Library of Medicine (NLM). He leads a team of professional translators for MedlinePlus en Español, augmenting NLM outreach capabilities to Hispanic and Latino populations via the MedlinePlus network, social media platforms, newsletters, and other unique program initiatives."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: " U.S. National Library of Medicine"
 
-# Agency Acronym [e.g., GSA]
-agency: "NLM"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Derwood, MD"
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -42,10 +27,5 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 ---

--- a/content/authors/jay-benforado/_index.md
+++ b/content/authors/jay-benforado/_index.md
@@ -7,32 +7,17 @@ display_name: "Jay Benforado"
 first_name: "Jay"
 last_name: "Benforado"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jay-benforado
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Jay Benforado is the Deputy Chief Innovation Officer in the Office of Research and Development at the Environmental Protection Agency (EPA)."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jay-shambaugh/_index.md
+++ b/content/authors/jay-shambaugh/_index.md
@@ -7,32 +7,17 @@ display_name: "Jay Shambaugh"
 first_name: "Jay"
 last_name: "Shambaugh"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jay-shambaugh
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Jay Shambaugh is a member of the Council of Economic Advisors."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jay-shao/_index.md
+++ b/content/authors/jay-shao/_index.md
@@ -2,12 +2,7 @@
 display_name: Jay Shao
 first_name: Jay
 last_name: Shao
-# Where can people learn more about your work?
-# Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: https://digitalcorps.gsa.gov/fellows/jay-shao/
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: U.S. Digital Corps
 slug: jay-shao
 ---

--- a/content/authors/jean-fox/_index.md
+++ b/content/authors/jean-fox/_index.md
@@ -7,32 +7,17 @@ display_name: "Jean Fox"
 first_name: "Jean"
 last_name: "Fox"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jean-fox
 
-# if you include an email address, it will be displayed on your profile page
-email: "fox.jean@bls.gov"
 
-# Bio — keep it under 50 words
-bio: "Jean Fox is a research psychologist in the Bureau of Labor Statistics (BLS) at the U.S. Department of Labor."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Department of Labor"
 
-# Agency Acronym [e.g., GSA]
-agency: "BLS"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jeanette-kennedy/_index.md
+++ b/content/authors/jeanette-kennedy/_index.md
@@ -7,32 +7,17 @@ display_name: "Jeanette Kennedy"
 first_name: "Jeanette"
 last_name: "Kennedy"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jeanette-kennedy
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Jeanette Kennedy, FirstNet Government Affairs."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jeanne-holm/_index.md
+++ b/content/authors/jeanne-holm/_index.md
@@ -7,32 +7,17 @@ display_name: "Jeanne Holm"
 first_name: "Jeanne"
 last_name: "Holm"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jeanne-holm
 
-# if you include an email address, it will be displayed on your profile page
-email: "jeanne.holm@jpl.nasa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jeannette-bruno/_index.md
+++ b/content/authors/jeannette-bruno/_index.md
@@ -2,20 +2,8 @@
 display_name: Jeannette Bruno
 first_name: Jeannette
 last_name: Bruno
-# List your pronoun(s) if you want them displayed alongside your name.
-# If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: She | Her
-# If you include an email address, it will be displayed on your profile page
-email: jeannette.bruno@gsa.gov
-# Keep it under 50 words and only one paragraph
-bio: Jeannette Bruno has over nine years of experience managing complex projects, conducting program evaluations, and supporting strategic change management initiatives. As an innovation adoption lead at the [Centers of Excellence (CoE)](https://coe.gsa.gov), she is passionate about centering change management at the intersection of people, process, and technology. An emerging futurist, she has a Professional Certificate in Strategic Foresight from the University of Houston and embeds the principles of strategic foresight into her work.
 # e.g. U.S. General Services Administration
 agency_full_name: " U.S. General Services Administration"
-# Agency Acronym [e.g., GSA]
-agency: GSA
 slug: jeannette-bruno
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: Philadelphia, PA
-linkedin: jeannette-a-bruno1415
 
 ---

--- a/content/authors/jeannie-chen/_index.md
+++ b/content/authors/jeannie-chen/_index.md
@@ -7,32 +7,17 @@ display_name: "Jeannie Chen"
 first_name: "Jeannie"
 last_name: "Chen"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jeannie-chen
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jeannie-yoon/_index.md
+++ b/content/authors/jeannie-yoon/_index.md
@@ -2,25 +2,12 @@
 display_name: Jeannie Yoon
 first_name: Jeannie
 last_name: Yoon
-# List your pronoun(s) if you want them displayed alongside your name.
-# If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: 
-# If you include an email address, it will be displayed on your profile page
-email: 
-# Keep it under 50 words and only one paragraph
-bio: Jeannie is a consultant who works with GSA’s Technology Transformation Services (TTS). As part of the Digital.gov team, Jeannie manages events, supports Communities of Practice, and writes content for the Digital.gov website.
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: 
-# [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
 # Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
 # Learn more about getting a Github account at [URL]
 github: jdotyoon
 # See [URL] for a full list of profile photo options
-profile_photo: github
 slug: jeannie-yoon
 
 ---

--- a/content/authors/jed-sundwall/_index.md
+++ b/content/authors/jed-sundwall/_index.md
@@ -7,32 +7,17 @@ display_name: "Jed Sundwall"
 first_name: "Jed"
 last_name: "Sundwall"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jed-sundwall
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jeff-bordogna/_index.md
+++ b/content/authors/jeff-bordogna/_index.md
@@ -5,10 +5,7 @@ last_name: Bordogna
 
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
 
-# [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
 # Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
 # Learn more about getting a Github account at [URL]
 github: 

--- a/content/authors/jeff-koses/_index.md
+++ b/content/authors/jeff-koses/_index.md
@@ -7,32 +7,17 @@ display_name: "Jeff Koses"
 first_name: "Jeff"
 last_name: "Koses"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jeff-koses
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Jeff Koses is a Senior Procurement Executive in the Office of Government-wide Policy at GSA."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jeff-pass/_index.md
+++ b/content/authors/jeff-pass/_index.md
@@ -2,10 +2,5 @@
 display_name: Jeff Pass
 first_name: Jeff
 last_name: Pass
-# Keep it under 50 words and only one paragraph
-bio: Jeff Pass made his first website in 1997 and has been involved in digital
-  communications, usability, information architecture, content strategy, and
-  design ever since. Since 2014, he has been the User Experience Team Lead for
-  USPS.gov.
 slug: jeff-pass
 ---

--- a/content/authors/jeff-woodworth/_index.md
+++ b/content/authors/jeff-woodworth/_index.md
@@ -7,32 +7,17 @@ display_name: "Jeff Woodworth"
 first_name: "Jeff"
 last_name: "Woodworth"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jeff-woodworth
 
-# if you include an email address, it will be displayed on your profile page
-email: "jeffrey.woodworth@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: "Jeff Woodworth is a Communications Specialist for the General Services Administration (GSA)."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jeffrey-chen/_index.md
+++ b/content/authors/jeffrey-chen/_index.md
@@ -7,32 +7,17 @@ display_name: "Jeffrey Chen"
 first_name: "Jeffrey"
 last_name: "Chen"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jeffrey-chen
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jeffrey-doi/_index.md
+++ b/content/authors/jeffrey-doi/_index.md
@@ -8,26 +8,14 @@ display_name: "Jeffrey Doi"
 first_name: "Jeffrey"
 last_name: "Doi"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Jeffrey Doi is a data and business integration specialist for NASA CoECI who is responsible for CoECI challenge information and data integration, proposal evaluation, challenge coordination, and NASA@WORK support. "
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "National Aeronautics and Space Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "NASA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/jeffrey-levy/_index.md
+++ b/content/authors/jeffrey-levy/_index.md
@@ -7,32 +7,17 @@ display_name: "Jeffrey Levy"
 first_name: "Jeffrey"
 last_name: "Levy"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jeffrey-levy
 
-# if you include an email address, it will be displayed on your profile page
-email: "jeffrey.m.levy@uscis.dhs.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jeku-j-r-arce/_index.md
+++ b/content/authors/jeku-j-r-arce/_index.md
@@ -2,10 +2,7 @@
 display_name: Jeku (J.R.) Arce
 first_name: Jeku (J.R.)
 last_name: Arce
-# [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
 agency_full_name: Veterans Benefits Administration
-# Agency Acronym [e.g., GSA]
-agency: VA
 # Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
 # Learn more about getting a Github account at [URL]
 github: jrarce

--- a/content/authors/jenn-gustetic/_index.md
+++ b/content/authors/jenn-gustetic/_index.md
@@ -7,32 +7,17 @@ display_name: "Jenn Gustetic"
 first_name: "Jenn"
 last_name: "Gustetic"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jenn-gustetic
 
-# if you include an email address, it will be displayed on your profile page
-email: "Jennifer_L_Gustetic@ostp.eop.gov"
 
-# Bio — keep it under 50 words
-bio: "Jenn Gustetic is the Assistant Director for Open Innovation at the White House Office of Science and Technology Policy (OSTP)."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jenn-noinaj/_index.md
+++ b/content/authors/jenn-noinaj/_index.md
@@ -2,18 +2,10 @@
 display_name: Jenn Noinaj
 first_name: Jenn
 last_name: Noinaj
-# List your pronoun(s) if you want them displayed alongside your name.
-# If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: she/her
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
-# [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
 # Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
 # Learn more about getting a Github account at [URL]
 github: actuallyjenn
 slug: jenn-noinaj
-# See [URL] for a full list of profile photo options
-profile_photo: github
 ---

--- a/content/authors/jenn-wingerberg/_index.md
+++ b/content/authors/jenn-wingerberg/_index.md
@@ -2,14 +2,7 @@
 display_name: Jenn Wingerberg
 first_name: Jennifer
 last_name: Wingerberg
-# If you include an email address, it will be displayed on your profile page
-email: jennifer.wingerberg@cfpb.gov
-# Keep it under 50 words and only one paragraph
-bio: Jenn Wingerberg is a web analytics specialist at the Consumer Financial
-  Protection Bureau (CFPB).
 # e.g. U.S. General Services Administration
 agency_full_name: Consumer Financial Protection Bureau
-# Agency Acronym [e.g., GSA]
-agency: CFPB
 slug: jenn-wingerberg
 ---

--- a/content/authors/jennifer-dorsey/_index.md
+++ b/content/authors/jennifer-dorsey/_index.md
@@ -7,32 +7,17 @@ display_name: "Jennifer Dorsey"
 first_name: "Jennifer"
 last_name: "Dorsey"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jennifer-dorsey
 
-# if you include an email address, it will be displayed on your profile page
-email: "jennifer.dorsey@opm.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jennifer-gonzalez/_index.md
+++ b/content/authors/jennifer-gonzalez/_index.md
@@ -7,32 +7,17 @@ display_name: "Jennifer González"
 first_name: "Jennifer"
 last_name: "Gonzalez"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jennifer-gonzalez
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Jennifer González is a legal information analyst at the Law Library of Congress."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jennifer-hoover/_index.md
+++ b/content/authors/jennifer-hoover/_index.md
@@ -8,40 +8,19 @@ display_name: "Jennifer Hoover"
 first_name: "Jennifer"
 last_name: "Hoover"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Department of Homeland Security"
 
-# Agency Acronym [e.g., GSA]
-agency: "DHS"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "jlhoover123"
 
-# Profile Photo
-# See [URL] for a full list of profile photo options
-profile_photo: ""
 
-# [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/jennifer-kerber/_index.md
+++ b/content/authors/jennifer-kerber/_index.md
@@ -7,32 +7,17 @@ display_name: "Jennifer Kerber"
 first_name: "Jennifer"
 last_name: "Kerber"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jennifer-kerber
 
-# if you include an email address, it will be displayed on your profile page
-email: "jennifer.kerber@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jennifer-kim/_index.md
+++ b/content/authors/jennifer-kim/_index.md
@@ -8,26 +8,14 @@ display_name: "Jennifer Kim"
 first_name: "Jennifer "
 last_name: "Kim"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Jennifer Kim is an Assistant Division Chief for Content, Translation, Puerto Rico and Island Areas Operations at the U.S. Census Bureau. She has served as the chair of the Decennial Content Council, lead language expert for the Census Bureau’s National Advisory Committee Language Working Group, and a Census Bureau representative on the International Census Forum Content Working Group. She holds a Ph.D. in International Education Policy from the University of Maryland, M.S. in International and Intercultural Education from the University of Southern California, and B.A. in Linguistics and Spanish from the University of Michigan."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: https://www.census.gov/newsroom/bios/jennifer-kim.html
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Census Bureau"
 
-# Agency Acronym [e.g., GSA]
-agency: "USCB"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/jennifer-reeves/_index.md
+++ b/content/authors/jennifer-reeves/_index.md
@@ -7,32 +7,17 @@ display_name: "Jennifer Reeves"
 first_name: "Jennifer"
 last_name: "Reeves"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jennifer-reeves
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jennifer-shieh/_index.md
+++ b/content/authors/jennifer-shieh/_index.md
@@ -8,26 +8,14 @@ display_name: "Jennifer Shieh"
 first_name: "Jennifer"
 last_name: "Shieh"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "White House Office of Science and Technology Policy"
 
-# Agency Acronym [e.g., GSA]
-agency: "OSTP"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Washington D.C."
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/jennifer-strickland/_index.md
+++ b/content/authors/jennifer-strickland/_index.md
@@ -8,26 +8,14 @@ display_name: "Jennifer Strickland"
 first_name: "Jennifer"
 last_name: "Strickland"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "With more than 25 years of experience in a variety of mediums, Jennifer has led product teams and served in nearly every role in the product lifecycle. Prioritizing “Ohana”, Jennifer aims to ensure no one is excluded from products and services. She first heard of Ohana in Disney’s Lilo & Stitch, “Ohana means family. Family means no one gets left behind or forgotten.”"
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/jennifer-thibault/_index.md
+++ b/content/authors/jennifer-thibault/_index.md
@@ -7,32 +7,17 @@ display_name: "Jennifer Thibault"
 first_name: "Jennifer"
 last_name: "Thibault"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jennifer-thibault
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jenny-johnson/_index.md
+++ b/content/authors/jenny-johnson/_index.md
@@ -7,32 +7,17 @@ display_name: "Jennifer Johnson"
 first_name: "Jennifer"
 last_name: "Johnson"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jenny-johnson
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Jennifer Johnson is a senior at Columbia College of South Carolina, soon to be receiving degrees in history and music. She is working on mobile with the Digital Government Division this Fall."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jeremiah-azurin/_index.md
+++ b/content/authors/jeremiah-azurin/_index.md
@@ -8,26 +8,14 @@ display_name: "Jeremiah Azurin"
 first_name: "Jeremiah"
 last_name: "Azurin"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/jeremy-glenn/_index.md
+++ b/content/authors/jeremy-glenn/_index.md
@@ -2,18 +2,7 @@
 display_name: Jeremy Glenn
 first_name: Jeremy
 last_name: Glenn
-# If you include an email address, it will be displayed on your profile page
-email: jeremy.glenn@nist.gov
-# Keep it under 50 words and only one paragraph
-bio: "Mr. Glenn is a Presidential Management Fellow serving as a prize and
-  challenge specialist for the Public Safety Communications Research Division
-  (PSCR) at NIST. In this role he designs and manages all aspects of prize
-  competitions to advance PSCR’s mission to further communications technologies
-  for first responders. Mr. Glenn is a licensed attorney and U.S. Marine Corps
-  veteran. "
 # e.g. U.S. General Services Administration
 agency_full_name: National Institute of Standards and Technology
-# Agency Acronym [e.g., GSA]
-agency: NIST
 slug: jeremy-glenn
 ---

--- a/content/authors/jeremyzilar/_index.md
+++ b/content/authors/jeremyzilar/_index.md
@@ -7,32 +7,17 @@ display_name: "Jeremy Zilar"
 first_name: "Jeremy"
 last_name: "Zilar"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jeremyzilar
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "As part of his four-year term with [18F](https://www.18f.gov), Jeremy served in GSA's Technology Transformation Service as Digital.gov's director from 2017 to 2020."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "New York City"
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: "jeremyzilar"
 # github-photo — requires a github ID
 profile_source: "github"
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: "jeremyzilar"
-facebook: "jeremy.zilar"
-linkedin: "jeremy.zilar"
-YouTube: "jeremy.zilar"
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jerry-sheehan/_index.md
+++ b/content/authors/jerry-sheehan/_index.md
@@ -7,32 +7,17 @@ display_name: "Jerry Sheehan"
 first_name: "Jerry"
 last_name: "Sheehan"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jerry-sheehan
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Jerry Sheehan is Assistant Director for Scientific Data &amp; Information at the White House Office of Science and Technology Policy."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jerry-sheehan/_index.md
+++ b/content/authors/jerry-sheehan/_index.md
@@ -7,6 +7,7 @@ display_name: "Jerry Sheehan"
 first_name: "Jerry"
 last_name: "Sheehan"
 
+expirydate: 2025-02-18
 
 # slug — the specific user-id for an author.
 slug: jerry-sheehan

--- a/content/authors/jesrael-lopez/_index.md
+++ b/content/authors/jesrael-lopez/_index.md
@@ -2,18 +2,7 @@
 display_name: Jesrael Lopez
 first_name: Jesrael
 last_name: Lopez
-# List your pronoun(s) if you want them displayed alongside your name.
-# If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: He/him
-# Keep it under 50 words and only one paragraph
-bio: "Jesrael is a Program Manager as well as one of the Diversity, Equity,
-  Inclusion and Accessibility (DEIA) leaders at Treasury's Bureau of the Fiscal
-  Service, supporting financial management transformation initiatives that
-  emphasize the use of new and emerging capabilities.  "
-# e.g. U.S. General Services Administration
 agency_full_name: Department of the Treasury; Bureau of the Fiscal Service,
   Office of Financial Innovation and Transformation
-# Agency Acronym [e.g., GSA]
-agency: USDT
 slug: jesrael-lopez
 ---

--- a/content/authors/jesse-taggert/_index.md
+++ b/content/authors/jesse-taggert/_index.md
@@ -7,32 +7,17 @@ display_name: "Jesse Taggert"
 first_name: "Jesse"
 last_name: "Taggert"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jesse-taggert
 
-# if you include an email address, it will be displayed on your profile page
-email: "jesse.taggert@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jesse-taggert/_index.md
+++ b/content/authors/jesse-taggert/_index.md
@@ -7,6 +7,7 @@ display_name: "Jesse Taggert"
 first_name: "Jesse"
 last_name: "Taggert"
 
+expirydate: 2025-02-18
 
 # slug — the specific user-id for an author.
 slug: jesse-taggert

--- a/content/authors/jessica-brown/_index.md
+++ b/content/authors/jessica-brown/_index.md
@@ -8,26 +8,14 @@ display_name: "Jessica Brown"
 first_name: "Jessica"
 last_name: "Brown"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "Internal Revenue Service"
 
-# Agency Acronym [e.g., GSA]
-agency: "IRS"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 

--- a/content/authors/jessica-dunbar/_index.md
+++ b/content/authors/jessica-dunbar/_index.md
@@ -2,29 +2,8 @@
 display_name: Jessica Dunbar
 first_name: Jessica
 last_name: Dunbar
-# List your pronoun(s) if you want them displayed alongside your name.
-# If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: she, her
-
-# If you include an email address, it will be displayed on your profile page
-email: 
-
-# Keep it under 50 words and only one paragraph
-bio: 
-
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. Army
-# Agency Acronym [e.g., GSA]
-agency: Army
-
-# [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
-# Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
-# Learn more about getting a Github account at [URL]
 github: jessicadunbar
-
 slug: jessica-dunbar
-
-# See [URL] for a full list of profile photo options
-profile_photo: github
-
 ---

--- a/content/authors/jessica-hawkins/_index.md
+++ b/content/authors/jessica-hawkins/_index.md
@@ -3,13 +3,9 @@ display_name: Jessica Hawkins
 first_name: Jessica
 last_name: Hawkins
 # If you include an email address, it will be displayed on your profile page
-email: jessica.hawkins@gsa.gov
 # Keep it under 50 words and only one paragraph
-bio: 
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
 slug: jessica-hawkins
 
 ---

--- a/content/authors/jessica-marine/_index.md
+++ b/content/authors/jessica-marine/_index.md
@@ -2,18 +2,10 @@
 display_name: Jessica Marine
 first_name: Jessica
 last_name: Marine
-# List your pronoun(s) if you want them displayed alongside your name.
-# If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: She, her
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
-# [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
 # Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
 # Learn more about getting a Github account at [URL]
 github: JessicaMarine1
 slug: jessica-marine
-# See [URL] for a full list of profile photo options
-profile_photo: github
 ---

--- a/content/authors/jessica-milcetich/_index.md
+++ b/content/authors/jessica-milcetich/_index.md
@@ -7,32 +7,17 @@ display_name: "Jessica Milcetich"
 first_name: "Jessica"
 last_name: "Milcetich"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jessica-milcetich
 
-# if you include an email address, it will be displayed on your profile page
-email: "jessica.milcetich@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: "Jessica Milcetich is a digital media strategist on the USA.gov Outreach Team."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jessica-milcetich/_index.md
+++ b/content/authors/jessica-milcetich/_index.md
@@ -7,6 +7,7 @@ display_name: "Jessica Milcetich"
 first_name: "Jessica"
 last_name: "Milcetich"
 
+expirydate: 2025-02-18
 
 # slug — the specific user-id for an author.
 slug: jessica-milcetich

--- a/content/authors/jessica-orquina/_index.md
+++ b/content/authors/jessica-orquina/_index.md
@@ -7,32 +7,17 @@ display_name: "Jessica Orquina"
 first_name: "Jessica"
 last_name: "Orquina"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jessica-orquina
 
-# if you include an email address, it will be displayed on your profile page
-email: "orquina.jessica@epa.gov"
 
-# Bio — keep it under 50 words
-bio: "Jessica Orquina is the Social Media Lead, Office of Web Communications at the Environmental Protection Agency (EPA)."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jessica-skretch/_index.md
+++ b/content/authors/jessica-skretch/_index.md
@@ -7,32 +7,17 @@ display_name: "Jessica Skretch"
 first_name: "Jessica"
 last_name: "Skretch"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jessica-skretch
 
-# if you include an email address, it will be displayed on your profile page
-email: "Jessica.L.Skretch@frb.gov"
 
-# Bio — keep it under 50 words
-bio: "Jessica Skretch is a UX and Visual Designer at the Federal Reserve Board. Jess works on a design and development team creating tools for Economists. Previously, she worked at the Federal Trade Commission (FTC) designing in support of consumer education goals. At the FTC, Jess led design and usability for IdentityTheft.gov. Jess is a strong visual designer that loves learning about users and designing to solve problems."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jessie-buerlein/_index.md
+++ b/content/authors/jessie-buerlein/_index.md
@@ -8,26 +8,14 @@ display_name: "Jessie Buerlein"
 first_name: "Jessie"
 last_name: "Buerlein"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Jessie Buerlein is a senior public health analyst and prize lead for the Maternal and Child Health Bureau, Health Resources and Services Administration, Department of Health and Human Services"
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "Department of Health and Human Services"
 
-# Agency Acronym [e.g., GSA]
-agency: "HHS"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/jessyka-castillo/_index.md
+++ b/content/authors/jessyka-castillo/_index.md
@@ -8,26 +8,14 @@ display_name: "Jessyka Castillo"
 first_name: "Jessyka"
 last_name: "Castillo"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: jessyka.castillo@gsa.gov
 
-# Bio — keep it under 50 words
-bio: "Jessyka Castillo currently leads Agency Partnerships for Cloud.gov. She is responsible for the relationship management of existing and prospective Cloud.gov partners."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Washington, DC"
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/jez-humble/_index.md
+++ b/content/authors/jez-humble/_index.md
@@ -8,26 +8,14 @@ display_name: "Jez Humble"
 first_name: "Jez "
 last_name: "Humble"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Jez Humble is co-author of the Shingo Award-winning Accelerate, The DevOps Handbook, Lean Enterprise, and the Jolt Award-winning Continuous Delivery. He has spent his career tinkering with code, infrastructure, and product development in companies of varying sizes across three continents, including work for the U.S. federal government at [18F](https://www.18f.gov). Jez works as a developer advocate at Google and teaches at UC Berkeley."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/jherman/_index.md
+++ b/content/authors/jherman/_index.md
@@ -7,32 +7,17 @@ display_name: "Justin Herman"
 first_name: "Justin"
 last_name: "Herman"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jherman
 
-# if you include an email address, it will be displayed on your profile page
-email: "justin.herman@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: "General Services Administration"
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Washington D.C."
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: "JustinHerman"
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: "JustinHerman"
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jia-gu/_index.md
+++ b/content/authors/jia-gu/_index.md
@@ -4,7 +4,5 @@ first_name: Jia
 last_name: Gu
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
 slug: jia-gu
 ---

--- a/content/authors/jill-james/_index.md
+++ b/content/authors/jill-james/_index.md
@@ -7,32 +7,17 @@ display_name: "Jill James"
 first_name: "Jill"
 last_name: "James"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jill-james
 
-# if you include an email address, it will be displayed on your profile page
-email: "jill.james@ed.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jillian-buttecali/_index.md
+++ b/content/authors/jillian-buttecali/_index.md
@@ -7,32 +7,17 @@ display_name: "Jillian Buttecali"
 first_name: "Jillian"
 last_name: "Buttecali"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jillian-buttecali
 
-# if you include an email address, it will be displayed on your profile page
-email: "jillian.g.buttecali@frb.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jim-costello/_index.md
+++ b/content/authors/jim-costello/_index.md
@@ -7,32 +7,17 @@ display_name: "Jim Costello"
 first_name: "Jim"
 last_name: "Costello"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jim-costello
 
-# if you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jim-reuter/_index.md
+++ b/content/authors/jim-reuter/_index.md
@@ -8,26 +8,14 @@ display_name: "Jim Reuter"
 first_name: "Jim"
 last_name: "Reuter"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "James L. Reuter was named NASA’s associate administrator for the Space Technology Mission Directorate (STMD) at NASA Headquarters in June 2019, a position in which he served in an acting capacity since February 2017. In this role, he provides executive leadership and management of the technology programs within STMD, with an annual investment value of $1.1 billion."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: https://www.nasa.gov/directorates/spacetech/about_us/bios/reuter_bio
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "National Aeronautics and Space Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "NASA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/jim-sheire/_index.md
+++ b/content/authors/jim-sheire/_index.md
@@ -7,32 +7,17 @@ display_name: "Jim Sheire"
 first_name: "Jim"
 last_name: "Sheire"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jim-sheire
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Jim is the Director of the FICAM Program."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jim-thompson/_index.md
+++ b/content/authors/jim-thompson/_index.md
@@ -8,26 +8,14 @@ display_name: "Jim Thompson"
 first_name: "Jim"
 last_name: "Thompson"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Department of State"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/jim-wilson/_index.md
+++ b/content/authors/jim-wilson/_index.md
@@ -7,32 +7,17 @@ display_name: "Jim Wilson"
 first_name: "Jim"
 last_name: "Wilson"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jim-wilson
 
-# if you include an email address, it will be displayed on your profile page
-email: "jim.wilson@nasa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jini-ryan/_index.md
+++ b/content/authors/jini-ryan/_index.md
@@ -7,32 +7,17 @@ display_name: "Jini Ryan"
 first_name: "Jini"
 last_name: "Ryan"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jini-ryan
 
-# if you include an email address, it will be displayed on your profile page
-email: "ryan.jini@epa.gov"
 
-# Bio — keep it under 50 words
-bio: "Jini Ryan is the Executive Video Producer in the Office of Multimedia at the U.S. Environmental Protection Agency (EPA)."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jini-ryan/_index.md
+++ b/content/authors/jini-ryan/_index.md
@@ -7,6 +7,7 @@ display_name: "Jini Ryan"
 first_name: "Jini"
 last_name: "Ryan"
 
+expirydate: 2025-02-18
 
 # slug — the specific user-id for an author.
 slug: jini-ryan

--- a/content/authors/jo-dwyer/_index.md
+++ b/content/authors/jo-dwyer/_index.md
@@ -8,26 +8,14 @@ display_name: "Jo Dwyer"
 first_name: "Jo"
 last_name: "Dwyer"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: "she/her"
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Jo’s career began at the American Museum of Natural History, where she wrote and taught lessons about anthropology, paleontology, and astronomy for students and teachers in K-12 classrooms. Since then, she’s continued her practice of listening, goal-setting, and planning ways to build stronger connections between people with something to say and the audiences who matter to them. Along the way she’s worked with museums, parks, nonprofits and governments, including the NYC Department of Parks & Recreation and TreeFolks."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/joanna-karpinski-widzer/_index.md
+++ b/content/authors/joanna-karpinski-widzer/_index.md
@@ -7,32 +7,17 @@ display_name: "Joanna Karpinski-Widzer"
 first_name: "Joanna"
 last_name: "Karpinski-Widzer"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: joanna-karpinski-widzer
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/joanna-karpinski-widzer/_index.md
+++ b/content/authors/joanna-karpinski-widzer/_index.md
@@ -7,6 +7,7 @@ display_name: "Joanna Karpinski-Widzer"
 first_name: "Joanna"
 last_name: "Karpinski-Widzer"
 
+expirydate: 2025-02-18
 
 # slug — the specific user-id for an author.
 slug: joanna-karpinski-widzer

--- a/content/authors/joanna-widzer/_index.md
+++ b/content/authors/joanna-widzer/_index.md
@@ -7,32 +7,17 @@ display_name: "Joanna Widzer"
 first_name: "Joanna"
 last_name: "Widzer"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: joanna-widzer
 
-# if you include an email address, it will be displayed on your profile page
-email: "joanna.widzer@nih.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/joanne-mcgovern/_index.md
+++ b/content/authors/joanne-mcgovern/_index.md
@@ -7,32 +7,17 @@ display_name: "Joanne McGovern"
 first_name: "Joanne"
 last_name: "McGovern"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: joanne-mcgovern
 
-# if you include an email address, it will be displayed on your profile page
-email: "joanne.mcgovern@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/joe-kimble/_index.md
+++ b/content/authors/joe-kimble/_index.md
@@ -8,26 +8,14 @@ display_name: "Joe Kimble"
 first_name: "Joe"
 last_name: "Kimble"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Professor Emeritus, Western Michigan University"
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/joel-minton/_index.md
+++ b/content/authors/joel-minton/_index.md
@@ -7,32 +7,17 @@ display_name: "Joel Minton"
 first_name: "Joel"
 last_name: "Minton"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: joel-minton
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Joel Minton, a member of the [U.S. Digital Service](https://www.usds.gov/), is working with GSA’s [Technology Transformation Service](https://www.gsa.gov/tts) as the director of [login.gov](https://www.login.gov/)."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/joel-minton/_index.md
+++ b/content/authors/joel-minton/_index.md
@@ -7,6 +7,7 @@ display_name: "Joel Minton"
 first_name: "Joel"
 last_name: "Minton"
 
+expirydate: 2025-02-18
 
 # slug — the specific user-id for an author.
 slug: joel-minton

--- a/content/authors/joel-virothaisakun/_index.md
+++ b/content/authors/joel-virothaisakun/_index.md
@@ -7,32 +7,17 @@ display_name: "Joël Virothaisakun"
 first_name: "Joël"
 last_name: "Virothaisakun"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: joel-virothaisakun
 
-# if you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Joël Virothaisakun is a graduate student in the Interaction Design and Information Architecture program at the University of Baltimore. He is interning with the DigitalGov User Experience Program at GSA this fall, and has published several games."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/joey-arora/_index.md
+++ b/content/authors/joey-arora/_index.md
@@ -8,26 +8,14 @@ display_name: "Joey Arora"
 first_name: "Joseph"
 last_name: "Arora"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Joseph “Joey” Arora is the co-founder of Air Force Ventures and AFWERX, where he directs ecosystem development for Air Force innovation. Joey strives to unite the country’s defense apparatus and startup space to reshape how the Air Force invests in small businesses and meet national security imperatives. He is an Air Force captain and has served as an airfield operations officer in the United States and Afghanistan. He has facilitated Startup Weekends across the country."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/john-donmoyer/_index.md
+++ b/content/authors/john-donmoyer/_index.md
@@ -7,32 +7,17 @@ display_name: "John Donmoyer"
 first_name: "John"
 last_name: "Donmoyer"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: john-donmoyer
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/john-grill/_index.md
+++ b/content/authors/john-grill/_index.md
@@ -7,32 +7,17 @@ display_name: "John Grill"
 first_name: "John"
 last_name: "Grill"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: john-grill
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "John Grill is the Director of the Strategic Initiatives Group at the National Institutes of Health’s Office of Human Resources."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/john-grill/_index.md
+++ b/content/authors/john-grill/_index.md
@@ -7,6 +7,7 @@ display_name: "John Grill"
 first_name: "John"
 last_name: "Grill"
 
+expirydate: 2025-02-18
 
 # slug — the specific user-id for an author.
 slug: john-grill

--- a/content/authors/john-hamilton/_index.md
+++ b/content/authors/john-hamilton/_index.md
@@ -8,26 +8,14 @@ display_name: "John Hamilton"
 first_name: "John"
 last_name: "Hamilton"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "John Hamilton is the Program Manager of Security Operations for FedRAMP. In this role, he works to ensure effective day-to-day operations of the FedRAMP PMO’s Readiness Assessment review process, public-facing website, customer mailbox, and secure repository. He also coordinates with FedRAMP’s Joint Authorization Board (JAB) and independent assessor accreditation body (A2LA) to ensure provisionally authorized Cloud Service Providers (CSPs) and Third Party Assessment Organizations (3PAOs) meet FedRAMP performance standards and guidelines."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: https://www.fedramp.gov/team/john_hamilton.html
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/john-mclaughlin/_index.md
+++ b/content/authors/john-mclaughlin/_index.md
@@ -8,26 +8,14 @@ display_name: "John McLaughlin"
 first_name: "John"
 last_name: "McLaughlin"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "John is the Education Program Manager in the Office of Education at the National Oceanic and Atmospheric Administration (NOAA)."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "National Oceanic and Atmospheric Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "NOAA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/john-paul/_index.md
+++ b/content/authors/john-paul/_index.md
@@ -7,32 +7,17 @@ display_name: "John Paul"
 first_name: "John"
 last_name: "Paul"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: john-paul
 
-# if you include an email address, it will be displayed on your profile page
-email: "john.paul@oc.usda.gov"
 
-# Bio — keep it under 50 words
-bio: "John Paul is an IT project manager for the United States Department of Agriculture (USDA). He has worked in information technology since 1999, and specializes in strategy, enterprise architecture and infrastructure."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/john-paul/_index.md
+++ b/content/authors/john-paul/_index.md
@@ -7,6 +7,7 @@ display_name: "John Paul"
 first_name: "John"
 last_name: "Paul"
 
+expirydate: 2025-02-18
 
 # slug — the specific user-id for an author.
 slug: john-paul

--- a/content/authors/john-pull/_index.md
+++ b/content/authors/john-pull/_index.md
@@ -8,26 +8,14 @@ display_name: "John Pull"
 first_name: "John"
 last_name: "Pull"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email:
 
-# Bio — keep it under 50 words
-bio: "John Pull’s library career spans 28 years but only two institutions: Harvard’s rare book collection (1992-1995) and the Library of Congress (1995-present). He has been a rare book curator, cataloger, web director, communications director, and is currently a UX specialist with LOC’s Design Directorate. From 1998 to 2013, in his spare time, he ran a successful digital arts consultancy in London.  He has lectured extensively in North America and Europe, and has worked with national libraries from six continents. He believes the roadblocks frequently presented by federal work can be launch pads."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url:
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "Library of Congress"
 
-# Agency Acronym [e.g., GSA]
-agency: "LOC"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,10 +25,5 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 # Make it better ♥
 ---

--- a/content/authors/john-sullivan/_index.md
+++ b/content/authors/john-sullivan/_index.md
@@ -7,47 +7,22 @@ display_name: "John Sullivan"
 first_name: "John"
 last_name: "Sullivan"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: john-sullivan
 
-# if you include an email address, it will be displayed on your profile page
-email: "john.j.sullivan@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: "Director of the Government-wide IT Accessibility Program at GSA."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Washington D.C."
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
 github: "rusty1992"
 
-# Profile Photo
-# See [URL] for a full list of profile photo options
-# github-photo — requires a github ID
-profile_source: ""
-
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/john-tindel/_index.md
+++ b/content/authors/john-tindel/_index.md
@@ -7,32 +7,17 @@ display_name: "John Tindel"
 first_name: "John"
 last_name: "Tindel"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: john-tindel
 
-# if you include an email address, it will be displayed on your profile page
-email: "john.tindel@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/john-whalen/_index.md
+++ b/content/authors/john-whalen/_index.md
@@ -8,26 +8,14 @@ display_name: "John Whalen"
 first_name: "John"
 last_name: "Whalen"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Founder and Lead of Psychological Innovations and Insights at Brilliant Experience"
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: https://www.brilliantexperience.com/about
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/john-yuda/_index.md
+++ b/content/authors/john-yuda/_index.md
@@ -7,32 +7,17 @@ display_name: "John Yuda"
 first_name: "John"
 last_name: "Yuda"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: john-yuda
 
-# if you include an email address, it will be displayed on your profile page
-email: "john.yuda@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jon-booth/_index.md
+++ b/content/authors/jon-booth/_index.md
@@ -7,32 +7,17 @@ display_name: "Jon Booth"
 first_name: "Jon"
 last_name: "Booth"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jon-booth
 
-# if you include an email address, it will be displayed on your profile page
-email: "jon.booth@cms.hhs.gov"
 
-# Bio — keep it under 50 words
-bio: "Centers for Medicare and Medicaid Services (CMS)"
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jon-raedeke/_index.md
+++ b/content/authors/jon-raedeke/_index.md
@@ -7,41 +7,11 @@ slug: jon-raedeke
 display_name: "Jon Raedeke "
 first_name: "Jon"
 last_name: "Raedeke "
-
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
-
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
-
-# Bio — keep it under 50 words
-bio: ""
-
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
-
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "National Institute of Standards and Technology"
 
-# Agency Acronym [e.g., GSA]
-agency: "NIST"
-
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
-
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "jonraedeke"
-
-# Profile Photo
-# See [URL] for a full list of profile photo options
-profile_photo: ""
-
-# [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 aliases:
  - john-raedeke

--- a/content/authors/jon-roberts/_index.md
+++ b/content/authors/jon-roberts/_index.md
@@ -2,24 +2,11 @@
 display_name: Jon Roberts
 first_name: Jon
 last_name: Roberts
-# If you include an email address, it will be displayed on your profile page
-email: jon.roberts@gsa.gov
-# Keep it under 50 words and only one paragraph
-bio: Jon Roberts lives and works in Salt Lake City, UT. He is a software
-  engineer at 18F and is serving along with Patrick as co-lead for the
-  Technology Transformation Service Diversity Guild. He is proud to be Deaf and
-  wants to make a positive impact within civic technology.
+
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: 18F
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: Salt Lake City, UT
-# [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
 # Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
 # Learn more about getting a Github account at [URL]
 github: Kewlguy781
 slug: jon-roberts
-# See [URL] for a full list of profile photo options
-profile_photo: github
 ---

--- a/content/authors/jona-decker/_index.md
+++ b/content/authors/jona-decker/_index.md
@@ -6,41 +6,18 @@ display_name: "Jona Decker"
 first_name: "Jona"
 last_name: "Decker"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: "she/her"
 
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: jona.decker@gsa.gov
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url:
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "10x | TTS"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Madison, WI"
 
 # A GitHub account will allow you to edit pages on DigitalGov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "jonadecker"
-
-# Profile Photo
-# See [URL] for a full list of profile photo options
-profile_photo: "github"
-
-# [e.g., Digital_Gov]
-twitter: "jonadecker"
-facebook: ""
-instagram: ""
-linkedin: "jonadecker"
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/jonathan-clinton/_index.md
+++ b/content/authors/jonathan-clinton/_index.md
@@ -2,16 +2,7 @@
 display_name: Jonathan Clinton
 first_name: Jonathan
 last_name: Clinton
-# If you include an email address, it will be displayed on your profile page
-email: jonathan.clinton@gsa.gov
-# Keep it under 50 words and only one paragraph
-bio: Jonathan Clinton is the acting deputy chief financial officer (CFO) and
-  leads the [Robotic Process Automation (RPA) Community of
-  Practice](https://digital.gov/communities/rpa/) at the U.S. General Services
-  Administration (GSA).
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
 slug: jonathan-clinton
 ---

--- a/content/authors/jonathan-finch/_index.md
+++ b/content/authors/jonathan-finch/_index.md
@@ -8,37 +8,8 @@ display_name: "Jonathan Finch"
 first_name: "Jonathan"
 last_name: "Finch"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: "he/him"
-
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
-
-# Bio — keep it under 50 words
-bio: 
-
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url:
-
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "Office of Management and Budget"
-
-# Agency Acronym [e.g., GSA]
-agency: "OMB"
-
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-
-# A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
-
-# Profile Photo
-# See [URL] for a full list of profile photo options
-
-# [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/jonathan-hart/_index.md
+++ b/content/authors/jonathan-hart/_index.md
@@ -2,12 +2,7 @@
 display_name: Jonathan Hart
 first_name: Jonathan
 last_name: Hart
-# Where can people learn more about your work?
-# Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: https://digitalcorps.gsa.gov/fellows/jonathan-hart/
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: U.S. Digital Corps
 slug: jonathan-hart
 ---

--- a/content/authors/jonathan-hooper/_index.md
+++ b/content/authors/jonathan-hooper/_index.md
@@ -7,32 +7,17 @@ display_name: "Jonathan Hooper"
 first_name: "Jonathan"
 last_name: "Hooper"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jonathan-hooper
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jonathan-prisby/_index.md
+++ b/content/authors/jonathan-prisby/_index.md
@@ -7,32 +7,17 @@ display_name: "Jonathan Prisby"
 first_name: "Jonathan"
 last_name: "Prisby"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jonathan-prisby
 
-# if you include an email address, it will be displayed on your profile page
-email: "jonathan.prisby@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jonathan-rubin/_index.md
+++ b/content/authors/jonathan-rubin/_index.md
@@ -7,32 +7,17 @@ display_name: "Jonathan Rubin"
 first_name: "Jonathan Rubin"
 last_name: "Jonathan Rubin"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jonathan-rubin
 
-# if you include an email address, it will be displayed on your profile page
-email: "jonathan.rubin@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jonathan-withington/_index.md
+++ b/content/authors/jonathan-withington/_index.md
@@ -8,26 +8,14 @@ display_name: "Jonathan Withington"
 first_name: "Jonathan"
 last_name: "Withington"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Chief, Plain Language Division, U.S. Citizenship and Immigration Services"
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Citizenship and Immigration Services"
 
-# Agency Acronym [e.g., GSA]
-agency: "USCIS"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/jordan-higgins/_index.md
+++ b/content/authors/jordan-higgins/_index.md
@@ -7,32 +7,17 @@ display_name: "Jordan Higgins"
 first_name: "Jordan"
 last_name: "Higgins"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jordan-higgins
 
-# if you include an email address, it will be displayed on your profile page
-email: "jordan.higgins@dodiis.mil"
 
-# Bio — keep it under 50 words
-bio: "Jordan Higgins is a Web and Social Media Manager in the Office of Corporate Communications at the Defense Intelligence Agency, and an active leader in the Federal SocialGov Community."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jordan-kasper/_index.md
+++ b/content/authors/jordan-kasper/_index.md
@@ -8,26 +8,14 @@ display_name: "Jordan Kasper"
 first_name: "Jordan"
 last_name: "Kasper"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Evangelist, developer, community organizer, open sourcer (and he’s been called worse). Currently improving tech at the US Digital Service."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url:
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Digital Service"
 
-# Agency Acronym [e.g., GSA]
-agency: "USDS"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "jakerella"
@@ -37,11 +25,6 @@ github: "jakerella"
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/joseph-castle/_index.md
+++ b/content/authors/joseph-castle/_index.md
@@ -8,26 +8,14 @@ display_name: "Joseph Castle"
 first_name: "Joseph"
 last_name: "Castle"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: "he/him"
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: joseph.castle@gsa.gov
 
-# Bio — keep it under 50 words
-bio: "Joseph Castle serves as the Product Owner & Front-End Engineer of Code.gov where he is responsible for maintaining the Code.gov website and overseeing federal agency implementation of the White House’s Federal Source Code Policy. Dr. Castle earned his PhD from Virginia Tech and his dissertation focused on open source software publication by the federal government. He served in the Obama Administration, is a U.S. Army veteran, and a Fed100 recipient."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: "https://www.linkedin.com/in/jrcastle/"
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Washington, D.C."
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "jcastle"
@@ -37,11 +25,6 @@ github: "jcastle"
 profile_photo: "github"
 
 # [e.g., Digital_Gov]
-twitter: "codedotgov"
-facebook: ""
-instagram: ""
-linkedin: "jrcastle"
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/joseph-galbo/_index.md
+++ b/content/authors/joseph-galbo/_index.md
@@ -4,7 +4,5 @@ first_name: Joseph
 last_name: Galbo
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. Consumer Product Safety Commission
-# Agency Acronym [e.g., GSA]
-agency: CPSC
 slug: joseph-galbo
 ---

--- a/content/authors/joshua-di-frances/_index.md
+++ b/content/authors/joshua-di-frances/_index.md
@@ -6,40 +6,23 @@ display_name: "Joshua Di Frances"
 first_name: "Joshua"
 last_name: "Di Frances"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: joshua.difrances@pif.gov
 
-# Bio — keep it under 50 words
-bio: "Joshua Di Frances is currently the Executive Director for the Presidential Innovation Fellowship program. Before joining the PIF program, he was on CVS Health’s Digital Strategy and Innovation team where he worked to accelerate innovation through healthcare and technology strategic partnerships and investments. Josh also worked at Brigham and Women’s Hospital—a Harvard-affiliated academic medical center—in their Innovation Hub where he helped Harvard Medical School professors to commercialize technology. Prior to Brigham, Josh served as Director of Operations for a biotechnology start-up that focused on novel gene editing technology."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: https://www.presidentialinnovationfellows.gov
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Washington, D.C."
 
 # A GitHub account will allow you to edit pages on DigitalGov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
 
 # Profile Photo
 # See [URL] for a full list of profile photo options
-profile_photo: "digit-white"
+profile_source: "digit-white"
 
 # [e.g., Digital_Gov]
-twitter: "InnovFellows"
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/joshua-hardy/_index.md
+++ b/content/authors/joshua-hardy/_index.md
@@ -2,12 +2,7 @@
 display_name: Joshua Hardy
 first_name: Joshua
 last_name: Hardy
-# List your pronoun(s) if you want them displayed alongside your name.
-# If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: He, him
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. Department of Veterans Affairs
-# Agency Acronym [e.g., GSA]
-agency: VA
 slug: joshua-hardy
 ---

--- a/content/authors/josie-anderson/_index.md
+++ b/content/authors/josie-anderson/_index.md
@@ -3,11 +3,8 @@ display_name: Josie Anderson
 first_name: Josie
 last_name: Anderson
 # Keep it under 50 words and only one paragraph
-bio: National Institute on Drug Abuse (NIDA) Digital Content Manager Josie Anderson splits her 20 years of communications experience between digital content management and multimedia creation. NIDA is part of the National Institutes of Health (NIH) at the U.S. Department of Health & Human Services (HHS).
 # e.g. U.S. General Services Administration
 agency_full_name: National Institute on Drug Abuse
-# Agency Acronym [e.g., GSA]
-agency: NIDA
 slug: josie-anderson
 
 ---

--- a/content/authors/jparcell/_index.md
+++ b/content/authors/jparcell/_index.md
@@ -7,32 +7,17 @@ display_name: "Jacob Parcell"
 first_name: "Jacob"
 last_name: "Parcell"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jparcell
 
-# if you include an email address, it will be displayed on your profile page
-email: "jacob.parcell@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Washington D.C."
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: "jpgsa"
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jsnee/_index.md
+++ b/content/authors/jsnee/_index.md
@@ -7,32 +7,17 @@ display_name: "Jacqueline Snee"
 first_name: "Jacqueline"
 last_name: "Snee"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jsnee
 
-# if you include an email address, it will be displayed on your profile page
-email: "jacqueline.snee@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/jthalls/_index.md
+++ b/content/authors/jthalls/_index.md
@@ -7,32 +7,17 @@ display_name: "Janelle Thalls"
 first_name: "Janelle"
 last_name: "Thalls"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: jthalls
 
-# if you include an email address, it will be displayed on your profile page
-email: "janelle.thalls@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/judith-snyderman/_index.md
+++ b/content/authors/judith-snyderman/_index.md
@@ -7,32 +7,17 @@ display_name: "Judith Snyderman"
 first_name: "Judith"
 last_name: "Snyderman"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: judith-snyderman
 
-# if you include an email address, it will be displayed on your profile page
-email: "SnydermanJE@state.gov"
 
-# Bio — keep it under 50 words
-bio: "Judith Snyderman is a multimedia analyst for government agencies."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/judy-romano/_index.md
+++ b/content/authors/judy-romano/_index.md
@@ -7,32 +7,17 @@ display_name: "Judy Romano"
 first_name: "Judy"
 last_name: "Romano"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: judy-romano
 
-# if you include an email address, it will be displayed on your profile page
-email: "judy.romano@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: "Judy Romano is a Video Producer and storyteller for Challenge.Gov. She came to GSA 7 years ago after producing news videos and anchoring for the Associated Press. She tweets @JudyARomano and blogs about her travels at TheWorldAtoZ.com. Her opinions are her own and do not reflect those of any Federal Agency."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/judy-suzuki/_index.md
+++ b/content/authors/judy-suzuki/_index.md
@@ -4,7 +4,5 @@ first_name: Judy
 last_name: Suzuki
 # e.g. U.S. General Services Administration
 agency_full_name: Environmental Protection Agency
-# Agency Acronym [e.g., GSA]
-agency: EPA
 slug: judy-suzuki
 ---

--- a/content/authors/julia-begley/_index.md
+++ b/content/authors/julia-begley/_index.md
@@ -2,15 +2,7 @@
 display_name: Julia Begley
 first_name: Julia
 last_name: Begley
-# If you include an email address, it will be displayed on your profile page
-email: Julia.Begley@cfpb.gov
-# Keep it under 50 words and only one paragraph
-bio: As a civic technologist, Julia is passionate about consumer finance,
-  innovative methodologies and technologies, digital government, citizen
-  engagement and excellence in government.
 # e.g. U.S. General Services Administration
 agency_full_name: Consumer Financial Protection Bureau
-# Agency Acronym [e.g., GSA]
-agency: CFPB
 slug: julia-begley
 ---

--- a/content/authors/julia-doherty/_index.md
+++ b/content/authors/julia-doherty/_index.md
@@ -7,32 +7,17 @@ display_name: "Julia Doherty"
 first_name: "Julia"
 last_name: "Doherty"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: julia-doherty
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Julia Doherty is the Senior Director, Agricultural and SPS Affairs in the Office of the U.S. Trade Representative."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/julia-jackson/_index.md
+++ b/content/authors/julia-jackson/_index.md
@@ -7,32 +7,17 @@ display_name: "Julia Jackson"
 first_name: "Julia"
 last_name: "Jackson"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: julia-jackson
 
-# if you include an email address, it will be displayed on your profile page
-email: "julia.jackson@nih.gov"
 
-# Bio — keep it under 50 words
-bio: "Julia Jackson is a Program Specialist and a member of the Digital Team at the Office of Communications and Public Liaison in the National Institute of Diabetes and Digestive and Kidney Diseases, part of the National Institutes of Health."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/julia-lindpaintner/_index.md
+++ b/content/authors/julia-lindpaintner/_index.md
@@ -8,26 +8,14 @@ display_name: "Julia Lindpaintner"
 first_name: "Julia"
 last_name: "Lindpaintner"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Project Lead and 18F UX Designer, GSA Technology Transformation Services"
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA TTS"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "juliaklindpaintner"
@@ -37,11 +25,6 @@ github: "juliaklindpaintner"
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/julia-solorzano/_index.md
+++ b/content/authors/julia-solorzano/_index.md
@@ -6,47 +6,21 @@ display_name: "Julia Solórzano"
 first_name: "Julia"
 last_name: "Solórzano"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: "she/her"
 
 # slug — the specific user-id for an author.
 slug: julia-solorzano
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Julia Solórzano is the Branch Chief of User Experience for Login.gov, where she leads a team of designers and developers to create secure and user-friendly identity solutions for federal agencies and the public. She has over twenty years of experience in design leadership, people management, user experience, web development, and open source projects."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
 github: "juliaelman"
-
-# Profile Photo
-# See [URL] for a full list of profile photo options
-# github-photo — requires a github ID
-profile_source: "github"
-
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/julia-winn/_index.md
+++ b/content/authors/julia-winn/_index.md
@@ -7,32 +7,17 @@ display_name: "Julia Winn"
 first_name: "Julia"
 last_name: "Winn"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: julia-winn
 
-# if you include an email address, it will be displayed on your profile page
-email: "julia.winn@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/julie-strothman/_index.md
+++ b/content/authors/julie-strothman/_index.md
@@ -8,26 +8,14 @@ display_name: "Julie Strothman"
 first_name: "Julie"
 last_name: "Strothman"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Julie Strothman is a user experience designer at 18F. Focusing on inclusive design, Julie has worked on apps to make affordable housing findable, to help agencies provide support to people experiencing homelessness, and to help citizens assess their community’s health through public health and environmental data."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "jstrothman"
@@ -37,11 +25,6 @@ github: "jstrothman"
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/julie-vastine/_index.md
+++ b/content/authors/julie-vastine/_index.md
@@ -8,26 +8,14 @@ display_name: "Julie Vastine"
 first_name: "Julie"
 last_name: "Vastine"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Julie Vastine is the director of the Alliance for Aquatic Resource Monitoring (ALLARM) at Dickinson College in Carlisle, Pennsylvania.  She is responsible for leadership of the ALLARM program and providing technical assistance to watershed communities interested in using science as a tool for change."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: https://www.dickinson.edu/info/20173/alliance_for_aquatic_resource_monitoring_allarm/2922/staff
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/justen-proctor/_index.md
+++ b/content/authors/justen-proctor/_index.md
@@ -4,7 +4,5 @@ first_name: Justen
 last_name: Proctor
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
 slug: justen-proctor
 ---

--- a/content/authors/justin-dopke/_index.md
+++ b/content/authors/justin-dopke/_index.md
@@ -7,32 +7,17 @@ display_name: "Justin Dopke"
 first_name: "Justin"
 last_name: "Dopke"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: justin-dopke
 
-# if you include an email address, it will be displayed on your profile page
-email: "Justin.Dopke@ssa.gov"
 
-# Bio — keep it under 50 words
-bio: "Justin Dopke is an IT Specialist with the Social Security Administration."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/justin-goldberger/_index.md
+++ b/content/authors/justin-goldberger/_index.md
@@ -7,32 +7,17 @@ display_name: "Justin Goldberger"
 first_name: "Justin"
 last_name: "Goldberger"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: justin-goldberger
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/justin-koufopoulos/_index.md
+++ b/content/authors/justin-koufopoulos/_index.md
@@ -7,47 +7,22 @@ display_name: "Justin Koufopoulos"
 first_name: "Justin Koufopoulos"
 last_name: "Justin Koufopoulos"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: justin-koufopoulos
 
-# if you include an email address, it will be displayed on your profile page
-email: "justin.koufopoulos@pif.gov"
 
-# Bio — keep it under 50 words
-bio: "Justin Koufopoulos is a two-term Presidential Innovation Fellow, with a background in product strategy, design research, and organizational consulting. He is currently working at the Department of Veterans Affairs on modernizing the VA’s clinical research policy and infrastructure to better meet the needs of Veterans."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: "https://www.pif.gov"
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "Presidential Innovation Fellows"
 
-# Agency Acronym [e.g., GSA]
-agency: "PIF"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Washington, DC"
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
 github: "jkoufopoulos"
 
-# Profile Photo
-# See [URL] for a full list of profile photo options
-# github-photo — requires a github ID
-profile_source: ""
-
-# Professional Social Media [e.g., Digital_Gov]
-twitter: "jkoufopoulos"
-facebook: ""
-linkedin: "jkoufopoulos"
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/news/2015/06/2015-06-12-digitalgov-citizen-services-summit-reflections-from-our-livestream-host-and-full-recording-now-available.md
+++ b/content/news/2015/06/2015-06-12-digitalgov-citizen-services-summit-reflections-from-our-livestream-host-and-full-recording-now-available.md
@@ -53,8 +53,6 @@ Federal agencies were also invited to showcase their programs, tools and innovat
 
 {{< tweet user="jakegab" id="601206392905674752" >}}
 
-{{< tweet user="lauraandotis" id="601432623186051072" >}}
-
 {{< tweet user="FedRAMP" id="601370769533308928" >}}
 
 The Summit's hashtag, [&#35;DigitalGov15](https://twitter.com/hashtag/DigitalGov15?src=hash), became a top trend across the United States on Twitter. Thank you to everyone who came in person to attend, tuned in online via livestream, tweeted throughout the event, put us in the top US trends, and helped to make &#35;DigitalGov15 such a success!


### PR DESCRIPTION
## Summary

Metadata removal for author with J.

> [!NOTE]
> Will be merged into #8216 and also includes author removal for authors with no published content.


## Solution

Removes all other `author` fields.

**Fields to Keep**

- display_name
- first_name
- last_name
- agency_full_name
- github (github username)
- profile_source (digit-light, digit-dark, blank)


## How To Test

1. Only fields listed above are displayed
2. Remove non-published authors

