### PR TITLE
Adds aria-label field to display unique link name

### DIFF
--- a/themes/digital.gov/layouts/events/card-event.html
+++ b/themes/digital.gov/layouts/events/card-event.html
@@ -22,6 +22,7 @@
           href="{{ .Permalink }}"
           title="{{ .Title | markdownify }}"
           rel="bookmark"
+          aria-label="{{ .Title}} on {{ dateFormat "Jan 02, 2006" .Date }}"
           >{{ .Title | markdownify }}</a
         >
       </h2>

--- a/themes/digital.gov/layouts/news/card-news.html
+++ b/themes/digital.gov/layouts/news/card-news.html
@@ -39,7 +39,7 @@
     {{ if $isExternal }}
       <div class="card__summary">
         <h3 id="{{ $titleID }}">
-          <a href="{{- $externalLink -}}">{{- $title | markdownify -}}</a>
+          <a aria-label="{{ .Title}} on {{ dateFormat "Jan 02, 2006" .Date }}" href="{{- $externalLink -}}">{{- $title | markdownify -}}</a>
         </h3>
         <p>
           {{- if $deck -}}
@@ -62,7 +62,7 @@
         </div>
       {{- end -}}
       <h3 id="{{ $titleID }}">
-        <a href="{{- $internalLink -}}">{{- $title | markdownify -}}</a>
+        <a aria-label="{{ .Title}} on {{ dateFormat "Jan 02, 2006" .Date }}" href="{{- $internalLink -}}">{{- $title | markdownify -}}</a>
       </h3>
 
       {{- if $summary -}}

--- a/themes/digital.gov/layouts/partials/core/card-stream.html
+++ b/themes/digital.gov/layouts/partials/core/card-stream.html
@@ -17,7 +17,7 @@
       </div>
     {{ end }}
     <h3 id="{{ $titleID }}">
-      <a href="{{ $internalLink }}">{{ $title | markdownify }}</a>
+      <a aria-label="{{ .Title}} on {{ dateFormat "Jan 02, 2006" .Date }}" href="{{ $internalLink }}">{{ $title | markdownify }}</a>
     </h3>
 
     {{ if $summary }}


### PR DESCRIPTION
## Summary

Ensures unique accessible titles when same title but different content type edge case occurs on the [authors stream](https://digital.gov/authors/alan-brouilette/). 

## Preview

[Link to Preview]()

<!--
⚠️ Significant visual changes require submitting previous design to wayback machine.
-->

## Solution

Provide a summary of the solution this PR offers.

<!--
It can be helpful if we understand:
1. What the solution is,
2. Why this approach was chosen,
3. How you implemented the change, and
4. Possible limitations of this approach and alternate solution paths.
-->


## How To Test

1. First Step
2. Second Step
3. Third Step

<!--
For PRs that include dependency updates, uncomment this section and
include a list of the changed dependencies and version numbers.
-->

<!--
## Dependency updates

| Dependency name              | Previous version | New version |
| ---------------------------- | :--------------: | :---------: |
| [Updated dependency example] |     [1.0.0]      |   [1.0.1]   |
| [New dependency example]     |        --        |   [3.0.1]   |
| [Removed dependency example] |     [2.10.2]     |     --      |
-->

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Branch is up-to-date and includes latest from `main`
- [ ] PR has correct labels
- [ ] A11y testing (voice over testing, meets WCAG, run axe tools)
-->
