### PR TITLE
Remove author landing page and metadata (authors M-O)

### DIFF
--- a/content/authors/ken-kato/_index.md
+++ b/content/authors/ken-kato/_index.md
@@ -2,8 +2,6 @@
 display_name: Ken Kato
 first_name: Ken
 last_name: Kato
-# Keep it under 50 words and only one paragraph
-  practitioner, and Co-Lead of the DevOps Community of Practice. "
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
 slug: ken-kato

--- a/content/authors/mackenzie-cummings/_index.md
+++ b/content/authors/mackenzie-cummings/_index.md
@@ -7,32 +7,17 @@ display_name: "Mackenzie Cummings"
 first_name: "Mackenzie"
 last_name: "Cummings"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: mackenzie-cummings
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Mackenzie Cummings works in the Health Resources and Services Administration Office of Communications."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/major-jeremy-f-thomas/_index.md
+++ b/content/authors/major-jeremy-f-thomas/_index.md
@@ -8,26 +8,14 @@ display_name: "Major Jeremy F. Thomas"
 first_name: "Major Jeremy F."
 last_name: "Thomas"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Major Jeremy F. Thomas is a native son of Florida and grew up in Daytona Beach. He is a 13-year veteran of the U. S. Marines and commissioned out of the U. S. Naval Academy. Major Thomas has applied his passion for information and data overseas and, most recently, as a technology consultant for the Marine Corps Chief Information Office. These days, you’ll most likely find him in the Defense Entrepreneurs Forum’s Slack workspace or contributing to knowledge products within the Naval Agility Cell (NavalX) out of Alexandria, VA."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/major-taylor-m-wilson/_index.md
+++ b/content/authors/major-taylor-m-wilson/_index.md
@@ -8,26 +8,14 @@ display_name: "Major Taylor M. Wilson"
 first_name: "Major Taylor"
 last_name: "Wilson"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Major Taylor M. Wilson is the Mission Systems Chief and Instructor Test Pilot, United States Air Force Test Pilot School, Edwards AFB, California. He directs the 150-hour academic and flying schedule for the $33 million US Air Force Test Pilot School Mission Systems curriculum. He is a dual-qualified fighter test pilot, leading $1 million weapon, structures, and functional test flights for unique $1.1 billion F-22A and F-16 test fleet. Prior to his current position, the major served as the acting Director of Operations and experimental test pilot for the 411th Flight Test Squadron as well as Program Manager of Air Force Materiel Command’s flight operations agile software development team."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Air Force"
 
-# Agency Acronym [e.g., GSA]
-agency: "USAF"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/malaika-carpenter/_index.md
+++ b/content/authors/malaika-carpenter/_index.md
@@ -8,40 +8,19 @@ display_name: "Malaika Carpenter"
 first_name: "Malaika"
 last_name: "Carpenter"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "Mtcarp"
 
-# Profile Photo
-# See [URL] for a full list of profile photo options
-profile_photo: ""
-
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/mara-goldberg/_index.md
+++ b/content/authors/mara-goldberg/_index.md
@@ -3,20 +3,12 @@ display_name: Mara Goldberg
 first_name: Mara
 last_name: Goldberg
 # If you include an email address, it will be displayed on your profile page
-email: mara.goldberg@gsa.gov
 # Keep it under 50 words and only one paragraph
-bio: Mara is a consultant who works with GSA’s Technology Transformation Services (TTS). As part of the Digital.gov team, Mara organizes events, supports Communities of Practice, and writes content for the Digital.gov website.
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: Washington, D.C.
-# [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
 # Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
 # Learn more about getting a Github account at [URL]
 github: mara-goldberg
 slug: mara-goldberg
 # See [URL] for a full list of profile photo options
-profile_photo: github
 ---

--- a/content/authors/marc-groman/_index.md
+++ b/content/authors/marc-groman/_index.md
@@ -7,32 +7,17 @@ display_name: "Marc Groman"
 first_name: "Marc"
 last_name: "Groman"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: marc-groman
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Marc Groman is the Senior Advisor for Privacy at the Office of Management and Budget."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/marc-kuchner/_index.md
+++ b/content/authors/marc-kuchner/_index.md
@@ -8,26 +8,14 @@ display_name: "Marc Kuchner"
 first_name: "Marc"
 last_name: "Kuchner"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: https://science.gsfc.nasa.gov/sed/bio/marc.j.kuchner
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "National Aeronautics and Space Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "NASA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/marco-segreto/_index.md
+++ b/content/authors/marco-segreto/_index.md
@@ -7,32 +7,17 @@ display_name: "Marco Segreto"
 first_name: "Marco"
 last_name: "Segreto"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: marco-segreto
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/margo-kabel/_index.md
+++ b/content/authors/margo-kabel/_index.md
@@ -8,26 +8,14 @@ display_name: "Margo Kabel"
 first_name: "Margo"
 last_name: "Kabel"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Margo Kabel, MS is a User Experience Analyst in the Veterans Health Administration (VHA).  She is the Pharmacy Engagement Lead in the Division of Human Factors Engineering, VHA. Her projects include evaluations of medical systems such as electronic health records, and web and mobile based products for both Clinical staff and Veterans."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Department of Veterans Affairs"
 
-# Agency Acronym [e.g., GSA]
-agency: "VA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/margot-johnson/_index.md
+++ b/content/authors/margot-johnson/_index.md
@@ -2,12 +2,7 @@
 display_name: Margot Johnson
 first_name: Margot
 last_name: Johnson
-# Where can people learn more about your work?
-# Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
 slug: margot-johnson
 ---

--- a/content/authors/margot-lawton-kern/_index.md
+++ b/content/authors/margot-lawton-kern/_index.md
@@ -7,32 +7,17 @@ display_name: "Margot Lawton Kern"
 first_name: "Margot Lawton"
 last_name: "Kern"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: margot-lawton-kern
 
-# if you include an email address, it will be displayed on your profile page
-email: "kernml@mail.nih.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/mari-nakano/_index.md
+++ b/content/authors/mari-nakano/_index.md
@@ -8,26 +8,14 @@ display_name: "Mari Nakano"
 first_name: "Joe"
 last_name: "Kimble"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Design Director, NYC Mayor's Office for Economic Opportunity"
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Brooklyn, NY"
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/maria-dayton/_index.md
+++ b/content/authors/maria-dayton/_index.md
@@ -6,43 +6,14 @@ display_name: "Maria Dayton"
 first_name: "Maria"
 last_name: "Dayton"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
-
 # user id — not easily changed
 slug: "maria-dayton"
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: maria.dayton@gsa.gov
-
-# Bio — keep it under 50 words
-bio: "Maria Dayton is a Presidential Innovation Fellow working on government wide customer experience at the U.S. General Services Administration and White House’s Office of Management and Budget. She formerly consulted with governments regularly on strategic communications and data policy."
-
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url:
-
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
-
-# Agency Acronym [e.g., GSA]
-agency: ""
-
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Washington, D.C."
+agency_full_name: "U.S. General Services Administration"
 
 # A GitHub account will allow you to edit pages on DigitalGov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "mariaday79"
-
-# Profile Photo
-# See [URL] for a full list of profile photo options
-profile_photo: "github"
-
-# [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/marietta-jelks/_index.md
+++ b/content/authors/marietta-jelks/_index.md
@@ -7,32 +7,17 @@ display_name: "Marietta Jelks"
 first_name: "Marietta"
 last_name: "Jelks"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: marietta-jelks
 
-# if you include an email address, it will be displayed on your profile page
-email: "marietta.jelks@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: "Marietta Jelks is the program manager of the Consumer Action Handbook and the Spanish version Guia del Consumidor in the Federal Citizen Information Center (FCIC). Besides managing this yearly guide on consumer issues and advice, she is also the consumer and money content manager for USA.gov and appears in the USA.gov web-series &#39;Ask Marietta&#39; where she answers questions from the public on consumer issues, scams, and frauds."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/marina-fox/_index.md
+++ b/content/authors/marina-fox/_index.md
@@ -7,47 +7,21 @@ display_name: "Marina Fox"
 first_name: "Marina"
 last_name: "Fox"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: marina-fox
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Marina Fox leads GSA&#39;s [DotGov Domain Services](https://home.dotgov.gov/) in the Office of Government-wide Policy (OGP). She has 20&#43; years of experience in data analysis, business intelligence and enterprise reporting, web performance analysis, advanced analytics, artificial intelligence (AI) and Big Data. Previously, Marina led a government-wide [Digital Analytics Program](https://digital.gov/dap/) (DAP) at GSA. Prior to becoming a public servant, Marina held various analytical and leadership roles at Deloitte, AOL, Booz Allen Hamilton, and Dow Jones. Her LinkedIn account is below."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Washington, DC"
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
 github: "smarina04"
-
-# Profile Photo
-# See [URL] for a full list of profile photo options
-# github-photo — requires a github ID
-profile_source: "github"
-
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: "marinavtuttle"
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/mario-damiani/_index.md
+++ b/content/authors/mario-damiani/_index.md
@@ -7,32 +7,17 @@ display_name: "Mario Damiani"
 first_name: "Mario"
 last_name: "Damiani"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: mario-damiani
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Office of Disability Employment Policy (ODEP) at the Department of Labor"
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/marion-royal/_index.md
+++ b/content/authors/marion-royal/_index.md
@@ -7,32 +7,17 @@ display_name: "Marion Royal"
 first_name: "Marion"
 last_name: "Royal"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: marion-royal
 
-# if you include an email address, it will be displayed on your profile page
-email: "marion.royal@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/marisa-hotchkiss/_index.md
+++ b/content/authors/marisa-hotchkiss/_index.md
@@ -8,26 +8,14 @@ display_name: "Marisa Hotchkiss"
 first_name: "Marisa"
 last_name: "Hotchkiss"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: " Marisa Hotchkiss is the Chief of the Content and Language Branch at the U.S. Census Bureau. The Content and Language Branch manages the content and design of 2020 Census questionnaires and associated non-questionnaire materials, and identifies ways to reduce language barriers for limited-English-speaking households. She holds bachelor's degrees in Economics and Spanish, a master's degree in Public Management, a master's certificate in Project Management, and the Project Management Professional (PMP) certification."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: https://www.census.gov/newsroom/bios/marisa_hotchkiss.html
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Census Bureau"
 
-# Agency Acronym [e.g., GSA]
-agency: "USCB"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/marisa-levine/_index.md
+++ b/content/authors/marisa-levine/_index.md
@@ -2,17 +2,7 @@
 display_name: Marisa Levine
 first_name: Marisa
 last_name: Levine
-# If you include an email address, it will be displayed on your profile page
-email: marisa.levine@gsa.gov
-# Keep it under 50 words and only one paragraph
-bio: Marisa Levine serves as the director of events and community partnerships
-  for Presidential Innovation Fellows at Technology Transformation Services.
-  Previously at Code for America and other non-profits with a brief stint in
-  startups, her background is in events, fundraising, culture, and
-  communications and her passion lies in connecting people and causes.
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
 slug: marisa-levine
 ---

--- a/content/authors/mark-anthony/_index.md
+++ b/content/authors/mark-anthony/_index.md
@@ -5,7 +5,7 @@
 
 display_name: "Mark Anthony Dingbaum"
 first_name: "Mark Anthony"
-last_name: "DIngbaum"
+last_name: "Dingbaum"
 
 
 # slug — the specific user-id for an author.

--- a/content/authors/mark-anthony/_index.md
+++ b/content/authors/mark-anthony/_index.md
@@ -7,32 +7,17 @@ display_name: "Mark Anthony Dingbaum"
 first_name: "Mark Anthony"
 last_name: "DIngbaum"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: mark-anthony
 
-# if you include an email address, it will be displayed on your profile page
-email: "markanthony.dingbaum@opm.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/mark-hopson/_index.md
+++ b/content/authors/mark-hopson/_index.md
@@ -8,40 +8,12 @@ display_name: "Mark Hopson"
 first_name: "Mark"
 last_name: "Hopson"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
-
-# Email — If you include an email address, it will be displayed on your profile page
-email: mark.hopson@gsa.gov
-
-# Bio — keep it under 50 words
-bio: "Mark Hopson is the Acquisition Alchemist at 18F housed within the Technology Transformation Services of the General Services Administration. He joined 18F as a contracting lead in January 2016 after working as a contracting officer at the U.S. Census Bureau for 5 years where he received numerous government and industry awards for innovative contracting methods. In his current role at 18F, he works on both internal procurements as well as consulting engagements for other agencies."
-
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
-
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
-
-# Agency Acronym [e.g., GSA]
-agency: "18F"
-
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Washington, DC"
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "mchopson"
 
-# Profile Photo
-# See [URL] for a full list of profile photo options
-profile_photo: "github"
-
-# [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/mark-m-mchale/_index.md
+++ b/content/authors/mark-m-mchale/_index.md
@@ -2,15 +2,7 @@
 display_name: "Mark M. McHale "
 first_name: Mark M.
 last_name: McHale
-# Keep it under 50 words and only one paragraph
-bio: Mark is a strategic communications executive and counselor with more than
-  25 years of experience working at public relations, public affairs, and
-  marketing agencies, as well as corporate communications. He currently serves
-  as the Associate Administrator for the Office of Strategic Communication at
-  the U.S. General Services Administration.
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
 slug: mark-m-mchale
 ---

--- a/content/authors/mark-przybocki/_index.md
+++ b/content/authors/mark-przybocki/_index.md
@@ -2,15 +2,7 @@
 display_name: Mark Przybocki
 first_name: Mark
 last_name: Przybocki
-# Keep it under 50 words and only one paragraph
-bio: "Mark Przybocki is the Acting Chief of the Information Access Division in
-  the National Institute of Standards and Technology (NIST). He leads NIST
-  collaborations with industry, academia, and other government agencies to
-  foster trust in emerging technologies that make sense of complex (human)
-  information. "
 # e.g. U.S. General Services Administration
 agency_full_name: National Institute of Standards and Technology
-# Agency Acronym [e.g., GSA]
-agency: NIST
 slug: mark-przybocki
 ---

--- a/content/authors/mark-trammell/_index.md
+++ b/content/authors/mark-trammell/_index.md
@@ -8,40 +8,19 @@ display_name: "Mark Trammell"
 first_name: "Mark"
 last_name: "Trammell"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Mark Trammell is a designer and researcher at 18F working most frequently with the U.S. Forest Service, Federal Acquisition Service, and Department of Veterans Affairs. His design work prior to 18F includes tenures with Sonos, Obama for America, Twitter, Digg, PayPal, the University of Florida, and the U.S. Navy. Trammell co-authored two books on Web design and standards and served as Designer-in-Residence for the VA."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "tram"
 
-# Profile Photo
-# See [URL] for a full list of profile photo options
-profile_photo: ""
-
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/mark-urban/_index.md
+++ b/content/authors/mark-urban/_index.md
@@ -7,32 +7,17 @@ display_name: "Mark Urban"
 first_name: "Mark"
 last_name: "Urban"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: mark-urban
 
-# if you include an email address, it will be displayed on your profile page
-email: "fka2@cdc.gov"
 
-# Bio — keep it under 50 words
-bio: "Mark Urban is a Section 508 Coordinator at the Centers for Disease Control (CDC)."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/maroya-faied/_index.md
+++ b/content/authors/maroya-faied/_index.md
@@ -2,27 +2,10 @@
 display_name: Maroya Faied
 first_name: Maroya
 last_name: Faied
-# List your pronoun(s) if you want them displayed alongside your name.
-# If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: She | Her
-# If you include an email address, it will be displayed on your profile page
-email: maroya.faied@onrr.gov
-# Keep it under 50 words and only one paragraph
-bio: Maroya Faied has a Master's degree in Minerals and Energy Economics. She
-  has worked for the Office of Natural Resources Revenue for over 10 years. She
-  currently manages a team responsible for the agency's public websites and is
-  committed to providing open and transparent federal data and information to
-  the public.
 # e.g. U.S. General Services Administration
 agency_full_name: Office of Natural Resources Revenue
-# Agency Acronym [e.g., GSA]
-agency: ONRR
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: Denver, Colorado
-# [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
 # Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
 # Learn more about getting a Github account at [URL]
 github: Maroyafaied
 slug: maroya-faied
-linkedin: maroya-faied-7511081a
 ---

--- a/content/authors/martha-dorris/_index.md
+++ b/content/authors/martha-dorris/_index.md
@@ -7,32 +7,17 @@ display_name: "Martha Dorris"
 first_name: "Martha"
 last_name: "Dorris"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: martha-dorris
 
-# if you include an email address, it will be displayed on your profile page
-email: "martha.dorris@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/mary-ann-monroe/_index.md
+++ b/content/authors/mary-ann-monroe/_index.md
@@ -7,32 +7,17 @@ display_name: "Mary Ann Monroe"
 first_name: "Mary Ann"
 last_name: "Monroe"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: mary-ann-monroe
 
-# if you include an email address, it will be displayed on your profile page
-email: "maryann.monroe@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: "Director of Customer Experience, Federal Citizen Information Center, Office of Citizen Services and Innovative Technologies, U.S. General Services Administration"
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/mary-davie/_index.md
+++ b/content/authors/mary-davie/_index.md
@@ -7,32 +7,17 @@ display_name: "Mary Davie"
 first_name: "Mary"
 last_name: "Davie"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: mary-davie
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Mary Davie is the Assistant Commissioner in the Office of Integrated Technology Services (ITS) at GSA."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/mary-king/_index.md
+++ b/content/authors/mary-king/_index.md
@@ -5,7 +5,7 @@
 
 display_name: "Mary King"
 first_name: "Mary"
-last_name: "Mary King"
+last_name: "King"
 
 
 # slug — the specific user-id for an author.

--- a/content/authors/mary-king/_index.md
+++ b/content/authors/mary-king/_index.md
@@ -4,7 +4,7 @@
 # https://digital.gov/authors/mary-king
 
 display_name: "Mary King"
-first_name: "Mary King"
+first_name: "Mary"
 last_name: "Mary King"
 
 

--- a/content/authors/mary-king/_index.md
+++ b/content/authors/mary-king/_index.md
@@ -7,32 +7,17 @@ display_name: "Mary King"
 first_name: "Mary King"
 last_name: "Mary King"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: mary-king
 
-# if you include an email address, it will be displayed on your profile page
-email: "mary.king@nara.gov"
 
-# Bio — keep it under 50 words
-bio: "Mary is a member of the Social Media Team in the Office of Innovation at the National Archives and Records Administration (NARA)."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/marybelle-guo/_index.md
+++ b/content/authors/marybelle-guo/_index.md
@@ -4,9 +4,6 @@ first_name: Marybelle
 last_name: Guo
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. Food and Drug Administration
-# Agency Acronym [e.g., GSA]
-agency: FDA
-# [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
 # Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
 # Learn more about getting a Github account at [URL]
 github: 

--- a/content/authors/marybeth-murphy/_index.md
+++ b/content/authors/marybeth-murphy/_index.md
@@ -7,32 +7,17 @@ display_name: "Marybeth Murphy"
 first_name: "Marybeth"
 last_name: "Murphy"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: marybeth-murphy
 
-# if you include an email address, it will be displayed on your profile page
-email: "marybeth.murphy@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/masha-danilova/_index.md
+++ b/content/authors/masha-danilova/_index.md
@@ -2,33 +2,10 @@
 display_name: Masha Danilova
 first_name: Masha
 last_name: Danilova
-# If you include an email address, it will be displayed on your profile page
-email: maria.danilova@pif.gov
-# Keep it under 50 words and only one paragraph
-bio: >-
-  Masha lives in Los Angeles, CA and is a White House [Presidential Innovation
-  Fellow](https://www.presidentialinnovationfellows.gov/) and co-founder of the
-  U.S. Digital Corps (USDC). She is an analytically-minded thinker and problem
-  solver who is passionate about mapping complexity. In the private sector,
-  Masha previously worked in algorithms and analytics, and product design and
-  development. She received her MBA at MIT and studied engineering at Purdue. 
-
-
-  [Follow the USDC on Twitter](https://twitter.com/USDigitalCorps).
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: PIF
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: Los Angeles, CA
-# [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
 # Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
 # Learn more about getting a Github account at [URL]
 github: mvdanilova
-# See [URL] for a full list of profile photo options
-profile_photo: github
-twitter: PIFgov
-facebook: PresidentialInnovationFellows
 slug: masha-danilova
-linkedin: mashavdanilova
 ---

--- a/content/authors/matt-dobson/_index.md
+++ b/content/authors/matt-dobson/_index.md
@@ -8,40 +8,17 @@ display_name: "Matt Dobson"
 first_name: "Matt"
 last_name: "Dobson"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Matt Dobson is a designer and researcher located in Louisville, KY. He is a member of 18F’s Human Services portfolio team and co-lead of the TTS Research Guild. Matt is also a local leader for Louisville’s IxDA chapter and an active participant in Code for Kentuckiana, the Louisville area Code for America brigade."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "matt-dobson"
-
-# Profile Photo
-# See [URL] for a full list of profile photo options
-profile_photo: ""
-
-# [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/matt-dozier/_index.md
+++ b/content/authors/matt-dozier/_index.md
@@ -8,26 +8,14 @@ display_name: "Matt Dozier"
 first_name: "Matt"
 last_name: "Dozier"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Matt Dozier is a Digital Content Specialist in the Office of Public Affairs. He covers renewable energy and climate change topics for Energy.gov, telling stories that explore the Energy Department’s work toward a sustainable energy future."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: https://www.energy.gov/contributors/matt-dozier
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Department of Energy"
 
-# Agency Acronym [e.g., GSA]
-agency: "DOE"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/matt-gieseke/_index.md
+++ b/content/authors/matt-gieseke/_index.md
@@ -7,32 +7,17 @@ display_name: "Matt Gieseke"
 first_name: "Matt"
 last_name: "Gieseke"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: matt-gieseke
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Matt Gieseke is a management analyst on the Strategic Initiatives Group, and heads up user engagement for the Federal HR Wiki."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/matt-goodrich/_index.md
+++ b/content/authors/matt-goodrich/_index.md
@@ -8,26 +8,14 @@ display_name: "Matt Goodrich"
 first_name: "Matt"
 last_name: "Goodrich"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: m
 
-# Bio — keep it under 50 words
-bio: "As former FedRAMP director, Matt managed the FedRAMP PMO and overall direction of the program. As a mandatory government-wide initiative, FedRAMP is one of the leading cloud computing security programs paving the way for cloud adoption and ensuring the security of cloud computing solutions used by the US government."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "MattGoodrich"
@@ -37,11 +25,6 @@ github: "MattGoodrich"
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 

--- a/content/authors/matt-harmon/_index.md
+++ b/content/authors/matt-harmon/_index.md
@@ -8,26 +8,14 @@ display_name: "Matt Harmon"
 first_name: "Matthew"
 last_name: "Harmon"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: matthew.harmon@hq.dhs.gov
 
-# Bio — keep it under 50 words
-bio: "Matt is the Director of Web Communications at the Department of Homeland Security. "
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Department of Homeland Security"
 
-# Agency Acronym [e.g., GSA]
-agency: "DHS"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/matt-petrowski/_index.md
+++ b/content/authors/matt-petrowski/_index.md
@@ -3,6 +3,5 @@ display_name: Matt Petrowski
 first_name: Matt
 last_name: Petrowski
 # Keep it under 50 words and only one paragraph
-bio: Matt Petrowski began his digital career in 2007 as an ad operations trafficker for a top online health publisher. After subsequent work as a digital strategist and eCommerce content manager, Matt joined the USPS digital brand marketing team in 2014 as the digital analytics program manager.
 slug: matt-petrowski
 ---

--- a/content/authors/matt-ross/_index.md
+++ b/content/authors/matt-ross/_index.md
@@ -8,26 +8,14 @@ display_name: "Matt Ross"
 first_name: "Matt"
 last_name: "Ross"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Matt Ross, is a member of the LinkedIn Marketing Solutions—Government, Advocacy, and Non Profits team. In the past dozen years in digital advertising, Matt has watched the industry change, grow, and adapt - through multiple vantage points of publisher, ad technology, and social platform. He believes at the core of marketing it’s important to remember that the goal of your organization’s message is to talk to your target audience as unique individuals so they feel understood and valued."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/matt-silber/_index.md
+++ b/content/authors/matt-silber/_index.md
@@ -2,17 +2,7 @@
 display_name: Matt Silber
 first_name: Matt
 last_name: Silber
-# If you include an email address, it will be displayed on your profile page
-email: matt.silber@gsa.gov
-# Keep it under 50 words and only one paragraph
-bio: Matt supports the [FedRAMP](https://www.fedramp.gov/) PMO through Communications, Outreach, and
-  Training in order to help FedRAMP stakeholders understand the FedRAMP
-  Authorization Process. Matt leads the analytics and website management support
-  to ensure that FedRAMP PMO is leveraging all available metrics tools and
-  resources.
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
 slug: matt-silber
 ---

--- a/content/authors/matthew-biggerstaff/_index.md
+++ b/content/authors/matthew-biggerstaff/_index.md
@@ -3,10 +3,7 @@ display_name: Dr. Matthew Biggerstaff
 first_name: Matthew
 last_name: Biggerstaff
 # Keep it under 50 words and only one paragraph
-bio: Dr. Matt Biggerstaff has been with the Centers for Disease Control and Prevention (CDC) since 2006, and an epidemiologist with its Influenza Division since 2009. In this role, he leads CDC influenza forecasting and modeling activities and works to understand and evaluate how forecasting and mathematical modeling can complement influenza surveillance and inform seasonal and pandemic influenza public health actions. He also serves as a Senior Advisor for Infectious Disease Modeling and Analytics to the CDC’s Deputy Director for Infectious Diseases, and has led and supported the CDC’s and the U.S. government’s interagency modeling and forecasting response to the COVID-19 pandemic since January 2020.
 # e.g. U.S. General Services Administration
 agency_full_name: Centers for Disease Control & Prevention
-# Agency Acronym [e.g., GSA]
-agency: CDC
 slug: matthew-biggerstaff
 ---

--- a/content/authors/matthew-bogdan/_index.md
+++ b/content/authors/matthew-bogdan/_index.md
@@ -2,17 +2,9 @@
 display_name: Matthew Bogdan
 first_name: Matthew
 last_name: Bogdan
-# List your pronoun(s) if you want them displayed alongside your name.
-# If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: he/him
 # Keep it under 50 words and only one paragraph
-bio: Matthew Bogdan is a Lead Engineer for Digital.gov on detail with the Innovation Portfolio of the [Technology Transformation Services](https://tts.gsa.gov) (TTS) Office of Solutions. Previously, he was with Defense Media Activity (DMA) working on development tasks on a Navy legacy web system. In Matthew’s spare time, he assists coaching children’s baseball, soccer and basketball teams.
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
 slug: matthew-bogdan
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: Baltimore, MD
 
 ---

--- a/content/authors/matthew-ford/_index.md
+++ b/content/authors/matthew-ford/_index.md
@@ -7,32 +7,17 @@ display_name: "Matthew Ford"
 first_name: "Matthew"
 last_name: "Ford"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: matthew-ford
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Matthew Ford is Customer Experience program lead at GSA&#39;s Office of Customer Experience."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/matthew-payne/_index.md
+++ b/content/authors/matthew-payne/_index.md
@@ -3,12 +3,8 @@ display_name: Matthew Payne
 first_name: Matthew
 last_name: Payne
 # If you include an email address, it will be displayed on your profile page
-email: mpayne@cns.gov
 # Keep it under 50 words and only one paragraph
-bio: Matthew Payne serves as marketing manager for AmeriCorps.
 # e.g. U.S. General Services Administration
 agency_full_name: The Corporation for National and Community Service, Americorps
-# Agency Acronym [e.g., GSA]
-agency: CNCS
 slug: matthew-payne
 ---

--- a/content/authors/matthew-turner/_index.md
+++ b/content/authors/matthew-turner/_index.md
@@ -8,26 +8,14 @@ display_name: "Matthew Turner"
 first_name: "Matthew"
 last_name: "Turner"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "Department of Interior"
 
-# Agency Acronym [e.g., GSA]
-agency: "DOI"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/maya-benari/_index.md
+++ b/content/authors/maya-benari/_index.md
@@ -7,32 +7,17 @@ display_name: "Maya Benari"
 first_name: "Maya"
 last_name: "Benari"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: maya-benari
 
-# if you include an email address, it will be displayed on your profile page
-email: "maya.ben-ari@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Los Angeles, CA"
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: "maya"
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/maya-rhodan/_index.md
+++ b/content/authors/maya-rhodan/_index.md
@@ -8,26 +8,14 @@ display_name: "Maya Rhodan"
 first_name: "Maya"
 last_name: "Rhodan"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Maya Rhodan is a former journalist who serves as the digital content producer for the National Museum of African American History’s Robert F. Smith Fund. Through her work at the Museum, she works to encourage storytelling and the sharing of family and community histories at the Smith Fund’s digitization and genealogy-focused events."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "National Museum of African American History and Culture"
 
-# Agency Acronym [e.g., GSA]
-agency: "NMAAHC"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/meenu-bhooshanan/_index.md
+++ b/content/authors/meenu-bhooshanan/_index.md
@@ -2,24 +2,7 @@
 display_name: Meenu Bhooshanan
 first_name: Meenu
 last_name: Bhooshanan
-# List your pronoun(s) if you want them displayed alongside your name.
-# If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: She/her
-# Keep it under 50 words and only one paragraph
-bio: Meenu Bhooshanan is a fellow in the [U.S. Digital
-  Corps](https://digitalcorps.gsa.gov/)' 2022 cohort.
-# Where can people learn more about your work?
-# Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: https://digitalcorps.gsa.gov/fellows/meenu-bhooshanan/
-# e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
-# [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
-# Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
-# Learn more about getting a Github account at [URL]
 github: meenubhooshanan
 slug: meenu-bhooshanan
-# See [URL] for a full list of profile photo options
-profile_photo: github
 ---

--- a/content/authors/megan-fella/_index.md
+++ b/content/authors/megan-fella/_index.md
@@ -7,32 +7,17 @@ display_name: "Megan Fella"
 first_name: "Megan"
 last_name: "Fella"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: megan-fella
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Megan Fella is a detailee from the Emerging Leaders Program."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/megan-miller/_index.md
+++ b/content/authors/megan-miller/_index.md
@@ -8,26 +8,14 @@ display_name: "Megan Miller"
 first_name: "Megan"
 last_name: "Miller"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Plain Language Writer/ Editor"
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "United States Patent and Trademark Office"
 
-# Agency Acronym [e.g., GSA]
-agency: "USPTO"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/megan-reed/_index.md
+++ b/content/authors/megan-reed/_index.md
@@ -3,11 +3,8 @@ display_name: Megan Reed
 first_name: Megan
 last_name: Reed
 # Keep it under 50 words and only one paragraph
-bio: "Megan Reed is the Operations Branch Chief within the Technology Transformation Services (TTS) Office of Acquisition, leading the organization's contracting staff. Her team champions the use of modern and agile acquisition methodologies, as well as applying service delivery and design principles to TTS' procurements."
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
 slug: megan-reed
 
 ---

--- a/content/authors/meghan-daly/_index.md
+++ b/content/authors/meghan-daly/_index.md
@@ -2,13 +2,7 @@
 display_name: Meghan Daly
 first_name: Meghan
 last_name: Daly
-# Keep it under 50 words and only one paragraph
-bio: Meghan Daly is a co-lead of the [Government Contact Center Council (G3C)
-  Community](https://digital.gov/communities/government-contact-center-council/). She works with various agencies as a director for the [Contact
-  Center Center of Excellence](https://coe.gsa.gov/coe/contact-center.html) at GSA.
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
 slug: meghan-daly
 ---

--- a/content/authors/meghan-lazier/_index.md
+++ b/content/authors/meghan-lazier/_index.md
@@ -7,32 +7,17 @@ display_name: "Meghan Lazier"
 first_name: "Meghan"
 last_name: "Lazier"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: meghan-lazier
 
-# if you include an email address, it will be displayed on your profile page
-email: "meghan.m.lazier@frb.gov"
 
-# Bio — keep it under 50 words
-bio: "Meghan Lazier is a design researcher and strategist who is currently creating apps and tools for economists at the Federal Reserve Board. Before joining the Board, Meghan was a designer at the Lab @ OPM. She is a graduate of the Design for Social Innovation MFA program at the School of Visual Arts in NYC and her work has been featured in the New York Times and Fast Company."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/melissa-goldstein/_index.md
+++ b/content/authors/melissa-goldstein/_index.md
@@ -7,32 +7,17 @@ display_name: "Melissa Goldstein"
 first_name: "Melissa"
 last_name: "Goldstein"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: melissa-goldstein
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Melissa Goldstein is Assistant Director for Bioethics and Privacy at the White House Office of Science and Technology Policy."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/melissa-heintz/_index.md
+++ b/content/authors/melissa-heintz/_index.md
@@ -7,32 +7,17 @@ display_name: "Melissa Heintz"
 first_name: "Melissa"
 last_name: "Heintz"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: melissa-heintz
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/melodee-mercer/_index.md
+++ b/content/authors/melodee-mercer/_index.md
@@ -7,32 +7,17 @@ display_name: "Melodee Mercer"
 first_name: "Melodee"
 last_name: "Mercer"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: melodee-mercer
 
-# if you include an email address, it will be displayed on your profile page
-email: "melodee.mercer@va.gov"
 
-# Bio — keep it under 50 words
-bio: "Melodee Mercer is the Public Affairs Officer for the VA Insurance Center. She can be reached at melodee.mercer@va.gov."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/melody-kramer/_index.md
+++ b/content/authors/melody-kramer/_index.md
@@ -7,32 +7,17 @@ display_name: "Melody Kramer"
 first_name: "Melody"
 last_name: "Kramer"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: melody-kramer
 
-# if you include an email address, it will be displayed on your profile page
-email: "melody.kramer@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/meredith-brown/_index.md
+++ b/content/authors/meredith-brown/_index.md
@@ -2,17 +2,8 @@
 display_name: Meredith Brown
 first_name: Meredith
 last_name: Brown
-# List your pronoun(s) if you want them displayed alongside your name.
-# If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: She, her
 # Keep it under 50 words and only one paragraph
-bio: Meredith is a [U.S Digital Corps](https://digitalcorps.gsa.gov/) fellow.
-# Where can people learn more about your work?
-# Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: https://digitalcorps.gsa.gov/fellows/meredith-brown/
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: U.S. Digital Corps
 slug: meredith-brown
 ---

--- a/content/authors/meredith-larson/_index.md
+++ b/content/authors/meredith-larson/_index.md
@@ -8,26 +8,14 @@ display_name: "Meredith Larson"
 first_name: "Meredith"
 last_name: "Larson"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "Department of Education"
 
-# Agency Acronym [e.g., GSA]
-agency: "Dept. of Ed"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/meredith-stewart/_index.md
+++ b/content/authors/meredith-stewart/_index.md
@@ -7,32 +7,17 @@ display_name: "Meredith Stewart"
 first_name: "Meredith"
 last_name: "Stewart"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: meredith-stewart
 
-# if you include an email address, it will be displayed on your profile page
-email: "Meredith.Stewart@nara.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/merrybelle-guo/_index.md
+++ b/content/authors/merrybelle-guo/_index.md
@@ -4,7 +4,5 @@ first_name: Merrybelle
 last_name: Guo
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. Food and Drug Administration
-# Agency Acronym [e.g., GSA]
-agency: FDA
 slug: merrybelle-guo
 ---

--- a/content/authors/michael-balint/_index.md
+++ b/content/authors/michael-balint/_index.md
@@ -7,32 +7,17 @@ display_name: "Michael Balint"
 first_name: "Michael"
 last_name: "Balint"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: michael-balint
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Michael Balint is a Presidential Innovation Fellow."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/michael-bloom/_index.md
+++ b/content/authors/michael-bloom/_index.md
@@ -7,32 +7,17 @@ display_name: "Michael Bloom"
 first_name: "Michael"
 last_name: "Bloom"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: michael-bloom
 
-# if you include an email address, it will be displayed on your profile page
-email: "michael.bloom@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/michael-harding/_index.md
+++ b/content/authors/michael-harding/_index.md
@@ -7,32 +7,17 @@ display_name: "Michael Harding"
 first_name: "Michael"
 last_name: "Harding"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: michael-harding
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Michael Harding is the CareerOneStop project manager in ETA."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/michael-horton/_index.md
+++ b/content/authors/michael-horton/_index.md
@@ -8,40 +8,19 @@ display_name: "Michael Horton"
 first_name: "Michael"
 last_name: "Horton"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: michael.horton@gsa.gov
 
-# Bio — keep it under 50 words
-bio: "Michael Horton is a Senior Information and Communication Technology (ICT) Accessibility Specialist in the General Services Administration's Office of Government-wide Policy (OGP), which has a mandate to provide technical assistance to agencies in implementing the requirements of Section 508 of the Rehabilitation Act."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "michaelhortongsa"
 
-# Profile Photo
-# See [URL] for a full list of profile photo options
-profile_photo: "github"
-
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Redirects: enter the path of the URL that you want redirected to this page
 aliases:

--- a/content/authors/michael-kelty/_index.md
+++ b/content/authors/michael-kelty/_index.md
@@ -4,14 +4,9 @@ first_name: Michael
 last_name: Kelty
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
-# [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
 # Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
 # Learn more about getting a Github account at [URL]
 github: GeneralSyntaxAnomaly
-# See [URL] for a full list of profile photo options
-profile_photo: github
 slug: michael-kelty
 
 ---

--- a/content/authors/michael-marin/_index.md
+++ b/content/authors/michael-marin/_index.md
@@ -4,14 +4,9 @@ first_name: Michael
 last_name: Marin
 # e.g. U.S. General Services Administration
 agency_full_name: National Aeronautics and Space Administration
-# Agency Acronym [e.g., GSA]
-agency: NASA
-# [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
 # Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
 # Learn more about getting a Github account at [URL]
 github: Michael-10101
 slug: michael-marin
-# See [URL] for a full list of profile photo options
-profile_photo: github
 
 ---

--- a/content/authors/michael-mule/_index.md
+++ b/content/authors/michael-mule/_index.md
@@ -8,26 +8,14 @@ display_name: "Michael Mulé"
 first_name: "Michael"
 last_name: "Mul&eacute;"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email:
 
-# Bio — keep it under 50 words
-bio: "Michael Mulé is an Attorney-Advisor in the Federal Coordination and Compliance Section of the Civil Rights Division at the U.S. Department of Justice. He conducts language access investigations, provides language access training and technical assistance, and administers LEP.gov."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url:
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Department of Justice"
 
-# Agency Acronym [e.g., GSA]
-agency: "DOJ"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/michael-niedzwiecki/_index.md
+++ b/content/authors/michael-niedzwiecki/_index.md
@@ -7,32 +7,17 @@ display_name: "Michael Niedzwiecki"
 first_name: "Michael"
 last_name: "Niedzwiecki"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: michael-niedzwiecki
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/michael-pulsifer/_index.md
+++ b/content/authors/michael-pulsifer/_index.md
@@ -7,32 +7,17 @@ display_name: "Michael Pulsifer"
 first_name: "Michael"
 last_name: "Pulsifer"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: michael-pulsifer
 
-# if you include an email address, it will be displayed on your profile page
-email: "pulsifer.michael@dol.gov"
 
-# Bio — keep it under 50 words
-bio: "U.S. Department of Labor"
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/michael-torres/_index.md
+++ b/content/authors/michael-torres/_index.md
@@ -7,32 +7,17 @@ display_name: "Michael Torres"
 first_name: "Michael"
 last_name: "Torres"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: michael-torres
 
-# if you include an email address, it will be displayed on your profile page
-email: "michael.torres@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/michelle-chronister/_index.md
+++ b/content/authors/michelle-chronister/_index.md
@@ -7,32 +7,17 @@ display_name: "Michelle Chronister"
 first_name: "Michelle"
 last_name: "Chronister"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: michelle-chronister
 
-# if you include an email address, it will be displayed on your profile page
-email: "michelle.chronister@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: "Michelle Chronister is the User Experience Team Lead for USA.gov at the U.S. General Services Administration. Prior to this position, she managed web content, search, and social media for USA.gov. Michelle has a BA in anthropology and a MS in library and information science. She is a former Presidential Management Fellow."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/michelle-mcnellis/_index.md
+++ b/content/authors/michelle-mcnellis/_index.md
@@ -8,26 +8,14 @@ display_name: "Michelle McNellis"
 first_name: "Michelle"
 last_name: "McNellis"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: michelle.mcnellis@gsa.gov
 
-# Bio — keep it under 50 words
-bio: "As the Acquisition Lead focusing on contracting at the IT Modernization Centers of Excellence, Michelle developed the procurement strategies that support agency partners and their modernization efforts. Formerly a warranted Contracting Officer, Michelle has 10+ years of experience in the Federal Government and is responsible to ensure procurement packages are compliant with the Federal Acquisition Regulations but also innovative in their acquisition approach. Prior to joining CoE, Michelle was the Director of Acquisitions at the Office of Products and Programs, the CO at 18F Office of Acquisitions that awarded the first civilian agency bug bounty program, and spent time working as an acquisition subject matter expert at the Public Buildings Service in GSA and the U.S. Coast Guard."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "CoE"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "MichelleMcNellis"
@@ -37,11 +25,6 @@ github: "MichelleMcNellis"
 profile_photo: "github"
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: "michelle-mcnellis"
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/michelle-rago/_index.md
+++ b/content/authors/michelle-rago/_index.md
@@ -4,9 +4,6 @@ first_name: Michelle
 last_name: Rago
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
-# [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
 # Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
 # Learn more about getting a Github account at [URL]
 github: michelle-rago

--- a/content/authors/michelle-samplin-salgado/_index.md
+++ b/content/authors/michelle-samplin-salgado/_index.md
@@ -7,32 +7,17 @@ display_name: "Michelle Samplin-Salgado"
 first_name: "Michelle"
 last_name: "Samplin-Salgado"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: michelle-samplin-salgado
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/miguel-gomez/_index.md
+++ b/content/authors/miguel-gomez/_index.md
@@ -7,32 +7,17 @@ display_name: "Miguel Gomez"
 first_name: "Miguel"
 last_name: "Gomez"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: miguel-gomez
 
-# if you include an email address, it will be displayed on your profile page
-email: "Miguel.Gomez@hhs.gov"
 
-# Bio — keep it under 50 words
-bio: "Miguel Gomez is the Director of AIDS.gov, and Senior Communications Advisor, Office of HIV/AIDS and Infectious Disease Policy at the U.S. Department of Health and Human Services (HHS)."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/mike-bland/_index.md
+++ b/content/authors/mike-bland/_index.md
@@ -7,32 +7,17 @@ display_name: "Mike Bland"
 first_name: "Mike"
 last_name: "Bland"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: mike-bland
 
-# if you include an email address, it will be displayed on your profile page
-email: "michael.bland@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/mike-gintz/_index.md
+++ b/content/authors/mike-gintz/_index.md
@@ -8,26 +8,14 @@ display_name: "Mike Gintz"
 first_name: "Mike"
 last_name: "Gintz"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "sawtoothwave"
@@ -37,11 +25,6 @@ github: "sawtoothwave"
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/mike-hessling/_index.md
+++ b/content/authors/mike-hessling/_index.md
@@ -7,41 +7,8 @@ slug: mike-hessling
 display_name: "Mike Hessling"
 first_name: "Mike"
 last_name: "Hessling"
-
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
-
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
-
-# Bio — keep it under 50 words
-bio: ""
-
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
-
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "Environmental Protection Agency"
-
-# Agency Acronym [e.g., GSA]
-agency: "EPA"
-
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
-
-# A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "cherrypj"
-
-# Profile Photo
-# See [URL] for a full list of profile photo options
-profile_photo: ""
-
-# [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
-
 # Make it better ♥
 ---

--- a/content/authors/mike-johansson/_index.md
+++ b/content/authors/mike-johansson/_index.md
@@ -2,18 +2,6 @@
 display_name: Mike Johansson
 first_name: Mike
 last_name: Johansson
-# Keep it under 50 words and only one paragraph
-bio: Dr. Michael Johansson has been a biologist in the Centers for Disease
-  Control and Prevention (CDC) Division of Vector-Borne Diseases since 2005. He
-  leads modeling and forecasting activities to improve surveillance, prevention,
-  and control of arboviral diseases including chikungunya, dengue, yellow fever,
-  and Zika. He also serves as a Senior Advisor for Infectious Disease Modeling
-  and Analytics in the Office of the Deputy Director for Infectious Diseases,
-  and has led and supported CDC and interagency modeling and forecasting for the
-  COVID-19 response since January 2020.
-# e.g. U.S. General Services Administration
 agency_full_name: Centers for Disease Control & Prevention
-# Agency Acronym [e.g., GSA]
-agency: CDC
 slug: mike-johansson
 ---

--- a/content/authors/mike-kruger/_index.md
+++ b/content/authors/mike-kruger/_index.md
@@ -7,32 +7,17 @@ display_name: "Mike Kruger"
 first_name: "Mike"
 last_name: "Kruger"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: mike-kruger
 
-# if you include an email address, it will be displayed on your profile page
-email: "mkruger@doc.gov"
 
-# Bio — keep it under 50 words
-bio: "Department of Commerce"
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/mike-rucki/_index.md
+++ b/content/authors/mike-rucki/_index.md
@@ -7,32 +7,17 @@ display_name: "Mike Rucki"
 first_name: "Mike"
 last_name: "Rucki"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: mike-rucki
 
-# if you include an email address, it will be displayed on your profile page
-email: "Rucki.Michael@pbgc.gov"
 
-# Bio — keep it under 50 words
-bio: "Mike Rucki manages the Communications &amp; Web Services Division at the Pension Benefit Guaranty Corporation. He and his team handle PBGC’s .gov site, intranet, graphic design, and video."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/mike-stern/_index.md
+++ b/content/authors/mike-stern/_index.md
@@ -8,26 +8,14 @@ display_name: "Mike Stern"
 first_name: "Mike"
 last_name: "Stern"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "mike-stern"
@@ -37,11 +25,6 @@ github: "mike-stern"
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/mikelyn-meyers/_index.md
+++ b/content/authors/mikelyn-meyers/_index.md
@@ -8,26 +8,14 @@ display_name: "Mikelyn Meyers"
 first_name: "Mikelyn"
 last_name: "Meyers"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Mikelyn Meyers is a sociolinguist with more than 10 years of experience researching the design of linguistically- and culturally-appropriate translated survey materials. She works in the Language and Cross-Cultural Research Group in the Center for Behavioral Science Methods at the U.S. Census Bureau."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Census Bureau"
 
-# Agency Acronym [e.g., GSA]
-agency: "USCB"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/mina-hanna/_index.md
+++ b/content/authors/mina-hanna/_index.md
@@ -8,26 +8,14 @@ display_name: "Mina Hanna"
 first_name: "Mina"
 last_name: "Hanna"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Chair of the Institute of Electrical and Electronics Engineers’ (IEEE) Artificial Intelligence and Autonomous Systems Policy Committee (AI&ASPC)"
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/minette-wilson/_index.md
+++ b/content/authors/minette-wilson/_index.md
@@ -7,32 +7,17 @@ display_name: "Minette Wilson"
 first_name: "Minette"
 last_name: "Wilson"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: minette-wilson
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/miriam-vincent/_index.md
+++ b/content/authors/miriam-vincent/_index.md
@@ -2,12 +2,7 @@
 display_name: Miriam Vincent
 first_name: Miriam
 last_name: Vincent
-# Keep it under 50 words and only one paragraph
-bio: Miriam Vincent is a web manager at the Office of the Federal Register,
-  National Archives and Records Administration.
 # e.g. U.S. General Services Administration
 agency_full_name: National Archives and Records Administration
-# Agency Acronym [e.g., GSA]
-agency: NARA
 slug: miriam-vincent
 ---

--- a/content/authors/mitchell-henke/_index.md
+++ b/content/authors/mitchell-henke/_index.md
@@ -4,9 +4,6 @@ first_name: Mitchell
 last_name: Henke
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
-# [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
 # Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
 # Learn more about getting a Github account at [URL]
 github: mitchellhenke

--- a/content/authors/mobilegov-team/_index.md
+++ b/content/authors/mobilegov-team/_index.md
@@ -7,32 +7,17 @@ display_name: "MobileGov Team"
 first_name: "MobileGov"
 last_name: "Team"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: mobilegov-team
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/mollie-ruskin/_index.md
+++ b/content/authors/mollie-ruskin/_index.md
@@ -7,32 +7,17 @@ display_name: "Mollie Ruskin"
 first_name: "Mollie"
 last_name: "Ruskin"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: mollie-ruskin
 
-# if you include an email address, it will be displayed on your profile page
-email: "Mollie_C_Ruskin@omb.eop.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/molly-cain/_index.md
+++ b/content/authors/molly-cain/_index.md
@@ -8,26 +8,14 @@ display_name: "Molly Cain"
 first_name: "Molly"
 last_name: "Cain"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Department of Homeland Security"
 
-# Agency Acronym [e.g., GSA]
-agency: "DHS"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "Majanssen"
@@ -37,11 +25,6 @@ github: "Majanssen"
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/monte-desai/_index.md
+++ b/content/authors/monte-desai/_index.md
@@ -7,32 +7,17 @@ display_name: "Monte Desai"
 first_name: "Monte"
 last_name: "Desai"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: monte-desai
 
-# if you include an email address, it will be displayed on your profile page
-email: "monte.desai@cfpb.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/myehsha-boone/_index.md
+++ b/content/authors/myehsha-boone/_index.md
@@ -7,32 +7,17 @@ display_name: "Myehsha Boone"
 first_name: "Myehsha"
 last_name: "Boone"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: myehsha-boone
 
-# if you include an email address, it will be displayed on your profile page
-email: "myehsha.boone@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/nancy-kreidler/_index.md
+++ b/content/authors/nancy-kreidler/_index.md
@@ -8,26 +8,14 @@ display_name: "Nancy Kreidler"
 first_name: "Nancy Kreidler "
 last_name: "Kreidler"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email:
 
-# Bio — keep it under 50 words
-bio: "Nancy Kreidler was selected for the Senior Executive Service and assumed her duties as the Director of Cybersecurity and Information Assurance at the Headquarters, Department of the U.S. Army, CIO/G-6 in March 2019.  As the Cybersecurity and Information Assurance Director, she serves as the principal advisor to the CIO/G-6 and other Senior Army Leaders on the integration of all aspects of information technology (IT) and cybersecurity strategy within CIO/G-6. Ms. Kreidler is responsible for assisting in the development of strategy, policy, and guidance for the Army's ongoing cybersecurity and information assurance efforts."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url:
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Army"
 
-# Agency Acronym [e.g., GSA]
-agency: "USA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,10 +25,5 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 # Make it better ♥
 ---

--- a/content/authors/nancy-kreidler/_index.md
+++ b/content/authors/nancy-kreidler/_index.md
@@ -5,7 +5,7 @@
 # slug — the specific user-id for an author.
 slug: nancy-kreidler
 display_name: "Nancy Kreidler"
-first_name: "Nancy Kreidler "
+first_name: "Nancy"
 last_name: "Kreidler"
 
 

--- a/content/authors/nancy-merritt/_index.md
+++ b/content/authors/nancy-merritt/_index.md
@@ -7,32 +7,17 @@ display_name: "Nancy Merritt"
 first_name: "Nancy"
 last_name: "Merritt"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: nancy-merritt
 
-# if you include an email address, it will be displayed on your profile page
-email: "nancy.merritt@usdoj.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/natale-goriel/_index.md
+++ b/content/authors/natale-goriel/_index.md
@@ -8,26 +8,14 @@ display_name: "Natale Goriel"
 first_name: "Natale"
 last_name: "Goriel"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Online Media Coordinator, Natale Goriel, manages the U.S. Small Business Administration’s online outreach to small business owners and entrepreneurs. She has led SBA’s efforts to launch the agency’s social media program, manage SBA initiatives and reach new audiences in innovative ways. She holds a master’s degree in Communication, Culture, & Technology from Georgetown University and a bachelor’s degree from University of the Pacific."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Small Business Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "USBA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/natalie-buda-smith/_index.md
+++ b/content/authors/natalie-buda-smith/_index.md
@@ -2,12 +2,7 @@
 display_name: Natalie Buda Smith
 first_name: Natalie
 last_name: Buda Smith
-# List your pronoun(s) if you want them displayed alongside your name.
-# If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: she/her/ella
 # e.g. U.S. General Services Administration
 agency_full_name: Library of Congress
-# Agency Acronym [e.g., GSA]
-agency: LOC
 slug: natalie-buda-smith
 ---

--- a/content/authors/nathan-dietz/_index.md
+++ b/content/authors/nathan-dietz/_index.md
@@ -8,26 +8,14 @@ display_name: "Nathan Dietz"
 first_name: "Nathan"
 last_name: "Dietz"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/nathan-king/_index.md
+++ b/content/authors/nathan-king/_index.md
@@ -3,14 +3,10 @@ display_name: Nathan King
 first_name: Nathan
 last_name: King
 # Keep it under 50 words and only one paragraph
-bio: Digital Communications Program Manager, National Park Service, U.S. Department of the Interior.
 
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. Department of the Interior
-# Agency Acronym [e.g., GSA]
-agency: NPS
 
-# [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
 # Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
 # Learn more about getting a Github account at [URL]
 github: rangernathan

--- a/content/authors/nathan-smith/_index.md
+++ b/content/authors/nathan-smith/_index.md
@@ -7,32 +7,17 @@ display_name: "Nathan Smith"
 first_name: "Nathan"
 last_name: "Smith"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: nathan-smith
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/ndavidson/_index.md
+++ b/content/authors/ndavidson/_index.md
@@ -7,32 +7,17 @@ display_name: "Natalie Davidson"
 first_name: "Natalie"
 last_name: "Davidson"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: ndavidson
 
-# if you include an email address, it will be displayed on your profile page
-email: "natalie.davidson@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/nicholas-garlow/_index.md
+++ b/content/authors/nicholas-garlow/_index.md
@@ -7,32 +7,17 @@ display_name: "Nicholas Garlow"
 first_name: "Nicholas"
 last_name: "Garlow"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: nicholas-garlow
 
-# if you include an email address, it will be displayed on your profile page
-email: "nicholas.garlow@hhs.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/nicholas-skytland/_index.md
+++ b/content/authors/nicholas-skytland/_index.md
@@ -7,32 +7,17 @@ display_name: "Nicholas Skytland"
 first_name: "Nicholas"
 last_name: "Skytland"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: nicholas-skytland
 
-# if you include an email address, it will be displayed on your profile page
-email: "nicholas.g.skytland@nasa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/nick-heiner/_index.md
+++ b/content/authors/nick-heiner/_index.md
@@ -7,32 +7,17 @@ display_name: "Nick Heiner"
 first_name: "Nick"
 last_name: "Heiner"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: nick-heiner
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "Nick Heiner is a Software Engineer for the U.S. Digital Service (USDS)."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/nick-marden/_index.md
+++ b/content/authors/nick-marden/_index.md
@@ -7,32 +7,17 @@ display_name: "Nick Marden"
 first_name: "Nick"
 last_name: "Marden"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: nick-marden
 
-# if you include an email address, it will be displayed on your profile page
-email: "nick.marden@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/nick-ng/_index.md
+++ b/content/authors/nick-ng/_index.md
@@ -4,11 +4,6 @@ first_name: Nick
 last_name: Ng
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
-# [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
-# Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
-# Learn more about getting a Github account at [URL]
 github: nickttng
 slug: nick-ng
 ---

--- a/content/authors/nick-reese/_index.md
+++ b/content/authors/nick-reese/_index.md
@@ -3,10 +3,7 @@ display_name: Nick Reese
 first_name: Nick
 last_name: Reese
 # Keep it under 50 words and only one paragraph
-bio: Senior Policy Analyst, Infrastructure, Risk and Resilience Policy
 # e.g. U.S. General Services Administration
 agency_full_name: Department of Homeland Security – Office of Strategy, Policy, and Plans
-# Agency Acronym [e.g., GSA]
-agency: DHS, PLCY
 slug: nick-reese
 ---

--- a/content/authors/nick-sinai/_index.md
+++ b/content/authors/nick-sinai/_index.md
@@ -7,32 +7,17 @@ display_name: "Nick Sinai"
 first_name: "Nick"
 last_name: "Sinai"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: nick-sinai
 
-# if you include an email address, it will be displayed on your profile page
-email: "Nicholas_S_Sinai@ostp.eop.gov"
 
-# Bio — keep it under 50 words
-bio: "Nick Sinai is the U.S. Deputy CTO (Chief Technology Officer)."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/nico-papafil/_index.md
+++ b/content/authors/nico-papafil/_index.md
@@ -6,29 +6,17 @@ display_name: "Nico Papafil"
 first_name: "Nico"
 last_name: "Papafil"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: nico-papafil
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: nicholas.papafil@gsa.gov
 
-# Bio — keep it under 50 words
-bio: "Nico Papafil is the Director of 10x. Before assuming the director role, Nico supported the project and has held a variety of roles in GSA. When not working, Nico loves traveling and spending time with his wife and daughter."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url:
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Washington, D.C."
 
 # A GitHub account will allow you to edit pages on DigitalGov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "nicopapafil"
@@ -38,11 +26,6 @@ github: "nicopapafil"
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 

--- a/content/authors/nicolas-chaillan/_index.md
+++ b/content/authors/nicolas-chaillan/_index.md
@@ -8,26 +8,14 @@ display_name: "Nicolas Chaillan"
 first_name: "Nicolas"
 last_name: "Chaillan"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Mr. Nicolas Chaillan is the first Air Force Chief Software Officer (CSO), under Dr. William Roper, the Assistant Secretary of the Air Force for Acquisition, Technology and Logistics, Arlington, Virginia. He is also the co-lead for the DoD Enterprise DevSecOps Initiative with the DoD Chief Information Officer (CIO). Mr. Chaillan is responsible for enabling Air Force programs in the transition to Agile and DevSecOps to establish force-wide DevSecOps capabilities and best practices, including continuous Authority to Operate processes and faster, streamlined technology adoption."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: https://www.af.mil/About-Us/Biographies/Display/Article/1926281/nicolas-m-chaillan/
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Air Force"
 
-# Agency Acronym [e.g., GSA]
-agency: "USAF"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/nicolas-pjontek/_index.md
+++ b/content/authors/nicolas-pjontek/_index.md
@@ -5,7 +5,7 @@
 # slug — the specific user-id for an author.
 slug: nicolas-pjontek
 display_name: "Nicolas Pjontek"
-first_name: "Nicolas "
+first_name: "Nicolas"
 last_name: "Nicolas Pjontek"
 
 

--- a/content/authors/nicolas-pjontek/_index.md
+++ b/content/authors/nicolas-pjontek/_index.md
@@ -8,26 +8,14 @@ display_name: "Nicolas Pjontek"
 first_name: "Nicolas "
 last_name: "Nicolas Pjontek"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "Nicolas Pjontek is the Manager of the [Canada.ca](https://www.canada.ca/) Analytics team at Service Canada (Government of Canada)."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/nicole-fenton/_index.md
+++ b/content/authors/nicole-fenton/_index.md
@@ -7,32 +7,17 @@ display_name: "Nicole Fenton"
 first_name: "Nicole"
 last_name: "Fenton"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: nicole-fenton
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/nicole-williams/_index.md
+++ b/content/authors/nicole-williams/_index.md
@@ -8,26 +8,14 @@ display_name: "Nicole Williams"
 first_name: "Nicole"
 last_name: "Williams"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: nicole.williams@gsa.gov
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "GSA"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/nicole-wong/_index.md
+++ b/content/authors/nicole-wong/_index.md
@@ -7,32 +7,17 @@ display_name: "Nicole Wong"
 first_name: "Nicole"
 last_name: "Wong"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: nicole-wong
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/nikki-ramos/_index.md
+++ b/content/authors/nikki-ramos/_index.md
@@ -2,12 +2,7 @@
 display_name: Nikki Ramos
 first_name: Anjenica
 last_name: Ramos
-# Where can people learn more about your work?
-# Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: https://digitalcorps.gsa.gov/fellows/nikki-ramos/
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: U.S. Digital Corps
 slug: nikki-ramos
 ---

--- a/content/authors/nikki-zeichner/_index.md
+++ b/content/authors/nikki-zeichner/_index.md
@@ -8,40 +8,19 @@ display_name: "Nikki Zeichner"
 first_name: "Nikki"
 last_name: "Zeichner"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: "she/her"
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: "nicole.zeichner@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: "Nikki is a member of 18F's Product chapter."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: "https://github.com/18F/privacy-tools"
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: "18F"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "San Francisco, CA"
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "nikzei"
 
-# Profile Photo
-# See [URL] for a full list of profile photo options
-profile_photo: "github"
-
 # [e.g., Digital_Gov]
-twitter: "nikzei"
-facebook: ""
-instagram: ""
-linkedin: "nikki-zeichner-82689412"
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/nina-anusavice/_index.md
+++ b/content/authors/nina-anusavice/_index.md
@@ -2,18 +2,11 @@
 display_name: Nina Anusavice
 first_name: Nina
 last_name: Anusavice
-# Where can people learn more about your work?
-# Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: https://digitalcorps.gsa.gov/fellows/nina-anusavice/
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: U.S. Digital Corps
-# [e.g. 'jeremyzilar'] — A GitHub account will allow you to edit pages on Digital.gov.
 # Also, the image used in your GitHub account can be used to populate your digital.gov profile photo.
 # Learn more about getting a Github account at [URL]
 github: ninaranusavice
 slug: nina-anusavice
 # See [URL] for a full list of profile photo options
-profile_photo: github
 ---

--- a/content/authors/nina-bianchi/_index.md
+++ b/content/authors/nina-bianchi/_index.md
@@ -8,41 +8,13 @@ display_name: "Nina Bianchi"
 first_name: "Nina"
 last_name: "Bianchi"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: Nina.Bianchi@fda.hhs.gov
 
-# Bio — keep it under 50 words
-bio: "Nina Bianchi formerly served as the Director of Workforce Solutions at the [Centers of Excellence](https://coe.gsa.gov/) (CoE), building teams and creating a community of more effective problem-solvers to drive modern organizations where great people want to work. To foster a 21st-century organizational culture of creative problem-solving and innovation operations for the future of work, Bianchi builds partnerships across siloed business units to enable holistic digital transformation and leads strategic operational innovation to inspire and cross-train diverse teams."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url:
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Food and Drug Administration"
-
-# Agency Acronym [e.g., GSA]
-agency: "FDA"
-
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Washington, D.C."
-
-# A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "nbianchiPIF"
-
-# Profile Photo
-# See [URL] for a full list of profile photo options
-profile_photo: "github"
-
-# [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: "bianchininafuture"
-youtube: ""
-
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors
 

--- a/content/authors/nirmala-ramprasad/_index.md
+++ b/content/authors/nirmala-ramprasad/_index.md
@@ -7,32 +7,17 @@ display_name: "Nirmala Ramprasad"
 first_name: "Nirmala"
 last_name: "Ramprasad"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: nirmala-ramprasad
 
-# if you include an email address, it will be displayed on your profile page
-email: "Nirmala.Ramprasad@ssa.gov"
 
-# Bio — keep it under 50 words
-bio: "Nirmala Ramprasad currently serves as a senior advisor at Social Security Administration. In her present role she develops IT strategy, and provides guidance and recommendations on IT initiatives and emerging technology. She has a double Master’s degree and over 25 years in Information Technology.  She is experienced in several industry verticals including government,  telecommunications, pharmaceuticals, electrical power distribution, human resources and payroll. Her special interest is in using data analytics to derive business value and is a member of the government customer experience community of practice. All opinions are her own and do not reflect that of any Federal Agency."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/nist-mep/_index.md
+++ b/content/authors/nist-mep/_index.md
@@ -7,32 +7,17 @@ display_name: "NIST MEP"
 first_name: "NIST"
 last_name: "MEP"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: nist-mep
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "The National Institute of Standards and Technology’s Hollings Manufacturing Extension Partnership (MEP) works with small and mid-sized U.S. manufacturers to help them create and retain jobs, increase profits, and save time and money. As a program of the U.S. Department of Commerce, MEP offers its clients a wealth of unique and effective resources centered on five critical areas: technology acceleration, supplier development, sustainability, workforce and continuous improvement. [Read more&lt;a&gt;]"
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/nist/_index.md
+++ b/content/authors/nist/_index.md
@@ -7,32 +7,17 @@ display_name: "National Institute of Standards and Technology Team"
 first_name: "NIST"
 last_name: ""
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: nist
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/nkunin/_index.md
+++ b/content/authors/nkunin/_index.md
@@ -7,32 +7,17 @@ display_name: "Noah Kunin"
 first_name: "Noah"
 last_name: "Kunin"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: nkunin
 
-# if you include an email address, it will be displayed on your profile page
-email: "Noah.Kunin@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/noah-manger/_index.md
+++ b/content/authors/noah-manger/_index.md
@@ -7,32 +7,17 @@ display_name: "Noah Manger"
 first_name: "Noah"
 last_name: "Manger"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: noah-manger
 
-# if you include an email address, it will be displayed on your profile page
-email: "noah.manger@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/nora-dempsey/_index.md
+++ b/content/authors/nora-dempsey/_index.md
@@ -8,26 +8,14 @@ display_name: "Nora Dempsey"
 first_name: "Nora"
 last_name: "Dempsey"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: ""
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "U.S. Department of State"
 
-# Agency Acronym [e.g., GSA]
-agency: "DOS"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Bethesda, MD"
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: ""
@@ -37,11 +25,6 @@ github: ""
 profile_photo: ""
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: ""
-youtube: ""
 
 # Make it better ♥
 ---

--- a/content/authors/norah-maki/_index.md
+++ b/content/authors/norah-maki/_index.md
@@ -3,14 +3,8 @@ display_name: Norah Maki
 first_name: Norah
 last_name: Maki
 # If you include an email address, it will be displayed on your profile page
-email: norah.maki@gsa.gov
 # Keep it under 50 words and only one paragraph
-bio: Norah Maki is a design strategist at 18F.
 # e.g. U.S. General Services Administration
 agency_full_name: U.S. General Services Administration
-# Agency Acronym [e.g., GSA]
-agency: GSA
 slug: norah-maki
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: Kingston, NY
 ---

--- a/content/authors/nramprasad/_index.md
+++ b/content/authors/nramprasad/_index.md
@@ -7,32 +7,17 @@ display_name: "Nirmala Ramprasad"
 first_name: "Nirmala"
 last_name: "Ramprasad"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: nramprasad
 
-# if you include an email address, it will be displayed on your profile page
-email: "Nirmala.Ramprasad@ssa.gov"
 
-# Bio — keep it under 50 words
-bio: ""
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/office-educational-technology/_index.md
+++ b/content/authors/office-educational-technology/_index.md
@@ -7,32 +7,17 @@ display_name: "Office of Educational Technology"
 first_name: "Office of"
 last_name: "Educational Technology"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: office-educational-technology
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "The Office of Educational Technology is part of the U.S. Department of Education."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: "https://tech.ed.gov/"
 
 # Agency Full Name [e.g. U.S. General Services Administration]
 agency_full_name: "Office of Educational Technology"
 
-# Agency Acronym [e.g., GSA]
-agency: "OET"
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: "OfficeofEdTech"
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/office-of-information-policy-doj/_index.md
+++ b/content/authors/office-of-information-policy-doj/_index.md
@@ -7,32 +7,17 @@ display_name: "Office of Information Policy, DOJ"
 first_name: "Office of Information Policy"
 last_name: "U.S. Department of Justice"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: office-of-information-policy-doj
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "The Office of Information Policy of the United States Department of Justice."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/office-of-information-policy/_index.md
+++ b/content/authors/office-of-information-policy/_index.md
@@ -7,32 +7,17 @@ display_name: "Office of Information Policy"
 first_name: "Office of"
 last_name: "Information Policy"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: office-of-information-policy
 
-# if you include an email address, it will be displayed on your profile page
-email: ""
 
-# Bio — keep it under 50 words
-bio: "The mission of the Office of Information Policy (OIP) is to provide legal and policy advice to all agencies on administration of the Freedom of Information Act (FOIA). OIP is responsible for encouraging agency compliance with the law and for overseeing agency implementation of it."
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: "https://www.justice.gov/jmd/organization-mission-and-functions-manual-office-information-policy"
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/authors/omid-ghaffari-tabrizi/_index.md
+++ b/content/authors/omid-ghaffari-tabrizi/_index.md
@@ -8,26 +8,14 @@ display_name: "Omid Ghaffari-Tabrizi"
 first_name: "Omid"
 last_name: "Ghaffari-Tabrizi"
 
-# List your pronoun(s) if you want them displayed alongside your name. If blank, we'll use just your name. Learn more http://mypronouns.org
-pronoun: ""
 
-# Email — If you include an email address, it will be displayed on your profile page
-email: 
 
-# Bio — keep it under 50 words
-bio: "A former GSA employee as of fall 2020, Omid was involved in implementing and improving modern IT acquisition processes. In his time here, he established the procurement management processes at the Technology Transformation Services' Office of Acquisition and the Centers of Excellence, with a stint in between to assist the login.gov team with their established process. His work in standardizing and automating bureaucratic processes started during his early career as an attorney specializing in contract law and criminal expungement processes."
 
-# bio_url — Where can people learn more about your work? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: 
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: "Washington, DC"
 
 # A GitHub account will allow you to edit pages on Digital.gov. Also, the image used in your GitHub account can be used to populate your digital.gov profile photo. Learn more about getting a Github account at [URL]
 github: "oghaffari"
@@ -37,11 +25,6 @@ github: "oghaffari"
 profile_photo: "github"
 
 # [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-instagram: ""
-linkedin: "oghaffari"
-youtube: ""
 
 # Make it better ♥
 

--- a/content/authors/ori-hoffer/_index.md
+++ b/content/authors/ori-hoffer/_index.md
@@ -7,32 +7,17 @@ display_name: "Ori Hoffer"
 first_name: "Ori"
 last_name: "Hoffer"
 
-# Pronoun preference — we strive to be inclusive, and don’t want to make assumptions on a person’s first name (be it a gender-neutral name, or is one more common in languages other than English). Learn more http://www.MyPronouns.org
-# List your pronoun(s) if you want them displayed alongside your name. Leave it blank and we'll use just your name.
-# See https://uwm.edu/lgbtrc/support/gender-pronouns/ for a list of pronouns
-# Examples: they/them, she/her, or he/him
-pronoun: ""
 
 # slug — the specific user-id for an author.
 slug: ori-hoffer
 
-# if you include an email address, it will be displayed on your profile page
-email: "ori.hoffer@gsa.gov"
 
-# Bio — keep it under 50 words
-bio: "Public Affairs Specialist at the U.S. General Services Administration (GSA)"
 
-# Where can people learn more about your agency or program? Provide a full URL [e.g. 'https://www.example.gov/']
-bio_url: ""
 
 # Agency Full Name [e.g. U.S. General Services Administration]
-agency_full_name: ""
+agency_full_name: "U.S. General Services Administration"
 
-# Agency Acronym [e.g., GSA]
-agency: ""
 
-# Tell us where you live and work [e.g. 'New York City' or 'Portland, OR']
-location: ""
 
 # Your GitHub username [e.g. 'jeremyzilar']
 # See [URL] Having a GitHub account will allow you to edit pages on DigitalGov. The image used in your GitHub account can also be used to populate your digital.gov profile photo.
@@ -43,11 +28,6 @@ github: ""
 # github-photo — requires a github ID
 profile_source: ""
 
-# Professional Social Media [e.g., Digital_Gov]
-twitter: ""
-facebook: ""
-linkedin: ""
-YouTube: ""
 
 # For more information on managing your author page,
 # see https://workflow.digital.gov/authors

--- a/content/news/2015/06/2015-06-12-digitalgov-citizen-services-summit-reflections-from-our-livestream-host-and-full-recording-now-available.md
+++ b/content/news/2015/06/2015-06-12-digitalgov-citizen-services-summit-reflections-from-our-livestream-host-and-full-recording-now-available.md
@@ -53,8 +53,6 @@ Federal agencies were also invited to showcase their programs, tools and innovat
 
 {{< tweet user="jakegab" id="601206392905674752" >}}
 
-{{< tweet user="lauraandotis" id="601432623186051072" >}}
-
 {{< tweet user="FedRAMP" id="601370769533308928" >}}
 
 The Summit's hashtag, [&#35;DigitalGov15](https://twitter.com/hashtag/DigitalGov15?src=hash), became a top trend across the United States on Twitter. Thank you to everyone who came in person to attend, tuned in online via livestream, tweeted throughout the event, put us in the top US trends, and helped to make &#35;DigitalGov15 such a success!


### PR DESCRIPTION
## Summary

Metadata removal for author with M to O.

> [!NOTE]
> Will be merged into #8216 and also includes author removal for authors with no published content.


## Solution

Removes all other `author` fields.

**Fields to Keep**

- display_name
- first_name
- last_name
- agency_full_name
- github (github username)
- profile_source (digit-light, digit-dark, blank)


## How To Test

1. Only fields listed above are displayed
2. Remove non-published authors

